### PR TITLE
Fix admin route 500 from middleware crash

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -9,7 +9,6 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { createServerClient } from '@supabase/ssr'
-import { env } from '@/lib/env'
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   const path = request.nextUrl.pathname
@@ -32,9 +31,9 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   response.headers.set('x-pathname', path)
 
   // Public routes: skip auth to reduce latency
-  // Note: /admin is temporarily unprotected until Supabase auth is configured.
-  // Once login flow is implemented, remove '/admin' from this list.
-  const isPublicRoute = !path.startsWith('/admin') || path === '/login'
+  // Admin routes (/admin, /admin/*) are protected; everything else is public.
+  const isAdminRoute = path === '/admin' || path.startsWith('/admin/')
+  const isPublicRoute = !isAdminRoute || path === '/login'
   if (isPublicRoute) {
     return response
   }
@@ -42,14 +41,21 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   // Refresh session for protected routes (critical for Supabase SSR).
   // Skip auth check entirely when Supabase isn't configured with real credentials
   // to allow admin access during development.
+  // NOTE: Read env var directly — the env.ts getter throws when the var is missing,
+  // which would crash the middleware before the falsy check can evaluate.
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   if (
-    !env.SUPABASE_URL ||
-    env.SUPABASE_URL.includes('placeholder')
+    !supabaseUrl ||
+    supabaseUrl.includes('placeholder')
   ) {
     return response
   }
 
-  const supabase = createServerClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY, {
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+    || ''
+
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
     cookies: {
       getAll() {
         return request.cookies.getAll()
@@ -76,7 +82,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   } = await supabase.auth.getUser()
 
   // Redirect unauthenticated users to login
-  if (!user && isProtectedRoute) {
+  if (!user && !isPublicRoute) {
     const url = request.nextUrl.clone()
     url.pathname = '/login'
     url.searchParams.set('returnTo', path)


### PR DESCRIPTION
## Summary

- **Fix `env.SUPABASE_URL` crash**: The getter in `env.ts` throws on the server when `NEXT_PUBLIC_SUPABASE_URL` is missing, crashing the middleware before the falsy check (`!env.SUPABASE_URL`) could evaluate. Fixed by reading `process.env.NEXT_PUBLIC_SUPABASE_URL` directly.
- **Fix `isProtectedRoute` ReferenceError**: The middleware referenced `isProtectedRoute` which was never defined, causing a ReferenceError when Supabase auth was configured. Replaced with `!isPublicRoute`.
- **Fix overly broad admin path matching**: `path.startsWith('/admin')` matched `/adminHome` and similar non-admin paths, routing them through the broken auth check instead of falling through to a 404. Fixed with exact matching: `path === '/admin' || path.startsWith('/admin/')`.

## Test plan

- [ ] Verify `/admin` loads without 500 error on Cloudflare Pages
- [ ] Verify `/adminHome` returns 404 (not 500)
- [ ] Verify other non-admin routes (e.g. `/salon-maria`) still work
- [ ] Verify middleware passes through when Supabase is not configured

https://claude.ai/code/session_014uA4tkcgXFrPZKkcr22ofo