### PR TITLE
feat(meal_prep): add meal prep type + De Abasto a Casa tenant + savings calculator

### DIFF
--- a/src/content/meal_prep.content.json
+++ b/src/content/meal_prep.content.json
@@ -1,0 +1,165 @@
+{
+  "id": "meal_prep",
+  "locale": "es-PY",
+
+  "hero": {
+    "headline": "Convertimos el caos del mercado en comida lista",
+    "subheadline": "Compras, prep y freezer meals puerta a puerta en {{city}}. Whole-animal, mayorista, sin conservantes.",
+    "ctaPrimary": "Calcula tu ahorro",
+    "ctaSecondary": "Pedir por WhatsApp"
+  },
+
+  "servicesPage": {
+    "title": "Nuestros Niveles de Servicio",
+    "subtitle": "Elegi lo que se adapta a tu semana. Precios referenciales, ajustables segun tu hogar.",
+    "categories": [
+      {
+        "key": "compras",
+        "title": "Nivel 1 - Compra por Lista (Raw)",
+        "description": "Vos nos mandas la lista, nosotros traemos los ingredientes enteros desde Abasto y mercado. Vos cocinas.",
+        "defaultServices": [
+          { "name": "Basico", "price": "250.000 Gs/semana", "duration": 120, "description": "Lista corta, 1 proveedor. Hasta 15 productos. Delivery incluido." },
+          { "name": "Completo", "price": "400.000 Gs/semana", "duration": 180, "description": "Lista completa + Abasto + mercado + almacen. Delivery y organizado en cocina." }
+        ]
+      },
+      {
+        "key": "prep",
+        "title": "Nivel 2 - Mise-en-Place Semanal (mas elegido)",
+        "description": "Compramos, lavamos, porcionamos y organizamos tu heladera y freezer. Listo para cocinar en minutos.",
+        "defaultServices": [
+          { "name": "Individual (1 persona)", "price": "400.000 Gs/semana", "duration": 240, "description": "Prep basico. Proteina + carbos + vegetales porcionados y sellados al vacio." },
+          { "name": "Pareja (2 personas)", "price": "650.000 Gs/semana", "duration": 300, "description": "Prep completo para 2. Organizacion de heladera y freezer." },
+          { "name": "Familia (3-4 personas)", "price": "900.000 Gs/semana", "duration": 360, "description": "Prep familiar. Variedad, porciones y sustituciones incluidas." }
+        ]
+      },
+      {
+        "key": "cocinado",
+        "title": "Nivel 3 - Comidas Listas (proximamente)",
+        "description": "Comidas completas selladas al vacio, listas para recalentar. Requiere habilitacion INAN en curso.",
+        "defaultServices": [
+          { "name": "10 comidas/semana", "priceFrom": "1.200.000 Gs/semana", "duration": 480, "description": "5 almuerzos + 5 cenas para 1 persona. Variedad rotativa." },
+          { "name": "15 comidas/semana", "priceFrom": "1.700.000 Gs/semana", "duration": 540, "description": "Pack familiar. 3 comidas/dia durante 5 dias laborables." }
+        ]
+      },
+      {
+        "key": "add-on",
+        "title": "Add-ons opcionales",
+        "description": "Sumables a cualquier nivel.",
+        "defaultServices": [
+          { "name": "Desayunos", "price": "+400.000 Gs/mes", "description": "Desayunos listos para la semana." },
+          { "name": "Postres", "price": "+200.000 Gs/mes", "description": "Postres caseros sumados al pack." },
+          { "name": "Bebidas / snacks", "price": "+300.000 Gs/mes", "description": "Bebidas y snacks saludables." }
+        ]
+      }
+    ]
+  },
+
+  "teamPage": {
+    "title": "Quien esta detras",
+    "memberTemplate": {
+      "buttonText": "Escribile a {{name}}"
+    }
+  },
+
+  "galleryPage": {
+    "title": "Cortes y calidad",
+    "subtitle": "Whole-animal, mayorista, lo mejor del mercado.",
+    "categories": ["Cortes de Carne", "Mise en Place", "Freezer Meals", "Mercado"],
+    "ctaText": "Ver mas"
+  },
+
+  "contactPage": {
+    "title": "Pedinos tu propuesta",
+    "locationTitle": "Cobertura en {{city}}",
+    "formFields": ["name", "phone", "plan", "message"],
+    "formSubmitText": "Enviar Consulta"
+  },
+
+  "faq": [
+    { "q": "Que incluye el servicio?", "a": "Incluye: compras en Abasto + mercado, prep (lavado, cortado, porcionado), sellado al vacio, 2 entregas por mes puerta a puerta con cadena de frio, sustituciones hasta 3 menus por mes, precio fijo 6 meses y pausa de vacaciones. No incluye desayunos, bebidas ni postres (disponibles como add-on)." },
+    { "q": "Como son las entregas?", "a": "Compramos martes y jueves. Entregamos el mismo dia, puerta a puerta, con cadena de frio. Coordinamos horario por WhatsApp." },
+    { "q": "Puedo pausar el servicio?", "a": "Si. Tenes 1 mes por ano de pausa sin costo (vacaciones, viajes, etc). Avisanos con 48 hrs." },
+    { "q": "Que pasa si no me gusta una comida?", "a": "Garantia de satisfaccion: si algo sale mal, lo reemplazamos sin cargo en la proxima entrega." },
+    { "q": "En que casos NO me conviene?", "a": "Honestidad total: si te encanta cocinar, si tu gasto actual es menor a Gs. 2M/mes para 3 personas, o si no tenes freezer. Mejor no te suscribas." },
+    { "q": "Como pago?", "a": "Transferencia bancaria o efectivo. Sin compromiso en el primer mes. Precio fijo 6 meses al suscribirte." },
+    { "q": "Atienden fuera de San Lorenzo?", "a": "Por ahora solo San Lorenzo (ciudad completa). Proximamente Asuncion centro." },
+    { "q": "Tienen habilitacion INAN?", "a": "Nivel 1 y Nivel 2 no requieren habilitacion especial (solo compra y prep). Nivel 3 (comidas cocidas listas) esta en proceso de habilitacion INAN." }
+  ],
+
+  "ctaBanner": {
+    "title": "Pedi tu propuesta en 5 min por WhatsApp",
+    "buttonText": "Escribir ahora"
+  },
+
+  "footer": {
+    "columns": ["about", "quickLinks", "contact", "social"],
+    "quickLinks": ["Servicios", "Calculadora", "Galeria", "FAQ", "Contacto"],
+    "copyright": "{{year}} {{businessName}} - San Lorenzo, Paraguay."
+  },
+
+  "whatsapp": {
+    "defaultMessage": "Hola! Vi el sitio de {{businessName}} y quiero saber mas sobre Nivel 2 (mise-en-place).",
+    "serviceMessage": "Hola! Me interesa {{serviceName}} de {{businessName}}. Podemos conversar?"
+  },
+
+  "savingsCalculator": {
+    "title": "Calcula tu ahorro real",
+    "subtitle": "Numeros honestos. Si no te conviene, te lo decimos.",
+    "inputs": {
+      "groceriesLabel": "Super + carniceria + feria (mes)",
+      "deliveryLabel": "Delivery + comer afuera (mes)",
+      "wasteLabel": "Comida tirada + compras impulsivas (mes)",
+      "utilitiesLabel": "Gas/luz extra cocinando (mes)",
+      "householdLabel": "Personas en el hogar",
+      "hourlyValueLabel": "Valor de tu hora en Gs.",
+      "hoursPerMonthLabel": "Horas por mes cocinando + comprando",
+      "tierLabel": "Nivel a comparar"
+    },
+    "tierOptions": [
+      { "key": "nivel1_completo", "label": "Nivel 1 Completo (1.600.000 Gs/mes)", "monthlyGs": 1600000 },
+      { "key": "nivel2_individual", "label": "Nivel 2 Individual (1.600.000 Gs/mes)", "monthlyGs": 1600000 },
+      { "key": "nivel2_pareja", "label": "Nivel 2 Pareja (2.600.000 Gs/mes)", "monthlyGs": 2600000 },
+      { "key": "nivel2_familia", "label": "Nivel 2 Familia (3.600.000 Gs/mes)", "monthlyGs": 3600000 }
+    ],
+    "outputs": {
+      "cashTotalLabel": "Plata real hoy",
+      "timeValueLabel": "Valor de tu tiempo hoy",
+      "totalTodayLabel": "Costo TOTAL hoy",
+      "ourServiceLabel": "Nuestro servicio (mes)",
+      "savingsLabel": "Ahorro mensual estimado",
+      "hoursRecoveredLabel": "Horas recuperadas por mes",
+      "negativeCopy": "Hoy ya sos muy eficiente. Probablemente no te conviene - pero si queres probar 1 mes sin compromiso, escribinos igual.",
+      "positiveCopy": "Si tu ahorro es grande, tiene sentido probar 1 mes sin compromiso.",
+      "ctaText": "Seguir por WhatsApp con mis numeros"
+    },
+    "disclaimer": "Estimacion referencial. Precios finales se ajustan segun tu hogar y nivel de servicio."
+  },
+
+  "howItWorks": {
+    "title": "Como funciona",
+    "steps": [
+      { "num": "01", "title": "Conversamos", "desc": "10 min por WhatsApp. Armamos tu plan segun presupuesto, personas y dias que queres recibir." },
+      { "num": "02", "title": "Planeamos tu semana", "desc": "Menu base, sustituciones, proveedores, horarios de compra y entrega." },
+      { "num": "03", "title": "Compramos y prepeamos", "desc": "Martes y jueves en Abasto y mercado. Prep en cocina certificada. Sellado al vacio." },
+      { "num": "04", "title": "Entregamos", "desc": "Puerta a puerta, con cadena de frio. Organizamos tu heladera y freezer si lo pedis." }
+    ]
+  },
+
+  "qualitySourcing": {
+    "title": "Como compramos",
+    "pillars": [
+      { "title": "Whole-animal", "desc": "Animales enteros, cortados y porcionados por nosotros. Mejor calidad, mejor precio por kilo." },
+      { "title": "Mayorista Abasto", "desc": "Proveedores directos, sin intermediarios. Precios de mercado mayorista trasladados al cliente." },
+      { "title": "Estacional", "desc": "Respetamos el calendario de Paraguay. Compramos lo que esta en temporada, mas barato y mas rico." },
+      { "title": "Sin conservantes", "desc": "Congelamos al instante despues del prep. Nunca usamos aditivos ni conservantes." }
+    ]
+  },
+
+  "seo": {
+    "altTextTemplates": {
+      "service": "{{serviceName}} en {{businessName}}, {{city}}",
+      "portfolio": "{{serviceName}} de {{businessName}} - Paraguay",
+      "team": "{{memberName}} - {{memberTitle}} en {{businessName}}"
+    }
+  }
+}

--- a/src/registry/index.json
+++ b/src/registry/index.json
@@ -147,6 +147,18 @@
       "leadCount": 0,
       "noWebsitePercent": 0,
       "priorityALeads": 0
+    },
+    "meal_prep": {
+      "id": "meal_prep",
+      "nameEs": "Meal Prep & Compras",
+      "nameEn": "Meal Prep & Personal Shopping",
+      "icon": "shopping-cart",
+      "tokens": "meal_prep",
+      "content": "meal_prep",
+      "schema": "meal_prep",
+      "leadCount": 0,
+      "noWebsitePercent": 0,
+      "priorityALeads": 0
     }
   },
 

--- a/src/registry/meal_prep.type.json
+++ b/src/registry/meal_prep.type.json
@@ -1,0 +1,70 @@
+{
+  "id": "meal_prep",
+  "nameEs": "Meal Prep & Compras",
+  "nameEn": "Meal Prep & Personal Shopping",
+
+  "tokens": "meal_prep",
+
+  "pages": {
+    "homepage": {
+      "sections": ["header", "hero", "servicesPreview", "savingsCalculator", "galleryPreview", "team", "testimonial", "faq", "contact", "ctaBanner", "footer"],
+      "requiredSections": ["header", "hero", "servicesPreview", "contact", "footer"]
+    },
+    "services": {
+      "sections": ["header", "serviceMenu", "faq", "ctaBanner", "footer"],
+      "requiredSections": ["header", "serviceMenu", "footer"]
+    },
+    "gallery": {
+      "sections": ["header", "portfolioGallery", "footer"],
+      "requiredSections": ["header", "portfolioGallery", "footer"]
+    },
+    "team": {
+      "sections": ["header", "teamProfiles", "footer"],
+      "requiredSections": ["header", "teamProfiles", "footer"]
+    },
+    "contact": {
+      "sections": ["header", "contactSplit", "footer"],
+      "requiredSections": ["header", "contactSplit", "footer"]
+    }
+  },
+
+  "features": {
+    "onlineBooking": { "enabled": false },
+    "serviceMenu": { "enabled": true, "showPrices": true, "showDuration": true, "filterable": true },
+    "portfolio": { "enabled": true, "minImages": 6, "categories": ["cortes_de_carne", "mise_en_place", "freezer_meals", "mercado"] },
+    "beforeAfter": { "enabled": false },
+    "staffProfiles": { "enabled": true, "showInstagram": true, "bookable": false },
+    "pricingDisplay": { "enabled": true, "showExactPrice": true },
+    "savingsCalculator": { "enabled": true, "defaultTierMonthlyGs": 1600000, "defaultHourlyValueGs": 25000 },
+    "seasonalCalendar": { "enabled": false, "optional": true },
+    "whatsappFloat": { "enabled": true },
+    "googleMapsEmbed": { "enabled": true }
+  },
+
+  "serviceCategories": ["compras", "prep", "cocinado", "add-on"],
+
+  "targetAudience": {
+    "primary": "Remote workers 25-45 in San Lorenzo, USD earners, time-poor professionals",
+    "secondary": "Busy households, couples, clinic doctors, students"
+  },
+
+  "seo": {
+    "titleTemplate": "{{businessName}} - Meal Prep y Compras en {{city}} | Tu tiempo vale mas",
+    "descriptionTemplate": "Hacemos tu mercado, prep semanal y comidas listas. Whole-animal, mayorista, sin conservantes. Entregamos en {{city}}. Calcula tu ahorro.",
+    "schemaType": "FoodService",
+    "keywords": ["meal prep {{city}}", "compras personalizadas {{city}}", "mercado {{neighborhood}}", "comida saludable San Lorenzo Paraguay", "prep semanal"]
+  },
+
+  "nav": {
+    "items": ["Servicios", "Calculadora", "Galeria", "FAQ", "Contacto"],
+    "cta": { "text": "Pedir por WhatsApp", "action": "whatsapp" }
+  },
+
+  "hero": {
+    "style": "image",
+    "headlineTemplate": "Convertimos el caos del mercado en comida lista",
+    "subheadlineTemplate": "{{businessName}}: compras, prep y freezer meals puerta a puerta en {{city}}. Whole-animal, mayorista, sin humo.",
+    "ctaPrimary": { "text": "Calcula tu ahorro", "action": "scrollTo:calculadora" },
+    "ctaSecondary": { "text": "Pedir por WhatsApp", "action": "whatsapp" }
+  }
+}

--- a/src/schemas/base-business.schema.json
+++ b/src/schemas/base-business.schema.json
@@ -23,7 +23,9 @@
         "estetica",
         "maquillaje",
         "depilacion",
-        "pestanas"
+        "pestanas",
+        "diseno_grafico",
+        "meal_prep"
       ],
       "description": "Business category determining template selection"
     },

--- a/src/schemas/meal_prep.schema.json
+++ b/src/schemas/meal_prep.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "meal_prep",
+  "title": "Meal Prep & Personal Shopping Business Input Schema",
+  "description": "Additional fields required from meal prep / personal shopping businesses beyond the base schema",
+  "allOf": [{ "$ref": "base-business" }],
+  "properties": {
+    "serviceCategories": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["compras", "prep", "cocinado", "add-on"] }
+    },
+    "portfolioTypes": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["cortes_de_carne", "mise_en_place", "freezer_meals", "mercado"] }
+    },
+    "coverageArea": {
+      "type": "string",
+      "description": "Free-text coverage area (e.g. 'San Lorenzo ciudad completa')"
+    },
+    "sourcing": {
+      "type": "object",
+      "properties": {
+        "wholeAnimal": { "type": "boolean", "default": true },
+        "wholesaleMarkets": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Wholesale markets used (e.g. 'Abasto', 'Mercado San Lorenzo')"
+        },
+        "seasonal": { "type": "boolean", "default": true },
+        "preservativeFree": { "type": "boolean", "default": true }
+      }
+    },
+    "shoppingDays": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Days of week shopping is done (e.g. ['martes', 'jueves'])"
+    },
+    "inanLicensed": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether the business holds an INAN license for cooked meals (Nivel 3)"
+    }
+  },
+  "inputForm": {
+    "priority1": ["businessName", "contact.phone", "contact.whatsapp", "location.city", "services"],
+    "priority2": ["team", "tagline", "portfolio.images", "hours", "coverageArea"],
+    "priority3": ["branding.logoUrl", "faq", "sourcing", "inanLicensed"]
+  }
+}

--- a/src/tokens/meal_prep.tokens.json
+++ b/src/tokens/meal_prep.tokens.json
@@ -1,0 +1,75 @@
+{
+  "name": "Meal Prep & Compras",
+  "extends": "base",
+  "theme": "light",
+  "mood": ["honest", "warm", "grounded", "artisanal"],
+
+  "palettes": {
+    "optionA": {
+      "name": "Mercado Verde",
+      "colors": {
+        "primary": "#3a6b4a",
+        "secondary": "#c2663a",
+        "background": "#f6f1e7",
+        "surface": "#ffffff",
+        "text": "#1f1f1f",
+        "textLight": "#5a5246",
+        "accent": "#d4a15a",
+        "success": "#3a6b4a",
+        "error": "#b0453e",
+        "secondaryHover": "#a8542f"
+      }
+    },
+    "optionB": {
+      "name": "Abasto Terracota",
+      "colors": {
+        "primary": "#b04b2a",
+        "secondary": "#2d5a3d",
+        "background": "#faf5eb",
+        "surface": "#ffffff",
+        "text": "#1a1a1a",
+        "textLight": "#55463a",
+        "accent": "#d4a15a",
+        "success": "#3a6b4a",
+        "error": "#a33e36"
+      }
+    }
+  },
+
+  "defaultPalette": "optionA",
+
+  "typography": {
+    "heading": "'Fraunces', 'Playfair Display', serif",
+    "body": "'Inter', 'Open Sans', sans-serif",
+    "accent": "'Fraunces', serif",
+    "headingWeight": "600",
+    "bodyWeight": "400",
+    "headingStyle": "normal",
+    "textTransform": "none"
+  },
+
+  "googleFonts": ["Fraunces:wght@400;500;600;700", "Inter:wght@300;400;500;600;700"],
+
+  "borderRadius": "md",
+  "buttonStyle": "rounded-md",
+
+  "components": {
+    "button": {
+      "padding": "14px 28px",
+      "borderRadius": "8px",
+      "hoverTranslateY": "-2px"
+    },
+    "serviceCard": {
+      "borderRadius": "12px",
+      "hoverTranslateY": "-4px",
+      "imageRatio": "4:3"
+    },
+    "teamCard": {
+      "imageShape": "rounded",
+      "imageSize": "180px"
+    },
+    "gallery": {
+      "layout": "grid"
+    }
+  }
+}

--- a/web/app/[business]/page.tsx
+++ b/web/app/[business]/page.tsx
@@ -28,6 +28,8 @@ function generateJsonLd(business: { type: string; name: string; slug: string; ad
     maquillaje: 'BeautySalon',
     depilacion: 'HealthAndBeautyBusiness',
     pestanas: 'BeautySalon',
+    diseno_grafico: 'ProfessionalService',
+    meal_prep: 'FoodService',
   }
 
   const schema = {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -23,6 +23,7 @@ import {
   MapPin,
   Users,
   TrendingUp,
+  ShoppingCart,
 } from 'lucide-react'
 import Link from 'next/link'
 import { Container } from '@/components/ui/container'
@@ -43,6 +44,7 @@ const TEMPLATES = [
   { id: 'maquillaje', name: 'Maquillaje', icon: Palette, leads: 130, pct: 72, color: '#c44569' },
   { id: 'pestanas', name: 'Pestanas y Cejas', icon: Eye, leads: 49, pct: 76, color: '#6c5ce7' },
   { id: 'depilacion', name: 'Depilacion', icon: Zap, leads: 20, pct: 78, color: '#e17055' },
+  { id: 'meal_prep', name: 'Meal Prep & Compras', icon: ShoppingCart, leads: 0, pct: 0, color: '#3a6b4a' },
 ] as const
 
 const TOTAL_LEADS = 7491
@@ -75,8 +77,8 @@ const FEATURES = [
   },
   {
     icon: Layers,
-    title: '11 Plantillas',
-    desc: 'Disenos especializados para cada tipo de negocio de belleza y bienestar.',
+    title: '12 Plantillas',
+    desc: 'Disenos especializados para multiples tipos de negocio: belleza, bienestar, diseno, meal prep.',
   },
 ]
 

--- a/web/components/sections/savings-calculator-section.tsx
+++ b/web/components/sections/savings-calculator-section.tsx
@@ -1,0 +1,317 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Button } from '@/components/ui/button'
+import { AnimatedSectionHeader } from '@/components/ui/animate-on-scroll'
+
+export interface SavingsCalculatorTierOption {
+  key: string
+  label: string
+  monthlyGs: number
+}
+
+export interface SavingsCalculatorSectionProps {
+  title?: string
+  subtitle?: string
+  whatsappPhone?: string
+  whatsappMessageTemplate?: string
+  disclaimer?: string
+  tierOptions?: SavingsCalculatorTierOption[]
+  inputLabels?: {
+    groceriesLabel?: string
+    deliveryLabel?: string
+    wasteLabel?: string
+    utilitiesLabel?: string
+    householdLabel?: string
+    hourlyValueLabel?: string
+    hoursPerMonthLabel?: string
+    tierLabel?: string
+  }
+  outputLabels?: {
+    cashTotalLabel?: string
+    timeValueLabel?: string
+    totalTodayLabel?: string
+    ourServiceLabel?: string
+    savingsLabel?: string
+    hoursRecoveredLabel?: string
+    negativeCopy?: string
+    positiveCopy?: string
+    ctaText?: string
+  }
+}
+
+const DEFAULT_TIERS: SavingsCalculatorTierOption[] = [
+  { key: 'nivel2_individual', label: 'Nivel 2 Individual (1.600.000 Gs/mes)', monthlyGs: 1_600_000 },
+  { key: 'nivel2_pareja', label: 'Nivel 2 Pareja (2.600.000 Gs/mes)', monthlyGs: 2_600_000 },
+  { key: 'nivel2_familia', label: 'Nivel 2 Familia (3.600.000 Gs/mes)', monthlyGs: 3_600_000 },
+]
+
+function formatGs(value: number): string {
+  const rounded = Math.round(value)
+  return new Intl.NumberFormat('es-PY').format(rounded)
+}
+
+export function SavingsCalculatorSection({
+  title = 'Calcula tu ahorro real',
+  subtitle = 'Numeros honestos. Si no te conviene, te lo decimos.',
+  whatsappPhone,
+  whatsappMessageTemplate,
+  disclaimer = 'Estimacion referencial. Precios finales se ajustan segun tu hogar y nivel de servicio.',
+  tierOptions = DEFAULT_TIERS,
+  inputLabels = {},
+  outputLabels = {},
+}: SavingsCalculatorSectionProps) {
+  const [groceries, setGroceries] = useState(4_000_000)
+  const [delivery, setDelivery] = useState(1_500_000)
+  const [waste, setWaste] = useState(500_000)
+  const [utilities, setUtilities] = useState(200_000)
+  const [household, setHousehold] = useState(3)
+  const [hourlyValue, setHourlyValue] = useState(25_000)
+  const [hoursPerMonth, setHoursPerMonth] = useState(60)
+  const [tierKey, setTierKey] = useState(tierOptions[0]?.key ?? '')
+
+  const tier = tierOptions.find((t) => t.key === tierKey) ?? tierOptions[0]
+
+  const cashTotal = groceries + delivery + waste + utilities
+  const timeValue = hourlyValue * hoursPerMonth
+  const totalToday = cashTotal + timeValue
+  const ourService = tier?.monthlyGs ?? 0
+  const savings = totalToday - ourService
+  const hoursRecovered = Math.max(0, hoursPerMonth - 8)
+
+  const whatsappHref = useMemo(() => {
+    if (!whatsappPhone) return undefined
+    const lines = [
+      'Hola! Hice el calculador en el sitio y quiero seguir:',
+      `- Personas en el hogar: ${household}`,
+      `- Plata real hoy: Gs. ${formatGs(cashTotal)}`,
+      `- Valor de tiempo: Gs. ${formatGs(timeValue)} (${hoursPerMonth} hrs x ${formatGs(hourlyValue)})`,
+      `- Costo TOTAL hoy: Gs. ${formatGs(totalToday)}`,
+      `- Plan elegido: ${tier?.label ?? ''}`,
+      `- Ahorro estimado: Gs. ${formatGs(savings)}`,
+    ]
+    const base = (whatsappMessageTemplate || lines.join('\n')).trim()
+    const text = whatsappMessageTemplate
+      ? base
+      : lines.join('\n')
+    const cleanPhone = whatsappPhone.replace(/[^0-9]/g, '')
+    return `https://wa.me/${cleanPhone}?text=${encodeURIComponent(text)}`
+  }, [whatsappPhone, whatsappMessageTemplate, household, cashTotal, timeValue, hoursPerMonth, hourlyValue, totalToday, tier, savings])
+
+  const positive = savings > 0
+
+  const l = {
+    groceriesLabel: inputLabels.groceriesLabel ?? 'Super + carniceria + feria (mes)',
+    deliveryLabel: inputLabels.deliveryLabel ?? 'Delivery + comer afuera (mes)',
+    wasteLabel: inputLabels.wasteLabel ?? 'Comida tirada + impulsivas (mes)',
+    utilitiesLabel: inputLabels.utilitiesLabel ?? 'Gas/luz extra cocinando (mes)',
+    householdLabel: inputLabels.householdLabel ?? 'Personas en el hogar',
+    hourlyValueLabel: inputLabels.hourlyValueLabel ?? 'Valor de tu hora (Gs.)',
+    hoursPerMonthLabel: inputLabels.hoursPerMonthLabel ?? 'Horas/mes cocinando + comprando',
+    tierLabel: inputLabels.tierLabel ?? 'Nivel a comparar',
+  }
+
+  const o = {
+    cashTotalLabel: outputLabels.cashTotalLabel ?? 'Plata real hoy',
+    timeValueLabel: outputLabels.timeValueLabel ?? 'Valor de tu tiempo hoy',
+    totalTodayLabel: outputLabels.totalTodayLabel ?? 'Costo TOTAL hoy',
+    ourServiceLabel: outputLabels.ourServiceLabel ?? 'Nuestro servicio (mes)',
+    savingsLabel: outputLabels.savingsLabel ?? 'Ahorro mensual estimado',
+    hoursRecoveredLabel: outputLabels.hoursRecoveredLabel ?? 'Horas recuperadas por mes',
+    negativeCopy: outputLabels.negativeCopy ?? 'Hoy ya sos muy eficiente. Probablemente no te conviene - pero si queres probar 1 mes sin compromiso, escribinos igual.',
+    positiveCopy: outputLabels.positiveCopy ?? 'Si tu ahorro es grande, tiene sentido probar 1 mes sin compromiso.',
+    ctaText: outputLabels.ctaText ?? 'Seguir por WhatsApp con mis numeros',
+  }
+
+  return (
+    <section id="calculadora" className="scroll-mt-24 bg-[var(--background)] py-16 sm:py-20">
+      <Container size="md">
+        <AnimatedSectionHeader>
+          <Heading level={2}>{title}</Heading>
+          {subtitle && (
+            <p className="mt-3 text-center text-[var(--text-light)]">{subtitle}</p>
+          )}
+        </AnimatedSectionHeader>
+
+        <div className="mx-auto mt-10 grid max-w-5xl gap-8 rounded-2xl border border-[var(--surface-light)] bg-[var(--surface)] p-6 shadow-card md:grid-cols-2 md:p-8">
+          {/* Inputs */}
+          <div className="space-y-5">
+            <NumberField
+              label={l.groceriesLabel}
+              value={groceries}
+              onChange={setGroceries}
+              step={50_000}
+              suffix="Gs."
+            />
+            <NumberField
+              label={l.deliveryLabel}
+              value={delivery}
+              onChange={setDelivery}
+              step={50_000}
+              suffix="Gs."
+            />
+            <NumberField
+              label={l.wasteLabel}
+              value={waste}
+              onChange={setWaste}
+              step={25_000}
+              suffix="Gs."
+            />
+            <NumberField
+              label={l.utilitiesLabel}
+              value={utilities}
+              onChange={setUtilities}
+              step={25_000}
+              suffix="Gs."
+            />
+            <NumberField
+              label={l.householdLabel}
+              value={household}
+              onChange={setHousehold}
+              step={1}
+              min={1}
+              max={12}
+            />
+            <NumberField
+              label={l.hourlyValueLabel}
+              value={hourlyValue}
+              onChange={setHourlyValue}
+              step={5_000}
+              suffix="Gs./hr"
+            />
+            <NumberField
+              label={l.hoursPerMonthLabel}
+              value={hoursPerMonth}
+              onChange={setHoursPerMonth}
+              step={5}
+              suffix="hrs"
+            />
+
+            <div>
+              <label className="mb-2 block text-sm font-medium text-[var(--text)]">
+                {l.tierLabel}
+              </label>
+              <select
+                value={tierKey}
+                onChange={(e) => setTierKey(e.target.value)}
+                className="w-full rounded-lg border border-[var(--surface-light)] bg-[var(--background)] px-4 py-3 text-[var(--text)] focus:border-[var(--primary)] focus:outline-none"
+              >
+                {tierOptions.map((t) => (
+                  <option key={t.key} value={t.key}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Outputs */}
+          <div className="flex flex-col justify-between gap-6 rounded-xl bg-[var(--background)] p-6">
+            <div className="space-y-3 text-sm">
+              <ResultRow label={o.cashTotalLabel} value={`Gs. ${formatGs(cashTotal)}`} />
+              <ResultRow label={o.timeValueLabel} value={`Gs. ${formatGs(timeValue)}`} />
+              <div className="border-t border-[var(--surface-light)] pt-3">
+                <ResultRow label={o.totalTodayLabel} value={`Gs. ${formatGs(totalToday)}`} bold />
+              </div>
+              <ResultRow label={o.ourServiceLabel} value={`Gs. ${formatGs(ourService)}`} />
+            </div>
+
+            <div className="rounded-lg bg-[var(--surface)] p-4 text-center">
+              <p className="text-xs uppercase tracking-wide text-[var(--text-light)]">
+                {o.savingsLabel}
+              </p>
+              <p
+                className="mt-1 text-3xl font-bold"
+                style={{ color: positive ? 'var(--primary)' : 'var(--text-light)' }}
+              >
+                {positive ? '+' : ''}Gs. {formatGs(savings)}
+              </p>
+              <p className="mt-3 text-sm text-[var(--text-light)]">
+                {o.hoursRecoveredLabel}:{' '}
+                <span className="font-semibold text-[var(--text)]">~{hoursRecovered} hrs</span>
+              </p>
+            </div>
+
+            <p className="text-sm italic leading-relaxed text-[var(--text-light)]">
+              {positive ? o.positiveCopy : o.negativeCopy}
+            </p>
+
+            {whatsappHref && (
+              <Button
+                variant="primary"
+                size="lg"
+                href={whatsappHref}
+              >
+                {o.ctaText}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {disclaimer && (
+          <p className="mx-auto mt-6 max-w-3xl text-center text-xs text-[var(--text-light)]">
+            {disclaimer}
+          </p>
+        )}
+      </Container>
+    </section>
+  )
+}
+
+function NumberField({
+  label,
+  value,
+  onChange,
+  step = 1,
+  min = 0,
+  max,
+  suffix,
+}: {
+  label: string
+  value: number
+  onChange: (n: number) => void
+  step?: number
+  min?: number
+  max?: number
+  suffix?: string
+}) {
+  return (
+    <div>
+      <label className="mb-2 block text-sm font-medium text-[var(--text)]">{label}</label>
+      <div className="flex items-center gap-2">
+        <input
+          type="number"
+          value={value}
+          step={step}
+          min={min}
+          max={max}
+          onChange={(e) => {
+            const n = Number(e.target.value)
+            if (!Number.isFinite(n)) return
+            onChange(n)
+          }}
+          className="w-full rounded-lg border border-[var(--surface-light)] bg-[var(--background)] px-4 py-3 text-[var(--text)] focus:border-[var(--primary)] focus:outline-none"
+        />
+        {suffix && (
+          <span className="shrink-0 text-sm text-[var(--text-light)]">{suffix}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ResultRow({ label, value, bold = false }: { label: string; value: string; bold?: boolean }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-[var(--text-light)]">{label}</span>
+      <span
+        className="text-[var(--text)]"
+        style={{ fontWeight: bold ? 700 : 500 }}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}

--- a/web/db/migrations/003_add_meal_prep_and_diseno_grafico.sql
+++ b/web/db/migrations/003_add_meal_prep_and_diseno_grafico.sql
@@ -1,0 +1,28 @@
+-- =============================================================================
+-- Add meal_prep and diseno_grafico business types
+-- =============================================================================
+-- Widens the businesses.type CHECK constraint to cover two types that were
+-- missing from the initial schema:
+--   - diseno_grafico (Dayah LitWorks was seeded but not in the constraint)
+--   - meal_prep      (new type: premium personal shopping + meal prep)
+--
+-- Safe to re-run: drops and recreates the constraint.
+-- =============================================================================
+
+ALTER TABLE businesses DROP CONSTRAINT IF EXISTS businesses_type_check;
+
+ALTER TABLE businesses ADD CONSTRAINT businesses_type_check CHECK (type IN (
+  'peluqueria',
+  'salon_belleza',
+  'gimnasio',
+  'spa',
+  'unas',
+  'tatuajes',
+  'barberia',
+  'estetica',
+  'maquillaje',
+  'depilacion',
+  'pestanas',
+  'diseno_grafico',
+  'meal_prep'
+));

--- a/web/lib/engine/compose.ts
+++ b/web/lib/engine/compose.ts
@@ -32,6 +32,7 @@ export type SectionType =
   | 'ctaBanner'
   | 'footer'
   | 'whatsappFloat'
+  | 'savingsCalculator'
 
 export interface ComposedSection {
   type: SectionType
@@ -192,6 +193,14 @@ interface ContentTemplate {
     copyright: string
   }
   whatsapp?: { defaultMessage: string }
+  savingsCalculator?: {
+    title?: string
+    subtitle?: string
+    disclaimer?: string
+    tierOptions?: Array<{ key: string; label: string; monthlyGs: number }>
+    inputs?: Record<string, string>
+    outputs?: Record<string, string>
+  }
 }
 
 // Map registry section names to our component types
@@ -216,6 +225,7 @@ const SECTION_MAP: Record<string, SectionType> = {
   ctaBanner: 'ctaBanner',
   footer: 'footer',
   whatsappFloat: 'whatsappFloat',
+  savingsCalculator: 'savingsCalculator',
 }
 
 /**
@@ -419,6 +429,20 @@ function buildSectionData(
         items: content.faq,
       }
 
+    case 'savingsCalculator': {
+      if (!registry.features?.savingsCalculator?.enabled) return null
+      const calc = content.savingsCalculator
+      return {
+        title: calc?.title,
+        subtitle: calc?.subtitle,
+        disclaimer: calc?.disclaimer,
+        tierOptions: calc?.tierOptions,
+        inputLabels: calc?.inputs,
+        outputLabels: calc?.outputs,
+        whatsappPhone: business.whatsapp,
+      }
+    }
+
     case 'ctaBanner':
       if (!content.ctaBanner) return null
       return {
@@ -469,6 +493,7 @@ function generatePlaceholderGallery(
     depilacion: { colors: ['#3498db', '#1abc9c', '#e8d5f5'], categories: ['Laser', 'Cera', 'Resultados'] },
     pestanas: { colors: ['#c4788b', '#d4a574', '#1a1a1a'], categories: ['Clasicas', 'Volumen', 'Cejas'] },
     diseno_grafico: { colors: ['#c4788b', '#d4af37', '#e8b4c8'], categories: ['Portadas', 'Premade', 'Mockups', 'Branding'] },
+    meal_prep: { colors: ['#3a6b4a', '#c2663a', '#d4a15a'], categories: ['Cortes de Carne', 'Mise en Place', 'Freezer Meals', 'Mercado'] },
   }
 
   const theme = PLACEHOLDER_THEMES[businessType] || PLACEHOLDER_THEMES.peluqueria

--- a/web/lib/engine/data-loader.ts
+++ b/web/lib/engine/data-loader.ts
@@ -8,21 +8,52 @@
 import type { BusinessData } from './compose'
 import { getDemoBusiness, getAllDemoSlugs, DEMO_BUSINESSES } from './demo-data'
 
-// Conditionally import lead data
+type BusinessType = BusinessData['type']
+
+type LeadDataModule = { LEAD_BUSINESSES?: Record<string, BusinessData> }
+
+// Conditionally import lead data (module is generated optionally during site
+// generation and may be absent in fresh checkouts).
 let LEAD_BUSINESSES: Record<string, BusinessData> = {}
 try {
-  const leadData = require('./lead-data')
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- optional module load
+  const leadData: LeadDataModule = require('./lead-data')
   LEAD_BUSINESSES = leadData.LEAD_BUSINESSES || {}
 } catch {
   // Lead data not generated yet
 }
 
-function rowToBusinessData(row: any): BusinessData {
+interface BusinessRow {
+  slug: string
+  name: string
+  type: string
+  tagline?: string
+  city?: string
+  neighborhood?: string
+  address?: string
+  phone?: string
+  email?: string
+  whatsapp?: string
+  instagram?: string
+  facebook?: string
+  google_maps_url?: string
+  hours?: Record<string, string>
+  data_json?: {
+    services?: BusinessData['services']
+    products?: BusinessData['products']
+    team?: BusinessData['team']
+    gallery?: BusinessData['gallery']
+    testimonials?: BusinessData['testimonials']
+    heroImage?: string
+  }
+}
+
+function rowToBusinessData(row: BusinessRow): BusinessData {
   const data = row.data_json || {}
   return {
     slug: row.slug,
     name: row.name,
-    type: row.type,
+    type: row.type as BusinessType,
     tagline: row.tagline,
     city: row.city || 'Asuncion',
     neighborhood: row.neighborhood,
@@ -88,7 +119,7 @@ export async function loadAllSlugs(): Promise<string[]> {
       .eq('status', 'active')
     
     if (data) {
-      data.forEach((row: any) => slugs.add(row.slug))
+      data.forEach((row: { slug: string }) => slugs.add(row.slug))
     }
   } catch {
     // Supabase not available, use local data only

--- a/web/lib/engine/demo-data.ts
+++ b/web/lib/engine/demo-data.ts
@@ -323,6 +323,46 @@ export const DEMO_BUSINESSES: Record<string, BusinessData> = {
     ],
   },
 
+  'de-abasto-a-casa': {
+    name: 'De Abasto a Casa',
+    slug: 'de-abasto-a-casa',
+    type: 'meal_prep',
+    tagline: 'Mercado, prep y comidas listas. Puerta a puerta, en San Lorenzo.',
+    city: 'San Lorenzo',
+    neighborhood: 'Ciudad Universitaria',
+    address: 'San Lorenzo (ciudad completa)',
+    phone: '+595000000000',
+    email: 'hola@deabastoacasa.com.py',
+    whatsapp: '+595000000000',
+    instagram: '@deabastoacasa',
+    hours: {
+      'Lunes - Viernes': '08:00 - 19:00 (coordinacion por WhatsApp)',
+      'Martes y Jueves': 'Compras en Abasto + mercado',
+      'Sabado': '09:00 - 14:00 (entregas)',
+      'Domingo': 'Cerrado',
+    },
+    services: [
+      { name: 'Nivel 1 - Basico', price: '250.000 Gs/semana', duration: 120, description: 'Lista corta, 1 proveedor. Hasta 15 productos. Delivery incluido.', category: 'Compras (Raw)' },
+      { name: 'Nivel 1 - Completo', price: '400.000 Gs/semana', duration: 180, description: 'Lista completa + Abasto + mercado + almacen. Delivery y organizado.', category: 'Compras (Raw)' },
+      { name: 'Nivel 2 - Individual', price: '400.000 Gs/semana', duration: 240, description: '1 persona. Prep basico: proteina + carbos + vegetales, sellado al vacio.', category: 'Mise-en-Place' },
+      { name: 'Nivel 2 - Pareja', price: '650.000 Gs/semana', duration: 300, description: '2 personas. Prep completo + organizacion de heladera/freezer.', category: 'Mise-en-Place' },
+      { name: 'Nivel 2 - Familia', price: '900.000 Gs/semana', duration: 360, description: '3-4 personas. Variedad, sustituciones y porciones para la semana.', category: 'Mise-en-Place' },
+      { name: 'Nivel 3 - 10 comidas/sem', priceFrom: '1.200.000 Gs/semana', duration: 480, description: 'Comidas listas, selladas al vacio. Proximamente (en habilitacion INAN).', category: 'Comidas Listas' },
+      { name: 'Nivel 3 - 15 comidas/sem', priceFrom: '1.700.000 Gs/semana', duration: 540, description: 'Pack familiar, 3 comidas/dia. Proximamente (en habilitacion INAN).', category: 'Comidas Listas' },
+      { name: 'Add-on: Desayunos', price: '+400.000 Gs/mes', description: 'Desayunos listos para la semana.', category: 'Add-on' },
+      { name: 'Add-on: Postres', price: '+200.000 Gs/mes', description: 'Postres caseros sumados al pack.', category: 'Add-on' },
+      { name: 'Add-on: Bebidas/snacks', price: '+300.000 Gs/mes', description: 'Bebidas y snacks saludables.', category: 'Add-on' },
+    ],
+    team: [
+      { name: 'Ivan Weiss van der Pol', role: 'Fundador & Chef de Mercado', bio: 'Del caos del mercado y la cocina a sistemas que funcionan. Proveedor propio en Abasto, prep semanal para clientes en San Lorenzo desde 2025.' },
+    ],
+    testimonials: [
+      { quote: 'Recupere 20+ horas al mes. No vuelvo a cocinar todos los dias. [Testimonio ilustrativo - clientes reales pronto]', author: 'Remoto Global', role: 'Cliente ilustrativo', rating: 5 },
+      { quote: 'La proteina sellada al vacio dura 4 meses en freezer sin perder sabor. Cambia todo. [Testimonio ilustrativo]', author: 'Profesional Medico', role: 'Cliente ilustrativo', rating: 5 },
+      { quote: 'Primera vez que pago un servicio con numeros honestos. No me inflan, me muestran. [Testimonio ilustrativo]', author: 'Pareja Commuter', role: 'Clientes ilustrativos', rating: 5 },
+    ],
+  },
+
   'depilacion-perfecta': {
     name: 'Depilacion Perfecta',
     slug: 'depilacion-perfecta',

--- a/web/lib/engine/renderer.tsx
+++ b/web/lib/engine/renderer.tsx
@@ -18,6 +18,7 @@ import { FAQSection } from '@/components/sections/faq-section'
 import { CTABannerSection } from '@/components/sections/cta-banner-section'
 import { FooterSection } from '@/components/sections/footer-section'
 import { WhatsAppFloat } from '@/components/sections/whatsapp-float'
+import { SavingsCalculatorSection } from '@/components/sections/savings-calculator-section'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const SECTION_COMPONENTS: Record<string, React.ComponentType<any>> = {
@@ -33,6 +34,7 @@ const SECTION_COMPONENTS: Record<string, React.ComponentType<any>> = {
   ctaBanner: CTABannerSection,
   footer: FooterSection,
   whatsappFloat: WhatsAppFloat,
+  savingsCalculator: SavingsCalculatorSection,
 }
 
 export function renderSection(section: ComposedSection): React.ReactNode {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -15,6 +15,7 @@ export const BUSINESS_TYPES = [
   'depilacion',
   'pestanas',
   'diseno_grafico',
+  'meal_prep',
 ] as const
 
 export type BusinessType = (typeof BUSINESS_TYPES)[number]


### PR DESCRIPTION
## Summary

- Adds a new `meal_prep` business type (registry + content + tokens + schema + DB migration) to support premium personal shopping / meal prep businesses.
- Ships the first tenant on this type: **De Abasto a Casa** (San Lorenzo, Paraguay) with 3 service tiers (Nivel 1 Raw / Nivel 2 Prep / Nivel 3 Cocido), add-ons, founder bio, illustrative testimonials.
- Introduces the first **interactive section** in the builder: `SavingsCalculatorSection` — live plata-+-tiempo calculator with a WhatsApp CTA pre-filled with the user's numbers.
- Opportunistically fixes a pre-existing constraint gap: adds `diseno_grafico` to the DB `type` CHECK and to `base-business.schema.json`, aligning with the existing Dayah LitWorks demo entry.

## What's in the diff

**New type files**
- `src/registry/meal_prep.type.json` — nav, hero template, SEO, section order, `savingsCalculator` feature flag
- `src/content/meal_prep.content.json` — all Spanish copy: hero, 3 service tiers (individual/pareja/familia + Nivel 1 y 3), 8 FAQ, savings calculator labels, footer
- `src/tokens/meal_prep.tokens.json` — Mercado Verde palette (`#3a6b4a` primary, `#c2663a` secondary, `#f6f1e7` cream bg) + Fraunces/Inter typography
- `src/schemas/meal_prep.schema.json` — per-type JSON Schema with sourcing/coverageArea/inanLicensed fields

**Registration**
- `web/lib/types.ts` — `'meal_prep'` added to `BUSINESS_TYPES`
- `src/schemas/base-business.schema.json` — `'meal_prep'` + `'diseno_grafico'` added to `businessType` enum
- `src/registry/index.json` — `meal_prep` entry with `shopping-cart` icon

**DB**
- `web/db/migrations/003_add_meal_prep_and_diseno_grafico.sql` — widens `businesses.type` CHECK

**Tenant data**
- `web/lib/engine/demo-data.ts` — `de-abasto-a-casa` entry with 10 services, 1 team member, 3 illustrative testimonials, hours, WhatsApp placeholder

**Homepage**
- `web/app/page.tsx` — new `ShoppingCart` import + `meal_prep` tile in `TEMPLATES`, updated "11 Plantillas" → "12 Plantillas"

**Engine wiring**
- `web/lib/engine/compose.ts` — `'savingsCalculator'` added to `SectionType`, `SECTION_MAP`, `buildSectionData` case; `meal_prep` added to placeholder gallery theme map; `ContentTemplate.savingsCalculator` typing
- `web/lib/engine/renderer.tsx` — `SavingsCalculatorSection` registered
- `web/app/[business]/page.tsx` — `meal_prep` → `FoodService`, `diseno_grafico` → `ProfessionalService` in JSON-LD schemaTypes

**New component**
- `web/components/sections/savings-calculator-section.tsx` — `'use client'` React component. 7 numeric inputs, tier dropdown, live totals, honest-copy branching (positive vs non-positive savings), WhatsApp deep link with pre-filled personalized message. `es-PY` number formatting.

## Test plan

- [x] `npm run validate:schemas` — 14/14 OK
- [x] `npm run validate:tokens` — 14/14 OK
- [x] `npm run typecheck` — OK
- [x] `npm run build` — 66/66 pages generated, no errors
- [x] `npm run dev` + `curl /de-abasto-a-casa` → all 10 sections present (hero headline, 3 tiers with prices, calculator, galeria, equipo, FAQ, contacto, CTA banner, float); homepage lists the Grocery tile linking to `/de-abasto-a-casa`
- [ ] After merge: verify on paragu-ai.com that the tile appears in "Proyectos" and the page loads
- [ ] Apply migration 003 on the production Supabase project before inserting a real `meal_prep` row

## Follow-ups for the tenant (not in this PR — Phase 2)

1. Replace WhatsApp placeholder `+595 000 000000` with Ivan's real number.
2. Swap illustrative testimonials for real quotes (Fran / Junior / Emilio & Lucia) once authorization is granted.
3. Upload curated gallery photos from `ivanweissvanderpol/grocery` → `02_Shopping_Guide/images/` to `public/assets/businesses/de-abasto-a-casa/` and wire via the `gallery` field.
4. Logo SVG (wordmark + shopping-bag icon) in `public/assets/businesses/de-abasto-a-casa/logo.svg`.

Companion docs in the business repo: [`ivanweissvanderpol/grocery#claude/grocery-website-plan-MerSn`](https://github.com/IvanWeissVanDerPol/grocery/tree/claude/grocery-website-plan-MerSn/09_Website) — plan, copy, brand guidelines, image curation.

https://claude.ai/code/session_01RGqJQTGZEinJQ8YKhvY1Mx
