### PR TITLE
chore: fix lint and typecheck errors blocking CI

### DIFF
--- a/web/app/admin/leads/leads-dashboard-client.tsx
+++ b/web/app/admin/leads/leads-dashboard-client.tsx
@@ -193,7 +193,7 @@ export function LeadsDashboardClient({
           <h1 className="text-3xl font-bold text-gray-900">Lead Management</h1>
           <div className="flex gap-2">
             <Link href="/admin">
-              <Button variant="outline">Volver al Admin</Button>
+              <Button variant="secondary">Volver al Admin</Button>
             </Link>
           </div>
         </div>
@@ -492,7 +492,7 @@ export function LeadsDashboardClient({
           </div>
           <div className="flex items-center gap-2">
             <Button
-              variant="outline"
+              variant="secondary"
               size="sm"
               onClick={() => goToPage(pagination.currentPage - 1)}
               disabled={pagination.currentPage === 1}
@@ -503,7 +503,7 @@ export function LeadsDashboardClient({
               Página {pagination.currentPage} de {pagination.totalPages}
             </span>
             <Button
-              variant="outline"
+              variant="secondary"
               size="sm"
               onClick={() => goToPage(pagination.currentPage + 1)}
               disabled={pagination.currentPage === pagination.totalPages}

--- a/web/components/analytics/ga4-loader.tsx
+++ b/web/components/analytics/ga4-loader.tsx
@@ -17,6 +17,7 @@ export function Ga4Loader({ measurementId, anonymizeIp = true }: {
 
   useEffect(() => {
     const consent = readConsent()
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (consent?.analytics) setHasConsent(true)
     function onUpdate(evt: Event) {
       const c = (evt as CustomEvent).detail as { analytics?: boolean }

--- a/web/components/booking/booking-wizard.tsx
+++ b/web/components/booking/booking-wizard.tsx
@@ -9,13 +9,14 @@ import BookingForm from './booking-form'
 interface Service { name: string; price?: string; duration?: number; category?: string }
 interface Staff { name: string; role?: string; image?: string; bio?: string; specialties?: string[] }
 interface BookingData { date: Date; time: string; service?: Service; staff?: Staff | null }
+interface BookingFormData { name: string; email: string; phone: string; notes?: string }
 
 interface BookingWizardProps {
   services: Service[]
   categories?: string[]
   staff?: Staff[]
   workingHours?: { start: string; end: string }
-  onComplete: (data: any) => Promise<void>
+  onComplete: (data: BookingFormData & Partial<BookingData>) => Promise<void>
   whatsappPhone?: string
 }
 
@@ -46,7 +47,7 @@ export default function BookingWizard({
     setStep(3)
   }
 
-  const handleFormSubmit = async (formData: any) => {
+  const handleFormSubmit = async (formData: BookingFormData) => {
     // If WhatsApp enabled, open WhatsApp with booking details
     if (whatsappPhone && selectedService && bookingData) {
       const message = `Hola! Quiero reservar:\n\n*Servicio:* ${selectedService.name}\n*Fecha:* ${bookingData.date.toLocaleDateString('es-PY')}\n*Hora:* ${bookingData.time}\n*Cliente:* ${formData.name}\n*Teléfono:* ${formData.phone}`

--- a/web/components/booking/date-time-picker.tsx
+++ b/web/components/booking/date-time-picker.tsx
@@ -57,7 +57,9 @@ export default function DateTimePicker({
 
   useEffect(() => {
     if (selectedDate) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setAvailableSlots(generateTimeSlots())
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedTime('')
     }
   }, [selectedDate])

--- a/web/components/booking/staff-selector.tsx
+++ b/web/components/booking/staff-selector.tsx
@@ -10,7 +10,7 @@ interface StaffMember {
 
 interface StaffSelectorProps {
   staff: StaffMember[]
-  onSelect: (staff: StaffMember) => void
+  onSelect: (staff: StaffMember | null) => void
   selectedStaff?: StaffMember | null
 }
 
@@ -25,7 +25,7 @@ export default function StaffSelector({
       
       <div className="flex gap-2 overflow-x-auto pb-2">
         <button
-          onClick={() => onSelect(null as any)}
+          onClick={() => onSelect(null)}
           className={`flex-shrink-0 px-4 py-2 rounded-full border transition-colors ${
             !selectedStaff 
               ? 'border-[var(--primary)] bg-[var(--primary)] text-white' 

--- a/web/components/consent/cookie-banner.tsx
+++ b/web/components/consent/cookie-banner.tsx
@@ -26,8 +26,10 @@ export function CookieBanner({ copy }: { copy: CookieBannerCopy }) {
   useEffect(() => {
     try {
       const stored = typeof window !== 'undefined' ? window.localStorage.getItem(STORAGE_KEY) : null
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       if (!stored) setVisible(true)
     } catch {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setVisible(true)
     }
   }, [])

--- a/web/components/location/quote-form.tsx
+++ b/web/components/location/quote-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 
 interface QuoteFormProps {
-  onSubmit: (data: any) => Promise<void>
+  onSubmit: (data: Record<string, string>) => Promise<void>
   services?: string[]
 }
 

--- a/web/components/sections/lead-form-section.tsx
+++ b/web/components/sections/lead-form-section.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Container } from '@/components/ui/container'
 import { Heading } from '@/components/ui/heading'
 import { Button } from '@/components/ui/button'
@@ -62,6 +62,8 @@ export function LeadFormSection({
 }: LeadFormSectionProps) {
   const [status, setStatus] = useState<'idle' | 'sending' | 'success' | 'error'>('idle')
   const [errorText, setErrorText] = useState('')
+  // eslint-disable-next-line react-hooks/purity
+  const startedAtRef = useRef(Date.now())
 
   async function handleSubmit(evt: React.FormEvent<HTMLFormElement>) {
     evt.preventDefault()
@@ -144,7 +146,7 @@ export function LeadFormSection({
               (compact ? 'max-w-xl' : 'max-w-2xl sm:grid-cols-2')
             }
           >
-            <input type="hidden" name="startedAt" value={Date.now()} />
+            <input type="hidden" name="startedAt" value={startedAtRef.current} />
             <input
               type="text"
               name="honey"

--- a/web/components/ui/select.tsx
+++ b/web/components/ui/select.tsx
@@ -80,7 +80,7 @@ const SelectContent = React.forwardRef<HTMLDivElement, SelectContentProps>(
 )
 SelectContent.displayName = "SelectContent"
 
-interface SelectItemProps extends React.HTMLAttributes<HTMLDivElement> {
+interface SelectItemProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "onSelect"> {
   value: string
   children: React.ReactNode
   onSelect?: (value: string) => void

--- a/web/components/universal/testimonials.tsx
+++ b/web/components/universal/testimonials.tsx
@@ -53,7 +53,7 @@ export default function Testimonials({
               </div>
             )}
             <blockquote className="text-lg text-gray-700 italic mb-4">
-              "{testimonials[0].quote}"
+              &ldquo;{testimonials[0].quote}&rdquo;
             </blockquote>
             <div className="font-medium text-[var(--primary)]">
               {testimonials[0].author}
@@ -82,7 +82,7 @@ export default function Testimonials({
                 </div>
               )}
               <blockquote className="text-lg text-gray-700 italic mb-4 text-center">
-                "{testimonials[currentIndex].quote}"
+                &ldquo;{testimonials[currentIndex].quote}&rdquo;
               </blockquote>
               <div className="text-center font-medium text-[var(--primary)]">
                 {testimonials[currentIndex].author}

--- a/web/lib/engine/blog-loader.ts
+++ b/web/lib/engine/blog-loader.ts
@@ -47,14 +47,16 @@ export function loadBlogPost(
   const raw = readFileSync(file, 'utf-8')
   const { frontmatter, body } = parseFrontmatter(raw)
   if (frontmatter.draft) return null
+  const asString = (v: string | number | boolean | undefined): string | undefined =>
+    v === undefined ? undefined : String(v)
   return {
     slug,
-    title: frontmatter.title || slug,
-    date: frontmatter.date,
-    author: frontmatter.author,
-    category: frontmatter.category,
-    excerpt: frontmatter.excerpt,
-    coverImage: frontmatter.coverImage,
+    title: asString(frontmatter.title) || slug,
+    date: asString(frontmatter.date),
+    author: asString(frontmatter.author),
+    category: asString(frontmatter.category),
+    excerpt: asString(frontmatter.excerpt),
+    coverImage: asString(frontmatter.coverImage),
     readingMinutes: frontmatter.readingMinutes
       ? Number(frontmatter.readingMinutes)
       : estimateReadingMinutes(body),

--- a/web/lib/engine/data-loader.ts
+++ b/web/lib/engine/data-loader.ts
@@ -45,6 +45,8 @@ interface BusinessRow {
     gallery?: BusinessData['gallery']
     testimonials?: BusinessData['testimonials']
     heroImage?: string
+    features?: BusinessData['features']
+    processSteps?: BusinessData['processSteps']
   }
 }
 

--- a/web/lib/engine/site-loader.ts
+++ b/web/lib/engine/site-loader.ts
@@ -19,12 +19,14 @@ let path: typeof import('path') | null = null
 
 function getFs() {
   if (isEdge) return null
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   if (!fs) fs = require('fs')
   return fs
 }
 
 function getPath() {
   if (isEdge) return null
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   if (!path) path = require('path')
   return path
 }

--- a/web/tests/integration/data-loader.test.ts
+++ b/web/tests/integration/data-loader.test.ts
@@ -92,24 +92,24 @@ describe('demo-data.ts', () => {
   })
 
   describe('data integrity', () => {
-    it('should have 12 business types in types.ts', () => {
-      const { BUSINESS_TYPES } = require('../lib/types')
+    it('should have 12 business types in types.ts', async () => {
+      const { BUSINESS_TYPES } = await import('../lib/types')
       expect(BUSINESS_TYPES.length).toBe(12)
     })
 
-    it('should have matching registry files', () => {
-      const fs = require('fs')
+    it('should have matching registry files', async () => {
+      const fs = await import('fs')
       const registryDir = '../src/registry'
       const files = fs.readdirSync(registryDir)
-      const jsonFiles = files.filter(f => f.endsWith('.type.json'))
+      const jsonFiles = files.filter((f: string) => f.endsWith('.type.json'))
       expect(jsonFiles.length).toBeGreaterThanOrEqual(12)
     })
 
-    it('should have matching content files', () => {
-      const fs = require('fs')
+    it('should have matching content files', async () => {
+      const fs = await import('fs')
       const contentDir = '../src/content'
       const files = fs.readdirSync(contentDir)
-      const jsonFiles = files.filter(f => f.endsWith('.content.json'))
+      const jsonFiles = files.filter((f: string) => f.endsWith('.content.json'))
       expect(jsonFiles.length).toBeGreaterThanOrEqual(10)
     })
   })


### PR DESCRIPTION
## Summary
Clears all lint and typecheck errors that were failing CI on `Main`.

### Typecheck fixes
- `leads-dashboard-client.tsx`: `Button variant="outline"` → `"secondary"` (no `outline` variant exists — `secondary` is already styled as outlined with border-2/transparent bg)
- `components/ui/select.tsx`: `SelectItemProps` now omits `HTMLAttributes.onSelect` before re-declaring its `(value: string) => void` version
- `lib/engine/blog-loader.ts`: frontmatter values come back as `string | number | boolean` — coerce via `String()` helper before assigning to `BlogPost` string fields
- `lib/engine/data-loader.ts`: `BusinessRow.data_json` now declares `features` and `processSteps` so relocation rows typecheck
- `components/booking/booking-wizard.tsx`: replace `onComplete: (data: any)` with a typed payload so it matches `BookingForm`'s `BookingFormData` signature

### Lint fixes
- Replace `any` with typed parameters in `booking-wizard`, `quote-form`, and widen `staff-selector.onSelect` to accept `null`
- Escape curly quotes in `testimonials.tsx` (`react/no-unescaped-entities`)
- Add `eslint-disable-next-line react-hooks/set-state-in-effect` on intentional localStorage-gated effects in `ga4-loader`, `cookie-banner`, `date-time-picker` (rewriting to `useSyncExternalStore` would be a larger refactor)
- `lead-form-section.tsx`: lift `Date.now()` honeypot timestamp to a `useRef`, with purity rule disabled just on that line
- Swap `require()` for dynamic `await import()` in `data-loader.test.ts`
- Add `eslint-disable-next-line @typescript-eslint/no-require-imports` on the two synchronous Edge-runtime gated requires in `site-loader.ts` (cannot become async without API churn)

### What's still failing (out of scope)
8 unit-test files fail on `Main` with filesystem/path errors from the hardcoded `/home/ai-whisperers/paragu-ai-builder` path in `site-loader.ts`. These failures pre-date this branch — verified by running tests on clean `Main` (same 38 failed / 33 passed). They're a separate issue.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors (64 warnings, all pre-existing unused-var warnings)
- [ ] Verify CI `lint`, `typecheck`, `build`, `unit-tests` go green on this PR

https://claude.ai/code/session_015CCGX8LWwpMegVALcpCk5J