### PR TITLE
Wire menu sections: featuredMenu, fullMenu, colorCodedMenu, specialOrder

### DIFF
--- a/web/components/sections/color-coded-menu-section.tsx
+++ b/web/components/sections/color-coded-menu-section.tsx
@@ -1,0 +1,240 @@
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Card, CardContent, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { AnimateOnScroll, AnimatedSectionHeader } from '@/components/ui/animate-on-scroll'
+import { SushiPlate, SeigaihaPattern } from '@/components/icons/sushi'
+
+export interface ColorCodedPlate {
+  key: string
+  title: string
+  price: string
+  items: string[]
+  color: string
+  description?: string
+}
+
+export interface ColorCodedMenuSectionProps {
+  title: string
+  subtitle?: string
+  description?: string
+  plates: ColorCodedPlate[]
+  legendTitle?: string
+}
+
+const VARIANTS: Array<'nigiri' | 'maki' | 'sashimi'> = ['nigiri', 'maki', 'sashimi']
+
+export function ColorCodedMenuSection({
+  title,
+  subtitle,
+  description,
+  plates,
+  legendTitle = 'Cada color = un precio',
+}: ColorCodedMenuSectionProps) {
+  return (
+    <section
+      id="menu"
+      className="relative overflow-hidden bg-[var(--background)] py-16 sm:py-20"
+    >
+      <div className="pointer-events-none absolute inset-0">
+        <SeigaihaPattern id="color-menu-seigaiha" color="var(--primary)" opacity={0.04} />
+      </div>
+
+      <Container className="relative">
+        <AnimatedSectionHeader className="mb-8 text-center">
+          <Heading as="h2" level={2} className="mb-4">
+            {title}
+          </Heading>
+          {subtitle && (
+            <p className="mx-auto max-w-2xl text-lg text-[var(--secondary)]">{subtitle}</p>
+          )}
+          {description && (
+            <p className="mx-auto mt-4 max-w-2xl text-sm text-[var(--text-muted)]">
+              {description}
+            </p>
+          )}
+        </AnimatedSectionHeader>
+
+        <div className="mx-auto mb-10 flex max-w-3xl flex-wrap items-center justify-center gap-3 rounded-full bg-[var(--surface-light)] p-3 shadow-sm">
+          <span className="px-2 text-sm font-semibold text-[var(--text-muted)]">
+            {legendTitle}:
+          </span>
+          {plates.map((plate) => (
+            <div
+              key={plate.key}
+              className="flex items-center gap-2 rounded-full bg-[var(--background)] px-3 py-1.5"
+            >
+              <span
+                className="inline-block h-4 w-4 rounded-full ring-2 ring-white"
+                style={{ backgroundColor: plate.color }}
+              />
+              <span className="text-sm font-medium text-[var(--text)]">{plate.price}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {plates.map((plate, index) => (
+            <AnimateOnScroll key={plate.key} stagger={index}>
+              <Card className="group relative h-full overflow-hidden transition-all duration-300 hover:-translate-y-1 hover:shadow-xl">
+                <div
+                  className="h-1.5 w-full"
+                  style={{ backgroundColor: plate.color }}
+                />
+                <CardContent className="p-6">
+                  <div className="mb-4 flex items-center gap-4">
+                    <div className="h-14 w-14 shrink-0 transition-transform duration-300 group-hover:scale-110">
+                      <SushiPlate
+                        plateColor={plate.color}
+                        toppingVariant={VARIANTS[index % VARIANTS.length]}
+                        width="56"
+                        height="56"
+                      />
+                    </div>
+                    <div>
+                      <CardTitle className="text-xl">{plate.title}</CardTitle>
+                      <p
+                        className="text-2xl font-bold"
+                        style={{ color: plate.color }}
+                      >
+                        {plate.price}
+                      </p>
+                    </div>
+                  </div>
+                  {plate.description && (
+                    <p className="mb-3 text-sm text-[var(--text-muted)]">
+                      {plate.description}
+                    </p>
+                  )}
+                  <ul className="space-y-2">
+                    {plate.items.map((item, i) => (
+                      <li
+                        key={i}
+                        className="flex items-start gap-2 text-sm text-[var(--text-light)]"
+                      >
+                        <span
+                          className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                          style={{ backgroundColor: plate.color }}
+                        />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            </AnimateOnScroll>
+          ))}
+        </div>
+      </Container>
+    </section>
+  )
+}
+
+export interface SpecialOrderItem {
+  name: string
+  description?: string
+  price?: string
+}
+
+export interface SpecialOrderSectionProps {
+  title: string
+  description?: string
+  items: Array<SpecialOrderItem | string>
+  tabletLabel?: string
+}
+
+export function SpecialOrderSection({
+  title,
+  description,
+  items,
+  tabletLabel = 'Pide desde la tableta',
+}: SpecialOrderSectionProps) {
+  const normalized = items.map((item) =>
+    typeof item === 'string' ? { name: item } : item
+  )
+
+  return (
+    <section id="special-order" className="bg-[var(--surface)] py-16 sm:py-20">
+      <Container>
+        <div className="mx-auto max-w-5xl overflow-hidden rounded-2xl border border-[var(--primary)]/10 bg-[var(--background)] shadow-lg">
+          <div className="grid gap-0 md:grid-cols-[1fr_1.5fr]">
+            <div className="relative flex items-center justify-center bg-gradient-to-br from-[var(--primary)] to-[var(--secondary)] p-10 text-[var(--primary-foreground)]">
+              <div className="relative z-10 text-center">
+                <div className="mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-3xl bg-white/15 backdrop-blur-sm">
+                  <svg
+                    width="40"
+                    height="40"
+                    viewBox="0 0 40 40"
+                    fill="none"
+                    aria-hidden="true"
+                  >
+                    <rect
+                      x="6"
+                      y="4"
+                      width="28"
+                      height="32"
+                      rx="3"
+                      stroke="currentColor"
+                      strokeWidth="2.5"
+                    />
+                    <rect
+                      x="10"
+                      y="8"
+                      width="20"
+                      height="22"
+                      rx="1"
+                      fill="currentColor"
+                      opacity="0.3"
+                    />
+                    <circle cx="20" cy="33" r="1.5" fill="currentColor" />
+                  </svg>
+                </div>
+                <p className="text-sm uppercase tracking-wider opacity-80">
+                  {tabletLabel}
+                </p>
+              </div>
+              <div
+                className="pointer-events-none absolute inset-0 opacity-20"
+                style={{
+                  backgroundImage:
+                    'radial-gradient(circle at 30% 30%, white 0%, transparent 60%)',
+                }}
+              />
+            </div>
+
+            <div className="p-8 md:p-10">
+              <Heading as="h2" level={2} className="mb-3">
+                {title}
+              </Heading>
+              {description && (
+                <p className="mb-6 text-[var(--text-muted)]">{description}</p>
+              )}
+              <div className="grid gap-3 sm:grid-cols-2">
+                {normalized.map((item, i) => (
+                  <AnimateOnScroll key={i} stagger={i}>
+                    <div className="flex items-start gap-3 rounded-lg border border-[var(--surface-light)] p-3 transition-colors hover:border-[var(--primary)]/30 hover:bg-[var(--surface-light)]">
+                      <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--primary)]/10 text-xs font-bold text-[var(--primary)]">
+                        {i + 1}
+                      </div>
+                      <div className="flex-1">
+                        <p className="font-medium text-[var(--text)]">{item.name}</p>
+                        {item.description && (
+                          <p className="text-xs text-[var(--text-muted)]">
+                            {item.description}
+                          </p>
+                        )}
+                      </div>
+                      {item.price && (
+                        <Badge variant="outline">{item.price}</Badge>
+                      )}
+                    </div>
+                  </AnimateOnScroll>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/sushi-menu-sections.tsx
+++ b/web/components/sections/sushi-menu-sections.tsx
@@ -1,0 +1,281 @@
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Card, CardContent, CardTitle, CardDescription } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { AnimateOnScroll, AnimatedSectionHeader } from '@/components/ui/animate-on-scroll'
+import { SushiCategoryIcon } from '@/components/icons/sushi-category'
+
+export interface MenuItem {
+  name: string
+  nameJa?: string
+  description?: string
+  price?: string
+  dietaryTags?: string[]
+  imageUrl?: string
+}
+
+export interface MenuCategory {
+  key: string
+  title: string
+  description?: string
+  items?: MenuItem[]
+}
+
+export interface FeaturedMenuSectionProps {
+  title: string
+  subtitle?: string
+  categories: MenuCategory[]
+  ctaText?: string
+  ctaHref?: string
+  dietaryLabels?: Record<string, string>
+}
+
+function DietaryBadge({ tag, label }: { tag: string; label?: string }) {
+  return (
+    <Badge variant="outline" className="text-[10px] uppercase">
+      {label ?? tag}
+    </Badge>
+  )
+}
+
+export function FeaturedMenuSection({
+  title,
+  subtitle,
+  categories,
+  ctaText,
+  ctaHref,
+  dietaryLabels,
+}: FeaturedMenuSectionProps) {
+  const filtered = categories.filter((c) => (c.items?.length ?? 0) > 0 || c.description)
+
+  return (
+    <section id="featured-menu" className="bg-[var(--background)] py-16 sm:py-20">
+      <Container>
+        <AnimatedSectionHeader className="mb-12 text-center">
+          <Heading as="h2" level={2} className="mb-4">
+            {title}
+          </Heading>
+          {subtitle && (
+            <p className="mx-auto max-w-2xl text-lg text-[var(--secondary)]">{subtitle}</p>
+          )}
+        </AnimatedSectionHeader>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((category, index) => (
+            <AnimateOnScroll key={category.key} stagger={index}>
+              <Card className="group h-full overflow-hidden transition-transform duration-300 hover:-translate-y-1 hover:shadow-xl">
+                <CardContent className="p-6">
+                  <div className="mb-4 flex items-center gap-3 text-[var(--primary)]">
+                    <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-[var(--primary)]/10 transition-transform duration-300 group-hover:scale-110">
+                      <SushiCategoryIcon
+                        category={category.key}
+                        width="32"
+                        height="32"
+                      />
+                    </div>
+                    <CardTitle className="text-xl">{category.title}</CardTitle>
+                  </div>
+
+                  {category.description && (
+                    <CardDescription className="mb-4">
+                      {category.description}
+                    </CardDescription>
+                  )}
+
+                  {category.items && category.items.length > 0 && (
+                    <ul className="space-y-2">
+                      {category.items.slice(0, 4).map((item, i) => (
+                        <li
+                          key={i}
+                          className="flex items-center justify-between gap-2 border-t border-[var(--surface-light)] pt-2 text-sm first:border-t-0 first:pt-0"
+                        >
+                          <div className="flex-1">
+                            <span className="font-medium text-[var(--text)]">
+                              {item.name}
+                            </span>
+                            {item.nameJa && (
+                              <span className="ml-1 text-xs text-[var(--text-muted)]">
+                                ({item.nameJa})
+                              </span>
+                            )}
+                            {item.dietaryTags && item.dietaryTags.length > 0 && (
+                              <span className="ml-2 inline-flex gap-1">
+                                {item.dietaryTags.map((t) => (
+                                  <DietaryBadge
+                                    key={t}
+                                    tag={t}
+                                    label={dietaryLabels?.[t]}
+                                  />
+                                ))}
+                              </span>
+                            )}
+                          </div>
+                          {item.price && (
+                            <span className="shrink-0 font-semibold text-[var(--primary)]">
+                              {item.price}
+                            </span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </CardContent>
+              </Card>
+            </AnimateOnScroll>
+          ))}
+        </div>
+
+        {ctaText && (
+          <div className="mt-12 text-center">
+            <a
+              href={ctaHref ?? '#menu'}
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--primary)] px-8 py-3 font-semibold text-[var(--primary-foreground)] shadow-lg transition-transform hover:-translate-y-0.5 hover:shadow-xl"
+            >
+              {ctaText}
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                <path
+                  d="M4 10h12m0 0l-4-4m4 4l-4 4"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </a>
+          </div>
+        )}
+      </Container>
+    </section>
+  )
+}
+
+export interface FullMenuSectionProps {
+  title: string
+  subtitle?: string
+  categories: MenuCategory[]
+  dietaryLabels?: Record<string, string>
+  japaneseTerms?: Record<string, string>
+}
+
+export function FullMenuSection({
+  title,
+  subtitle,
+  categories,
+  dietaryLabels,
+  japaneseTerms,
+}: FullMenuSectionProps) {
+  return (
+    <section id="full-menu" className="bg-[var(--background)] py-16 sm:py-20">
+      <Container>
+        <AnimatedSectionHeader className="mb-12 text-center">
+          <Heading as="h1" level={1} className="mb-4">
+            {title}
+          </Heading>
+          {subtitle && (
+            <p className="mx-auto max-w-2xl text-lg text-[var(--secondary)]">{subtitle}</p>
+          )}
+        </AnimatedSectionHeader>
+
+        {dietaryLabels && Object.keys(dietaryLabels).length > 0 && (
+          <div className="mx-auto mb-12 flex max-w-3xl flex-wrap items-center justify-center gap-3 rounded-2xl bg-[var(--surface-light)] p-4">
+            <span className="text-sm font-semibold text-[var(--text-muted)]">
+              Etiquetas:
+            </span>
+            {Object.entries(dietaryLabels).map(([tag, label]) => (
+              <div key={tag} className="flex items-center gap-1.5">
+                <Badge variant="outline" className="text-[10px] uppercase">
+                  {tag}
+                </Badge>
+                <span className="text-xs text-[var(--text-light)]">{label}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="mx-auto max-w-5xl space-y-12">
+          {categories.map((category, index) => (
+            <AnimateOnScroll key={category.key} stagger={Math.min(index, 5)}>
+              <div>
+                <div className="mb-6 flex items-center gap-4 border-b border-[var(--surface-light)] pb-4">
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-[var(--primary)]/10 text-[var(--primary)]">
+                    <SushiCategoryIcon category={category.key} width="28" height="28" />
+                  </div>
+                  <div>
+                    <Heading as="h2" level={3} className="mb-0">
+                      {category.title}
+                    </Heading>
+                    {category.description && (
+                      <p className="text-sm text-[var(--text-muted)]">
+                        {category.description}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {category.items && category.items.length > 0 ? (
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    {category.items.map((item, i) => (
+                      <div
+                        key={i}
+                        className="flex items-start justify-between gap-3 rounded-lg p-3 transition-colors hover:bg-[var(--surface-light)]"
+                      >
+                        <div className="flex-1">
+                          <div className="flex flex-wrap items-baseline gap-2">
+                            <p className="font-semibold text-[var(--text)]">
+                              {item.name}
+                            </p>
+                            {item.nameJa && (
+                              <p className="text-xs text-[var(--text-muted)]">
+                                {item.nameJa}
+                                {japaneseTerms?.[item.nameJa.toLowerCase()] && (
+                                  <span className="ml-1 italic">
+                                    ({japaneseTerms[item.nameJa.toLowerCase()]})
+                                  </span>
+                                )}
+                              </p>
+                            )}
+                          </div>
+                          {item.description && (
+                            <p className="mt-1 text-sm text-[var(--text-muted)]">
+                              {item.description}
+                            </p>
+                          )}
+                          {item.dietaryTags && item.dietaryTags.length > 0 && (
+                            <div className="mt-2 flex gap-1">
+                              {item.dietaryTags.map((t) => (
+                                <Badge
+                                  key={t}
+                                  variant="outline"
+                                  className="text-[10px] uppercase"
+                                >
+                                  {t}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                        {item.price && (
+                          <div className="shrink-0 text-right">
+                            <p className="font-semibold text-[var(--primary)]">
+                              {item.price}
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  category.description === undefined && (
+                    <p className="italic text-[var(--text-muted)]">
+                      Consulta con nuestro equipo por la selección del día.
+                    </p>
+                  )
+                )}
+              </div>
+            </AnimateOnScroll>
+          ))}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/lib/engine/compose.ts
+++ b/web/lib/engine/compose.ts
@@ -50,6 +50,10 @@ export type SectionType =
   | 'omakase'
   | 'sakeMenu'
   | 'conveyorBelt'
+  | 'featuredMenu'
+  | 'fullMenu'
+  | 'colorCodedMenu'
+  | 'specialOrder'
 
 export interface ComposedSection {
   type: SectionType
@@ -294,6 +298,22 @@ const SECTION_MAP: Record<string, SectionType> = {
   footer: 'footer',
   whatsappFloat: 'whatsappFloat',
   savingsCalculator: 'savingsCalculator',
+  // Restaurant / sushi / kaiten
+  omakase: 'omakase',
+  omakaseExperience: 'omakase',
+  sakeMenu: 'sakeMenu',
+  sakePairing: 'sakeMenu',
+  conveyorBelt: 'conveyorBelt',
+  howItWorks: 'conveyorBelt',
+  featuredMenu: 'featuredMenu',
+  fullMenu: 'fullMenu',
+  colorCodedMenu: 'colorCodedMenu',
+  specialOrder: 'specialOrder',
+  reservationForm: 'contact',
+  reservations: 'contact',
+  location: 'contact',
+  contactInfo: 'contact',
+  photoGallery: 'gallery',
 }
 
 /**
@@ -734,14 +754,155 @@ case 'beforeAfter': {
     }
 
     case 'conveyorBelt': {
-      const conveyorContent = content as { howItWorks?: { title?: string; subtitle?: string; steps?: Array<{ number: number; title: string; description: string }>; tips?: string[] }; plateColors?: Array<{ color: string; name: string; price: string; description: string }> }
+      type KaitenContent = {
+        howItWorks?: {
+          title?: string
+          subtitle?: string
+          steps?: Array<{ number: number; title: string; description: string }>
+          tips?: string[]
+        }
+        menuPage?: {
+          plates?: Record<
+            string,
+            { title: string; price: string; color: string; items: string[] }
+          >
+        }
+        plateColors?: Array<{ color: string; name: string; price: string; description: string }>
+      }
+      const conveyorContent = content as KaitenContent
       if (!conveyorContent?.howItWorks) return null
+      const platesFromMenu = conveyorContent.menuPage?.plates
+        ? Object.entries(conveyorContent.menuPage.plates).map(([key, v]) => ({
+            color: v.color,
+            name: v.title,
+            price: v.price,
+            description: key,
+          }))
+        : []
       return {
         title: conveyorContent.howItWorks.title || 'Cómo Funciona',
         subtitle: conveyorContent.howItWorks.subtitle,
         steps: conveyorContent.howItWorks.steps || [],
-        plateColors: conveyorContent.plateColors || [],
+        plateColors: conveyorContent.plateColors || platesFromMenu,
         tips: conveyorContent.howItWorks.tips,
+      }
+    }
+
+    case 'featuredMenu': {
+      type FeaturedContent = {
+        menuPage?: {
+          title?: string
+          subtitle?: string
+          categories?: Array<{
+            key: string
+            title: string
+            description?: string
+            items?: Array<{
+              name: string
+              nameJa?: string
+              description?: string
+              price?: string
+              dietaryTags?: string[]
+            }>
+          }>
+          dietaryLabels?: Record<string, string>
+        }
+      }
+      const featuredContent = content as FeaturedContent
+      const categories = featuredContent.menuPage?.categories
+      if (!categories || categories.length === 0) return null
+      return {
+        title: featuredContent.menuPage?.title || 'Nuestro Menú',
+        subtitle: featuredContent.menuPage?.subtitle,
+        categories: categories.slice(0, 6),
+        dietaryLabels: featuredContent.menuPage?.dietaryLabels,
+        ctaText: 'Ver Menú Completo',
+        ctaHref: `/${business.slug}/menu`,
+      }
+    }
+
+    case 'fullMenu': {
+      type FullMenuContent = {
+        menuPage?: {
+          title?: string
+          subtitle?: string
+          categories?: Array<{
+            key: string
+            title: string
+            description?: string
+            items?: Array<{
+              name: string
+              nameJa?: string
+              description?: string
+              price?: string
+              dietaryTags?: string[]
+            }>
+          }>
+          dietaryLabels?: Record<string, string>
+          japaneseTerms?: Record<string, string>
+        }
+      }
+      const fullMenuContent = content as FullMenuContent
+      const categories = fullMenuContent.menuPage?.categories
+      if (!categories || categories.length === 0) return null
+      return {
+        title: fullMenuContent.menuPage?.title || 'Menú Completo',
+        subtitle: fullMenuContent.menuPage?.subtitle,
+        categories,
+        dietaryLabels: fullMenuContent.menuPage?.dietaryLabels,
+        japaneseTerms: fullMenuContent.menuPage?.japaneseTerms,
+      }
+    }
+
+    case 'colorCodedMenu': {
+      type ColorMenuContent = {
+        menuPage?: {
+          title?: string
+          subtitle?: string
+          description?: string
+          plates?: Record<
+            string,
+            { title: string; price: string; items: string[]; color: string; description?: string }
+          >
+        }
+      }
+      const colorMenuContent = content as ColorMenuContent
+      const plates = colorMenuContent.menuPage?.plates
+      if (!plates) return null
+      const plateList = Object.entries(plates).map(([key, v]) => ({
+        key,
+        title: v.title,
+        price: v.price,
+        items: v.items,
+        color: v.color,
+        description: v.description,
+      }))
+      if (plateList.length === 0) return null
+      return {
+        title: colorMenuContent.menuPage?.title || 'Menú por Colores',
+        subtitle: colorMenuContent.menuPage?.subtitle,
+        description: colorMenuContent.menuPage?.description,
+        plates: plateList,
+      }
+    }
+
+    case 'specialOrder': {
+      type SpecialOrderContent = {
+        menuPage?: {
+          specialOrder?: {
+            title?: string
+            description?: string
+            items?: Array<string | { name: string; description?: string; price?: string }>
+          }
+        }
+      }
+      const specialContent = content as SpecialOrderContent
+      const special = specialContent.menuPage?.specialOrder
+      if (!special || !special.items || special.items.length === 0) return null
+      return {
+        title: special.title || 'Pedidos Especiales',
+        description: special.description,
+        items: special.items,
       }
     }
 

--- a/web/lib/engine/renderer.tsx
+++ b/web/lib/engine/renderer.tsx
@@ -39,6 +39,14 @@ import { ProcessTimelineSection } from '@/components/sections/process-timeline-s
 import { OmakaseSection } from '@/components/sections/omakase-section'
 import { SakeMenuSection } from '@/components/sections/sake-menu-section'
 import { ConveyorBeltSection } from '@/components/sections/conveyor-belt-section'
+import {
+  ColorCodedMenuSection,
+  SpecialOrderSection,
+} from '@/components/sections/color-coded-menu-section'
+import {
+  FeaturedMenuSection,
+  FullMenuSection,
+} from '@/components/sections/sushi-menu-sections'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const SECTION_COMPONENTS: Record<string, React.ComponentType<any>> = {
@@ -84,8 +92,16 @@ const SECTION_COMPONENTS: Record<string, React.ComponentType<any>> = {
   omakase: OmakaseSection,
   sakeMenu: SakeMenuSection,
   conveyorBelt: ConveyorBeltSection,
+  featuredMenu: FeaturedMenuSection,
+  fullMenu: FullMenuSection,
+  colorCodedMenu: ColorCodedMenuSection,
+  specialOrder: SpecialOrderSection,
   'sake-menu': SakeMenuSection,
   'conveyor-belt': ConveyorBeltSection,
+  'featured-menu': FeaturedMenuSection,
+  'full-menu': FullMenuSection,
+  'color-coded-menu': ColorCodedMenuSection,
+  'special-order': SpecialOrderSection,
 }
 
 export function renderSection(section: ComposedSection): React.ReactNode {

--- a/web/lib/engine/static-config.ts
+++ b/web/lib/engine/static-config.ts
@@ -2,7 +2,7 @@
  * Static config with embedded JSON content
  * Generated at build time - DO NOT EDIT MANUALLY
  * 
- * Generated: 2026-04-18T22:18:47.855Z
+ * Generated: 2026-04-19T00:23:36.730Z
  */
 
 export const REGISTRY_MAP: Record<string, unknown> = {
@@ -2470,7 +2470,7 @@ export const REGISTRY_MAP: Record<string, unknown> = {
     "nameEs": "Sushi Bar",
     "nameEn": "Sushi Bar",
     "extends": "restaurant",
-    "tokens": "sushi",
+    "tokens": "sushi_bar",
     "pages": {
       "homepage": {
         "sections": [
@@ -2673,7 +2673,7 @@ export const REGISTRY_MAP: Record<string, unknown> = {
     "nameEs": "Sushi Cinta Transportadora",
     "nameEn": "Conveyor Belt Sushi",
     "extends": "sushi_bar",
-    "tokens": "kaiten",
+    "tokens": "kaiten_zushi",
     "pages": {
       "homepage": {
         "sections": [
@@ -2683,6 +2683,7 @@ export const REGISTRY_MAP: Record<string, unknown> = {
           "conveyorBelt",
           "featuredMenu",
           "howItWorks",
+          "specialOrder",
           "reservations",
           "gallery",
           "footer"
@@ -2751,33 +2752,6 @@ export const REGISTRY_MAP: Record<string, unknown> = {
       "black_plates",
       "special_order"
     ],
-    "platePricing": {
-      "green": {
-        "color": "#22c55e",
-        "price": "15.000 Gs",
-        "description": "Platos básicos"
-      },
-      "yellow": {
-        "color": "#eab308",
-        "price": "25.000 Gs",
-        "description": "Favoritos populares"
-      },
-      "orange": {
-        "color": "#f97316",
-        "price": "35.000 Gs",
-        "description": "Especiales"
-      },
-      "red": {
-        "color": "#ef4444",
-        "price": "50.000 Gs",
-        "description": "Premium"
-      },
-      "black": {
-        "color": "#1a1a1a",
-        "price": "75.000 Gs",
-        "description": "Ultra premium"
-      }
-    },
     "targetAudience": {
       "primary": "Families, casual diners, quick lunch seekers",
       "secondary": "Sushi beginners, groups, kids"


### PR DESCRIPTION
## Summary
Wire up the four menu-related section types that were referenced by the restaurant / sushi_bar / kaiten_zushi registries but never rendered. Before this PR they silently fell through with "Unknown section type" warnings.

### New section components
- **FeaturedMenuSection** (homepage) — categorized preview with `SushiCategoryIcon` glyphs, dietary badges, per-item prices, and a CTA to the full menu page.
- **FullMenuSection** (menu page) — category detail view with dietary-label legend and optional Japanese-term translations.
- **ColorCodedMenuSection** (kaiten menu page) — plate-color cards with `SushiPlate` SVG, price-tier legend, and per-tier item list.
- **SpecialOrderSection** (kaiten) — tablet-ordering callout with numbered grid and gradient panel.

### Engine wiring
- Extend `SectionType` with `featuredMenu` / `fullMenu` / `colorCodedMenu` / `specialOrder`.
- Add `SECTION_MAP` aliases so registry names (`reservationForm`, `reservations`, `location`, `photoGallery`, `howItWorks`, `omakaseExperience`, `sakePairing`) route correctly.
- Add `buildSectionData` switch cases that extract `menuPage.categories` / `menuPage.plates` / `menuPage.specialOrder` from content JSON.
- Register all four components (camelCase + kebab-case) in the renderer.
- Regenerate `static-config.ts`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run generate:static-config` — 16 types
- [ ] Visually verify `/kaiten-zushi-demo/` homepage shows featured menu + conveyor + special order
- [ ] Visually verify `/kaiten-zushi-demo/menu` shows color-coded plates
- [ ] Visually verify `/sushi-bar-demo/menu` shows full menu with dietary labels

https://claude.ai/code/session_01HmpwqYWEmEc5EyyCLdYafH