### PR TITLE
feat(engine): section library expansion — 22 new reusable sections

### DIFF
--- a/src/registry/book_cover_designer.type.json
+++ b/src/registry/book_cover_designer.type.json
@@ -1,0 +1,46 @@
+{
+  "id": "book_cover_designer",
+  "nameEs": "Diseñador de Portadas de Libros",
+  "nameEn": "Book Cover Designer",
+  "verticalId": "portfolio-professional",
+  "extends": "diseno_grafico",
+  "tokens": "book_cover_designer",
+  "subVertical": "fashion-design",
+  "pages": {
+    "homepage": {
+      "sections": [
+        "header",
+        "hero",
+        "services",
+        "portfolio",
+        "product-catalog",
+        "creative-commission-process",
+        "pricing-range",
+        "testimonials",
+        "faq-categorized",
+        "intake-questionnaire",
+        "contact",
+        "footer",
+        "whatsapp-float"
+      ],
+      "requiredSections": ["header", "hero", "services", "portfolio", "contact", "footer"]
+    }
+  },
+  "features": {
+    "portfolio": { "enabled": true, "categoriesHint": ["fantasia", "romance", "thriller", "ciencia_ficcion", "terror", "ya"] },
+    "productCatalog": { "enabled": true, "whatsappOrder": true, "showPrices": true },
+    "intakeQuestionnaire": { "enabled": true, "fields": ["genre", "trimSize", "mood", "referenceCovers", "budget"] },
+    "internationalCurrency": { "enabled": true, "default": "USD" },
+    "whatsappFloat": { "enabled": true }
+  },
+  "seo": {
+    "schemaType": "ProfessionalService",
+    "titleTemplate": "{{businessName}} - Diseñador de Portadas de Libros",
+    "descriptionTemplate": "Portadas personalizadas, mockups 3D y premades para autores indie."
+  },
+  "hero": {
+    "style": "image",
+    "headlineTemplate": "{{businessName}}",
+    "subheadlineTemplate": "Portadas que venden libros."
+  }
+}

--- a/web/components/sections/before-after-split-section.tsx
+++ b/web/components/sections/before-after-split-section.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+
+/**
+ * Before/after split — two-column comparison for transformation stories.
+ * Different from `before-after` slider: this shows ORDERED LISTS, not images.
+ *
+ * Use cases: "before Nexa / after Nexa", "before meal prep / after",
+ * "pre-renovation / post-renovation", "DIY / with us".
+ */
+
+export interface BeforeAfterSplitProps {
+  title?: string
+  subtitle?: string
+  before: { label: string; items: string[]; icon?: string }
+  after: { label: string; items: string[]; icon?: string }
+}
+
+export function BeforeAfterSplitSection({
+  title,
+  subtitle,
+  before,
+  after,
+}: BeforeAfterSplitProps) {
+  return (
+    <section className="py-14 bg-[var(--background)]">
+      <Container>
+        {title && (
+          <div className="text-center mb-10">
+            <Heading level={2}>{title}</Heading>
+            {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+          </div>
+        )}
+
+        <div className="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
+          <div className="rounded-lg border border-[var(--surface-light)] p-6 bg-[var(--surface)]">
+            <h3 className="font-semibold text-[var(--text-muted)] mb-3">{before.label}</h3>
+            <ul className="space-y-2">
+              {before.items.map((x, i) => (
+                <li key={i} className="flex gap-2 text-sm text-[var(--text-muted)]">
+                  <span>✕</span>
+                  <span>{x}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-lg border-2 border-[var(--primary)] p-6 bg-[var(--surface)]">
+            <h3 className="font-semibold text-[var(--primary)] mb-3">{after.label}</h3>
+            <ul className="space-y-2">
+              {after.items.map((x, i) => (
+                <li key={i} className="flex gap-2 text-sm text-[var(--text)]">
+                  <span className="text-[var(--primary)]">✓</span>
+                  <span>{x}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/compare-plans-matrix-section.tsx
+++ b/web/components/sections/compare-plans-matrix-section.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+
+export interface ComparePlansMatrixProps {
+  title?: string
+  subtitle?: string
+  plans: Array<{ id: string; name: string; price?: string; popular?: boolean }>
+  features: Array<{ label: string; values: Record<string, string | boolean> }>
+  ctaTextBuilder?: (planId: string) => string
+}
+
+function renderValue(v: string | boolean | undefined) {
+  if (v === true) return '✓'
+  if (v === false || v === undefined) return '—'
+  return v
+}
+
+export function ComparePlansMatrixSection({
+  title = 'Compara los planes',
+  subtitle,
+  plans,
+  features,
+  ctaTextBuilder,
+}: ComparePlansMatrixProps) {
+  return (
+    <section className="py-16 bg-[var(--background)]">
+      <Container>
+        <div className="text-center mb-8">
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full max-w-5xl mx-auto text-sm border-collapse">
+            <thead>
+              <tr>
+                <th className="text-left p-3 text-[var(--text-muted)]">Caracteristica</th>
+                {plans.map((p) => (
+                  <th
+                    key={p.id}
+                    className={`p-3 text-center ${
+                      p.popular ? 'bg-[var(--primary)] text-[var(--primary-foreground)] rounded-t' : ''
+                    }`}
+                  >
+                    <div className="font-semibold">{p.name}</div>
+                    {p.price && <div className="text-xs mt-1">{p.price}</div>}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {features.map((f, i) => (
+                <tr key={i} className="border-t border-[var(--surface-light)]">
+                  <td className="p-3 text-[var(--text)]">{f.label}</td>
+                  {plans.map((p) => (
+                    <td key={p.id} className="p-3 text-center text-[var(--text)]">
+                      {renderValue(f.values[p.id])}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+              {ctaTextBuilder && (
+                <tr className="border-t border-[var(--surface-light)]">
+                  <td />
+                  {plans.map((p) => (
+                    <td key={p.id} className="p-3 text-center">
+                      <span className="text-[var(--primary)] font-medium">{ctaTextBuilder(p.id)}</span>
+                    </td>
+                  ))}
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/compliance-disclaimer-footer-section.tsx
+++ b/web/components/sections/compliance-disclaimer-footer-section.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+
+/**
+ * Legal / compliance disclaimer footer. Render below the main footer.
+ * Holds fine-print text (no investment advice / no medical advice / AML /
+ * license numbers) per jurisdiction.
+ */
+
+export interface ComplianceDisclaimerFooterProps {
+  paragraphs: string[]
+  licenseNumbers?: Array<{ label: string; number: string }>
+  linkText?: string
+  linkHref?: string
+}
+
+export function ComplianceDisclaimerFooterSection({
+  paragraphs,
+  licenseNumbers,
+  linkText,
+  linkHref,
+}: ComplianceDisclaimerFooterProps) {
+  if (!paragraphs?.length && !licenseNumbers?.length) return null
+  return (
+    <section className="py-6 bg-[var(--background)] border-t border-[var(--surface-light)]">
+      <Container>
+        <div className="max-w-4xl mx-auto text-xs text-[var(--text-muted)] space-y-2">
+          {paragraphs.map((p, i) => (
+            <p key={i}>{p}</p>
+          ))}
+          {licenseNumbers && licenseNumbers.length > 0 && (
+            <p>
+              {licenseNumbers.map((ln, i) => (
+                <span key={i} className="mr-3">
+                  <strong>{ln.label}:</strong> {ln.number}
+                </span>
+              ))}
+            </p>
+          )}
+          {linkText && linkHref && (
+            <p>
+              <a href={linkHref} className="underline">
+                {linkText}
+              </a>
+            </p>
+          )}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/countdown-timer-section.tsx
+++ b/web/components/sections/countdown-timer-section.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { useEffect, useState } from 'react'
+
+export interface CountdownTimerProps {
+  title?: string
+  subtitle?: string
+  /** ISO 8601 target date. */
+  targetDate: string
+  expiredMessage?: string
+  labels?: { days: string; hours: string; minutes: string; seconds: string }
+  ctaText?: string
+  ctaHref?: string
+}
+
+function diff(target: Date) {
+  const ms = target.getTime() - Date.now()
+  if (ms <= 0) return null
+  const s = Math.floor(ms / 1000)
+  return {
+    days: Math.floor(s / 86400),
+    hours: Math.floor((s % 86400) / 3600),
+    minutes: Math.floor((s % 3600) / 60),
+    seconds: s % 60,
+  }
+}
+
+export function CountdownTimerSection({
+  title,
+  subtitle,
+  targetDate,
+  expiredMessage = 'Este evento ya comenzó.',
+  labels = { days: 'dias', hours: 'horas', minutes: 'min', seconds: 'seg' },
+  ctaText,
+  ctaHref,
+}: CountdownTimerProps) {
+  const target = new Date(targetDate)
+  const [remaining, setRemaining] = useState(() => diff(target))
+
+  useEffect(() => {
+    const t = setInterval(() => setRemaining(diff(target)), 1000)
+    return () => clearInterval(t)
+  }, [targetDate]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <section className="py-12 bg-[var(--surface)]">
+      <Container>
+        <div className="max-w-2xl mx-auto text-center">
+          {title && <Heading level={2}>{title}</Heading>}
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+
+          {remaining ? (
+            <div className="mt-6 flex items-center justify-center gap-4">
+              {(['days', 'hours', 'minutes', 'seconds'] as const).map((k) => (
+                <div
+                  key={k}
+                  className="bg-[var(--background)] rounded-lg px-4 py-3 min-w-[72px]"
+                >
+                  <div className="text-3xl font-bold text-[var(--primary)]">
+                    {String(remaining[k]).padStart(2, '0')}
+                  </div>
+                  <div className="text-xs text-[var(--text-muted)] uppercase tracking-wide">
+                    {labels[k]}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-6 text-lg font-semibold text-[var(--text)]">{expiredMessage}</p>
+          )}
+
+          {ctaText && ctaHref && remaining && (
+            <a
+              href={ctaHref}
+              className="inline-block mt-6 bg-[var(--primary)] text-[var(--primary-foreground)] px-6 py-2 rounded"
+            >
+              {ctaText}
+            </a>
+          )}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/currency-toggle-section.tsx
+++ b/web/components/sections/currency-toggle-section.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState } from 'react'
+
+/**
+ * Currency toggle — small pill component that swaps display currency for any
+ * price rendered using `formatPrice` from `@/lib/currency`. Intentionally
+ * light: the actual swap logic lives in a React Context in consumer tenants.
+ * Drop this in header/footer; consumers subscribe to the dispatched event.
+ */
+
+export interface CurrencyToggleProps {
+  options: Array<{ code: string; label: string }>
+  initial?: string
+  /** CustomEvent name dispatched on window when user toggles. */
+  eventName?: string
+}
+
+export function CurrencyToggleSection({
+  options,
+  initial,
+  eventName = 'currency:change',
+}: CurrencyToggleProps) {
+  const [active, setActive] = useState(initial || options[0]?.code || '')
+  if (!options.length) return null
+
+  function onPick(code: string) {
+    setActive(code)
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(eventName, { detail: { code } }))
+    }
+  }
+
+  return (
+    <div className="inline-flex items-center gap-1 p-1 bg-[var(--surface-light)] rounded-full text-xs">
+      {options.map((opt) => (
+        <button
+          key={opt.code}
+          type="button"
+          onClick={() => onPick(opt.code)}
+          className={`px-3 py-1 rounded-full ${
+            active === opt.code ? 'bg-[var(--primary)] text-[var(--primary-foreground)]' : 'text-[var(--text)]'
+          }`}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/web/components/sections/delivery-slot-picker-section.tsx
+++ b/web/components/sections/delivery-slot-picker-section.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Button } from '@/components/ui/button'
+import { useState } from 'react'
+
+/**
+ * Delivery-slot picker — simple day + window chooser. Callers pass the set
+ * of available windows; the section submits selection to an endpoint.
+ *
+ * Full Cal.com integration is a follow-up (embeddable iframe). For now this
+ * handles the data model.
+ */
+
+export interface DeliverySlot {
+  day: string
+  label: string
+  windows: Array<{ id: string; from: string; to: string; available: boolean }>
+}
+
+export interface DeliverySlotPickerProps {
+  title?: string
+  subtitle?: string
+  slots: DeliverySlot[]
+  submitEndpoint?: string
+  submitLabel?: string
+  onPick?: (payload: { dayId: string; windowId: string }) => void
+}
+
+export function DeliverySlotPickerSection({
+  title = 'Elige tu horario de entrega',
+  subtitle,
+  slots,
+  submitEndpoint = '/api/delivery-slot',
+  submitLabel = 'Confirmar',
+  onPick,
+}: DeliverySlotPickerProps) {
+  const [activeDay, setActiveDay] = useState(slots[0]?.day ?? '')
+  const [activeWindow, setActiveWindow] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [done, setDone] = useState(false)
+
+  const currentSlot = slots.find((s) => s.day === activeDay)
+
+  async function onConfirm() {
+    if (!activeDay || !activeWindow) return
+    setSubmitting(true)
+    try {
+      if (onPick) {
+        onPick({ dayId: activeDay, windowId: activeWindow })
+      } else {
+        await fetch(submitEndpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ dayId: activeDay, windowId: activeWindow }),
+        })
+      }
+      setDone(true)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (done) {
+    return (
+      <section className="py-12 bg-[var(--background)]">
+        <Container>
+          <p className="text-center text-[var(--primary)] font-medium">
+            Listo — tu horario esta reservado.
+          </p>
+        </Container>
+      </section>
+    )
+  }
+
+  return (
+    <section className="py-12 bg-[var(--background)]">
+      <Container>
+        <div className="max-w-3xl mx-auto">
+          <div className="text-center mb-6">
+            <Heading level={2}>{title}</Heading>
+            {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+          </div>
+
+          <div className="flex flex-wrap gap-2 mb-4">
+            {slots.map((s) => (
+              <button
+                key={s.day}
+                onClick={() => {
+                  setActiveDay(s.day)
+                  setActiveWindow(null)
+                }}
+                className={`px-3 py-1.5 rounded-full text-sm ${
+                  activeDay === s.day
+                    ? 'bg-[var(--primary)] text-[var(--primary-foreground)]'
+                    : 'bg-[var(--surface-light)] text-[var(--text)]'
+                }`}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            {(currentSlot?.windows || []).map((w) => {
+              const selected = activeWindow === w.id
+              return (
+                <button
+                  key={w.id}
+                  disabled={!w.available}
+                  onClick={() => setActiveWindow(w.id)}
+                  className={`p-2 rounded text-sm border ${
+                    !w.available
+                      ? 'bg-[var(--surface-light)] text-[var(--text-muted)] line-through cursor-not-allowed'
+                      : selected
+                        ? 'border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]'
+                        : 'border-[var(--surface-light)] bg-[var(--surface)] hover:border-[var(--primary)]'
+                  }`}
+                >
+                  {w.from} – {w.to}
+                </button>
+              )
+            })}
+          </div>
+
+          <div className="mt-6 flex justify-center">
+            <Button onClick={onConfirm} disabled={!activeWindow || submitting}>
+              {submitting ? '...' : submitLabel}
+            </Button>
+          </div>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/faq-categorized-section.tsx
+++ b/web/components/sections/faq-categorized-section.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { useMemo, useState } from 'react'
+
+export interface FaqCategorizedProps {
+  title?: string
+  subtitle?: string
+  categories: Array<{ id: string; label: string; items: Array<{ q: string; a: string }> }>
+  searchPlaceholder?: string
+}
+
+export function FaqCategorizedSection({
+  title = 'Preguntas Frecuentes',
+  subtitle,
+  categories,
+  searchPlaceholder = 'Buscar en preguntas...',
+}: FaqCategorizedProps) {
+  const [query, setQuery] = useState('')
+  const [active, setActive] = useState(categories[0]?.id ?? '')
+
+  const filtered = useMemo(() => {
+    if (!query) return categories.find((c) => c.id === active)?.items ?? []
+    const q = query.toLowerCase()
+    return categories.flatMap((c) =>
+      c.items.filter((it) => it.q.toLowerCase().includes(q) || it.a.toLowerCase().includes(q)),
+    )
+  }, [categories, active, query])
+
+  return (
+    <section className="py-16 bg-[var(--background)]">
+      <Container>
+        <div className="text-center mb-8">
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+        </div>
+
+        <div className="max-w-3xl mx-auto">
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={searchPlaceholder}
+            className="w-full mb-4 px-3 py-2 border border-[var(--surface-light)] rounded bg-[var(--surface)] text-[var(--text)]"
+          />
+
+          {!query && (
+            <div className="flex flex-wrap gap-2 mb-4">
+              {categories.map((c) => (
+                <button
+                  key={c.id}
+                  onClick={() => setActive(c.id)}
+                  className={`px-3 py-1 rounded-full text-sm ${
+                    active === c.id
+                      ? 'bg-[var(--primary)] text-[var(--primary-foreground)]'
+                      : 'bg-[var(--surface-light)] text-[var(--text)]'
+                  }`}
+                >
+                  {c.label}
+                </button>
+              ))}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            {filtered.map((item, i) => (
+              <details
+                key={i}
+                className="rounded-lg bg-[var(--surface)] border border-[var(--surface-light)] p-3"
+              >
+                <summary className="cursor-pointer font-medium text-[var(--text)]">
+                  {item.q}
+                </summary>
+                <p className="mt-2 text-sm text-[var(--text-muted)]">{item.a}</p>
+              </details>
+            ))}
+            {filtered.length === 0 && (
+              <p className="text-center text-[var(--text-muted)] py-6">Sin resultados.</p>
+            )}
+          </div>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/google-reviews-widget-section.tsx
+++ b/web/components/sections/google-reviews-widget-section.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Card, CardContent } from '@/components/ui/card'
+
+/**
+ * Google reviews widget. Content is passed in — the server-side fetcher
+ * against Google Places API lives in /api/google-reviews and is stubbed.
+ * If `fetchedFromApi=false`, this renders whatever curated content the tenant provides.
+ */
+
+export interface GoogleReviewsWidgetProps {
+  title?: string
+  subtitle?: string
+  avgRating?: number
+  reviewCount?: number
+  reviews: Array<{ author: string; rating: number; text: string; date?: string }>
+  placeUrl?: string
+  writeReviewUrl?: string
+}
+
+function stars(rating: number): string {
+  const full = '★'.repeat(Math.round(rating))
+  const empty = '☆'.repeat(5 - Math.round(rating))
+  return full + empty
+}
+
+export function GoogleReviewsWidgetSection({
+  title = 'Lo que dicen en Google',
+  subtitle,
+  avgRating,
+  reviewCount,
+  reviews,
+  placeUrl,
+  writeReviewUrl,
+}: GoogleReviewsWidgetProps) {
+  if (!reviews?.length) return null
+  return (
+    <section className="py-14 bg-[var(--background)]">
+      <Container>
+        <div className="text-center mb-8">
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+          {avgRating !== undefined && (
+            <div className="mt-2 text-[var(--primary)]">
+              <span className="text-2xl">{stars(avgRating)}</span>
+              <span className="ml-2 text-[var(--text-muted)]">
+                {avgRating.toFixed(1)}{' '}
+                {reviewCount && <>({reviewCount} reseñas)</>}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3 max-w-5xl mx-auto">
+          {reviews.slice(0, 6).map((r, i) => (
+            <Card key={i}>
+              <CardContent className="p-4">
+                <div className="text-[var(--primary)] text-sm mb-1">{stars(r.rating)}</div>
+                <p className="text-sm text-[var(--text)]">{r.text}</p>
+                <div className="mt-3 text-xs text-[var(--text-muted)]">
+                  {r.author}
+                  {r.date && <> · {r.date}</>}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        {(placeUrl || writeReviewUrl) && (
+          <div className="text-center mt-6 space-x-4 text-sm">
+            {placeUrl && (
+              <a href={placeUrl} target="_blank" rel="noopener noreferrer" className="text-[var(--primary)]">
+                Ver todas las reseñas
+              </a>
+            )}
+            {writeReviewUrl && (
+              <a href={writeReviewUrl} target="_blank" rel="noopener noreferrer" className="text-[var(--primary)]">
+                Escribir una reseña
+              </a>
+            )}
+          </div>
+        )}
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/instagram-feed-section.tsx
+++ b/web/components/sections/instagram-feed-section.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+
+/**
+ * Instagram feed — renders a 2×N grid of post thumbnails. Content is passed
+ * in (either fetched server-side from IG Graph API or curated manually in
+ * content JSON). The component stays dumb on purpose so we don't ship the
+ * IG API surface into every tenant.
+ */
+
+export interface InstagramFeedProps {
+  title?: string
+  handle?: string
+  posts: Array<{ url: string; imageUrl: string; caption?: string }>
+  ctaText?: string
+}
+
+export function InstagramFeedSection({
+  title = 'Siguenos en Instagram',
+  handle,
+  posts,
+  ctaText,
+}: InstagramFeedProps) {
+  if (!posts?.length) return null
+  return (
+    <section className="py-14 bg-[var(--background)]">
+      <Container>
+        <div className="text-center mb-6">
+          <Heading level={2}>{title}</Heading>
+          {handle && (
+            <a
+              href={`https://instagram.com/${handle.replace(/^@/, '')}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block mt-1 text-[var(--primary)]"
+            >
+              @{handle.replace(/^@/, '')}
+            </a>
+          )}
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2 max-w-5xl mx-auto">
+          {posts.slice(0, 12).map((p, i) => (
+            <a
+              key={i}
+              href={p.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block aspect-square overflow-hidden rounded"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={p.imageUrl}
+                alt={p.caption || 'Instagram post'}
+                className="w-full h-full object-cover hover:scale-105 transition-transform"
+              />
+            </a>
+          ))}
+        </div>
+        {ctaText && handle && (
+          <div className="text-center mt-6">
+            <a
+              href={`https://instagram.com/${handle.replace(/^@/, '')}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm font-medium text-[var(--primary)]"
+            >
+              {ctaText}
+            </a>
+          </div>
+        )}
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/intake-questionnaire-section.tsx
+++ b/web/components/sections/intake-questionnaire-section.tsx
@@ -1,0 +1,311 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { AnimatedSectionHeader } from '@/components/ui/animate-on-scroll'
+import { useState } from 'react'
+
+/**
+ * Generic intake questionnaire. Config-driven so every real client can author
+ * its own question set in content JSON without touching code.
+ *
+ * Use cases covered today:
+ *   - De Abasto a Casa: household size, dietary constraints, dislikes,
+ *     delivery window, weekly budget.
+ *   - Dayah LitWorks: book genre, trim size, mood, reference covers, budget.
+ *   - Nexa Paraguay: residency goal, timeline, dependants count, source country.
+ *
+ * The submission flow posts to /api/leads with `source: <tenant>-intake` and
+ * the full answers object; CRM consumes it like any other lead.
+ */
+
+export type IntakeQuestionKind = 'text' | 'textarea' | 'radio' | 'checkbox' | 'select' | 'number'
+
+export interface IntakeQuestion {
+  id: string
+  kind: IntakeQuestionKind
+  label: string
+  placeholder?: string
+  helpText?: string
+  required?: boolean
+  options?: Array<{ value: string; label: string }>
+  min?: number
+  max?: number
+}
+
+export interface IntakeQuestionnaireSectionProps {
+  title: string
+  subtitle?: string
+  questions: IntakeQuestion[]
+  submitLabel?: string
+  successMessage?: string
+  /** Tenant slug — becomes the source tag on the lead. */
+  tenantSlug?: string
+  /** Where to POST answers. Defaults to /api/leads. */
+  submitEndpoint?: string
+  /** Optional WhatsApp fallback shown below the form. */
+  whatsappPhone?: string
+  whatsappFallbackLabel?: string
+}
+
+type AnswerValue = string | string[] | number | null
+
+export function IntakeQuestionnaireSection({
+  title,
+  subtitle,
+  questions,
+  submitLabel = 'Enviar',
+  successMessage = 'Gracias — te escribimos en las proximas horas.',
+  tenantSlug,
+  submitEndpoint = '/api/leads',
+  whatsappPhone,
+  whatsappFallbackLabel = 'O consulta directo por WhatsApp',
+}: IntakeQuestionnaireSectionProps) {
+  const [answers, setAnswers] = useState<Record<string, AnswerValue>>({})
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const update = (id: string, value: AnswerValue) =>
+    setAnswers((prev) => ({ ...prev, [id]: value }))
+
+  const missingRequired = questions
+    .filter((q) => q.required)
+    .filter((q) => {
+      const v = answers[q.id]
+      if (v === null || v === undefined) return true
+      if (typeof v === 'string' && v.trim() === '') return true
+      if (Array.isArray(v) && v.length === 0) return true
+      return false
+    })
+    .map((q) => q.id)
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    if (missingRequired.length > 0) {
+      setError('Por favor, responde las preguntas marcadas con *.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const res = await fetch(submitEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          source: tenantSlug ? `${tenantSlug}-intake` : 'intake',
+          answers,
+        }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setSubmitted(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error enviando.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (submitted) {
+    return (
+      <section className="py-16 bg-[var(--background)]">
+        <Container>
+          <Card className="max-w-xl mx-auto">
+            <CardContent className="p-8 text-center">
+              <Heading level={3}>{successMessage}</Heading>
+            </CardContent>
+          </Card>
+        </Container>
+      </section>
+    )
+  }
+
+  return (
+    <section className="py-16 bg-[var(--background)]">
+      <Container>
+        <AnimatedSectionHeader>
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+        </AnimatedSectionHeader>
+
+        <form
+          onSubmit={onSubmit}
+          className="max-w-2xl mx-auto space-y-5 bg-[var(--surface)] rounded-lg p-6 shadow-sm"
+        >
+          {questions.map((q) => (
+            <QuestionField
+              key={q.id}
+              question={q}
+              value={answers[q.id] ?? null}
+              onChange={(v) => update(q.id, v)}
+            />
+          ))}
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <div className="flex items-center justify-between gap-4">
+            <Button type="submit" disabled={submitting}>
+              {submitting ? 'Enviando...' : submitLabel}
+            </Button>
+            {whatsappPhone && (
+              <a
+                href={`https://wa.me/${whatsappPhone.replace(/\D/g, '')}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-[var(--primary)] underline"
+              >
+                {whatsappFallbackLabel}
+              </a>
+            )}
+          </div>
+        </form>
+      </Container>
+    </section>
+  )
+}
+
+function QuestionField({
+  question,
+  value,
+  onChange,
+}: {
+  question: IntakeQuestion
+  value: AnswerValue
+  onChange: (v: AnswerValue) => void
+}) {
+  const labelClasses = 'block text-sm font-medium text-[var(--text)] mb-1'
+  const inputClasses =
+    'w-full border border-[var(--surface-light)] rounded-md px-3 py-2 bg-[var(--surface)] text-[var(--text)]'
+
+  const label = (
+    <label htmlFor={question.id} className={labelClasses}>
+      {question.label}
+      {question.required && <span className="text-red-600 ml-1">*</span>}
+    </label>
+  )
+
+  const helpText = question.helpText && (
+    <p className="text-xs text-[var(--text-muted)] mt-1">{question.helpText}</p>
+  )
+
+  switch (question.kind) {
+    case 'text':
+      return (
+        <div>
+          {label}
+          <input
+            id={question.id}
+            type="text"
+            value={typeof value === 'string' ? value : ''}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={question.placeholder}
+            className={inputClasses}
+          />
+          {helpText}
+        </div>
+      )
+    case 'number':
+      return (
+        <div>
+          {label}
+          <input
+            id={question.id}
+            type="number"
+            value={typeof value === 'number' ? value : ''}
+            onChange={(e) => onChange(e.target.value ? Number(e.target.value) : null)}
+            min={question.min}
+            max={question.max}
+            className={inputClasses}
+          />
+          {helpText}
+        </div>
+      )
+    case 'textarea':
+      return (
+        <div>
+          {label}
+          <textarea
+            id={question.id}
+            value={typeof value === 'string' ? value : ''}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={question.placeholder}
+            rows={3}
+            className={inputClasses}
+          />
+          {helpText}
+        </div>
+      )
+    case 'select':
+      return (
+        <div>
+          {label}
+          <select
+            id={question.id}
+            value={typeof value === 'string' ? value : ''}
+            onChange={(e) => onChange(e.target.value)}
+            className={inputClasses}
+          >
+            <option value="">—</option>
+            {(question.options || []).map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          {helpText}
+        </div>
+      )
+    case 'radio':
+      return (
+        <div>
+          {label}
+          <div className="space-y-1">
+            {(question.options || []).map((o) => (
+              <label key={o.value} className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name={question.id}
+                  value={o.value}
+                  checked={value === o.value}
+                  onChange={() => onChange(o.value)}
+                />
+                <span className="text-sm text-[var(--text)]">{o.label}</span>
+              </label>
+            ))}
+          </div>
+          {helpText}
+        </div>
+      )
+    case 'checkbox': {
+      const current: string[] = Array.isArray(value) ? value : []
+      return (
+        <div>
+          {label}
+          <div className="space-y-1">
+            {(question.options || []).map((o) => {
+              const checked = current.includes(o.value)
+              return (
+                <label key={o.value} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => {
+                      const next = checked ? current.filter((v) => v !== o.value) : [...current, o.value]
+                      onChange(next)
+                    }}
+                  />
+                  <span className="text-sm text-[var(--text)]">{o.label}</span>
+                </label>
+              )
+            })}
+          </div>
+          {helpText}
+        </div>
+      )
+    }
+    default:
+      return null
+  }
+}

--- a/web/components/sections/language-selector-section.tsx
+++ b/web/components/sections/language-selector-section.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+/**
+ * Language selector — dropdown that redirects to /s/<locale>/<tenant>/<path>.
+ * Content is passed in (no assumption about routing structure).
+ */
+
+export interface LanguageSelectorProps {
+  locales: Array<{ code: string; label: string; flag?: string }>
+  currentLocale: string
+  /** URL pattern with {{locale}} placeholder. Defaults to swapping 1st path segment. */
+  urlPattern?: string
+  currentPath?: string
+}
+
+export function LanguageSelectorSection({
+  locales,
+  currentLocale,
+  urlPattern,
+  currentPath,
+}: LanguageSelectorProps) {
+  if (!locales?.length) return null
+
+  function hrefFor(code: string): string {
+    if (urlPattern) return urlPattern.replace('{{locale}}', code)
+    if (typeof window === 'undefined' || !currentPath) return '#'
+    // Swap the 1st non-empty path segment.
+    const parts = currentPath.split('/').filter(Boolean)
+    if (parts.length > 0) parts[0] = code
+    return '/' + parts.join('/')
+  }
+
+  return (
+    <div className="relative inline-block">
+      <select
+        value={currentLocale}
+        onChange={(e) => {
+          const href = hrefFor(e.target.value)
+          if (typeof window !== 'undefined') window.location.href = href
+        }}
+        className="text-sm bg-[var(--surface)] border border-[var(--surface-light)] rounded px-2 py-1 text-[var(--text)]"
+        aria-label="Seleccionar idioma"
+      >
+        {locales.map((l) => (
+          <option key={l.code} value={l.code}>
+            {l.flag ? `${l.flag} ` : ''}
+            {l.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/web/components/sections/mortgage-calculator-section.tsx
+++ b/web/components/sections/mortgage-calculator-section.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { useState, useMemo } from 'react'
+import { formatPrice, type SupportedCurrency } from '@/lib/currency'
+
+/**
+ * Mortgage calculator — simple monthly-payment estimator.
+ * Formula: M = P * (r(1+r)^n) / ((1+r)^n – 1)
+ * where P = principal, r = monthly rate, n = months.
+ *
+ * Reusable for real-estate tenants. Rate presets are passed in per tenant
+ * (PY bank rates differ from EU rates; author in content JSON).
+ */
+
+export interface MortgageRatePreset {
+  label: string
+  annualRate: number // e.g. 0.095 for 9.5%
+}
+
+export interface MortgageCalculatorProps {
+  title?: string
+  subtitle?: string
+  defaultPrincipal: number
+  currency: SupportedCurrency
+  locale?: string
+  termYearsOptions: number[]
+  ratePresets: MortgageRatePreset[]
+  disclaimer?: string
+}
+
+function monthlyPayment(principal: number, annualRate: number, years: number): number {
+  const r = annualRate / 12
+  const n = years * 12
+  if (r === 0) return principal / n
+  return (principal * r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1)
+}
+
+export function MortgageCalculatorSection({
+  title = 'Calculadora de cuotas',
+  subtitle,
+  defaultPrincipal,
+  currency,
+  locale = 'es-PY',
+  termYearsOptions,
+  ratePresets,
+  disclaimer,
+}: MortgageCalculatorProps) {
+  const [principal, setPrincipal] = useState(defaultPrincipal)
+  const [years, setYears] = useState(termYearsOptions[0] || 10)
+  const [ratePreset, setRatePreset] = useState(ratePresets[0])
+
+  const monthly = useMemo(
+    () => (ratePreset ? monthlyPayment(principal, ratePreset.annualRate, years) : 0),
+    [principal, ratePreset, years],
+  )
+  const totalPaid = monthly * years * 12
+  const totalInterest = totalPaid - principal
+
+  return (
+    <section className="py-14 bg-[var(--background)]">
+      <Container>
+        <div className="max-w-2xl mx-auto">
+          <div className="text-center mb-6">
+            <Heading level={2}>{title}</Heading>
+            {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+          </div>
+
+          <div className="bg-[var(--surface)] rounded-lg p-5 space-y-4 shadow-sm">
+            <div>
+              <label className="block text-sm font-medium mb-1">Monto del prestamo</label>
+              <input
+                type="number"
+                value={principal}
+                onChange={(e) => setPrincipal(Number(e.target.value) || 0)}
+                className="w-full border border-[var(--surface-light)] rounded px-3 py-2 bg-[var(--background)]"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium mb-1">Plazo (años)</label>
+                <select
+                  value={years}
+                  onChange={(e) => setYears(Number(e.target.value))}
+                  className="w-full border border-[var(--surface-light)] rounded px-3 py-2 bg-[var(--background)]"
+                >
+                  {termYearsOptions.map((y) => (
+                    <option key={y} value={y}>
+                      {y} años
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium mb-1">Tasa</label>
+                <select
+                  value={ratePreset?.label || ''}
+                  onChange={(e) =>
+                    setRatePreset(ratePresets.find((r) => r.label === e.target.value) || ratePresets[0])
+                  }
+                  className="w-full border border-[var(--surface-light)] rounded px-3 py-2 bg-[var(--background)]"
+                >
+                  {ratePresets.map((r) => (
+                    <option key={r.label} value={r.label}>
+                      {r.label} — {(r.annualRate * 100).toFixed(1)}% anual
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-3 gap-3 pt-4 border-t border-[var(--surface-light)] text-center">
+              <div>
+                <div className="text-xs text-[var(--text-muted)]">Cuota mensual</div>
+                <div className="text-xl font-bold text-[var(--primary)]">
+                  {formatPrice(monthly, { currency, locale })}
+                </div>
+              </div>
+              <div>
+                <div className="text-xs text-[var(--text-muted)]">Total a pagar</div>
+                <div className="text-sm font-semibold">{formatPrice(totalPaid, { currency, locale })}</div>
+              </div>
+              <div>
+                <div className="text-xs text-[var(--text-muted)]">Intereses</div>
+                <div className="text-sm font-semibold">
+                  {formatPrice(totalInterest, { currency, locale })}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {disclaimer && (
+            <p className="mt-4 text-xs italic text-[var(--text-muted)] text-center">{disclaimer}</p>
+          )}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/multi-step-form-section.tsx
+++ b/web/components/sections/multi-step-form-section.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Button } from '@/components/ui/button'
+import { useState } from 'react'
+
+/**
+ * Multi-step form — wizard alternative to intake-questionnaire when there are
+ * more than 5 questions and chunking into steps improves completion rate.
+ */
+
+export interface MultiStepFormProps {
+  title: string
+  subtitle?: string
+  steps: Array<{
+    id: string
+    title: string
+    fields: Array<{
+      id: string
+      label: string
+      kind: 'text' | 'textarea' | 'select'
+      options?: Array<{ value: string; label: string }>
+      required?: boolean
+    }>
+  }>
+  submitEndpoint?: string
+  tenantSlug?: string
+  submitLabel?: string
+  successMessage?: string
+}
+
+type Answers = Record<string, string>
+
+export function MultiStepFormSection({
+  title,
+  subtitle,
+  steps,
+  submitEndpoint = '/api/leads',
+  tenantSlug,
+  submitLabel = 'Enviar',
+  successMessage = 'Gracias, te responderemos pronto.',
+}: MultiStepFormProps) {
+  const [idx, setIdx] = useState(0)
+  const [answers, setAnswers] = useState<Answers>({})
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const step = steps[idx]
+
+  function update(id: string, value: string) {
+    setAnswers((prev) => ({ ...prev, [id]: value }))
+  }
+
+  function canAdvance(): boolean {
+    return step.fields.every((f) => !f.required || (answers[f.id] || '').trim().length > 0)
+  }
+
+  async function onSubmit() {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch(submitEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          source: tenantSlug ? `${tenantSlug}-multistep` : 'multistep',
+          answers,
+        }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setSubmitted(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error enviando.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (submitted) {
+    return (
+      <section className="py-16 bg-[var(--background)]">
+        <Container>
+          <p className="text-center text-[var(--text)]">{successMessage}</p>
+        </Container>
+      </section>
+    )
+  }
+
+  return (
+    <section className="py-16 bg-[var(--background)]">
+      <Container>
+        <div className="text-center mb-6">
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+        </div>
+
+        <div className="max-w-xl mx-auto bg-[var(--surface)] rounded-lg p-6 shadow-sm">
+          <div className="flex items-center justify-between mb-4 text-xs text-[var(--text-muted)]">
+            <span>
+              Paso {idx + 1} de {steps.length}
+            </span>
+            <span>{Math.round(((idx + 1) / steps.length) * 100)}%</span>
+          </div>
+          <div className="h-1 bg-[var(--surface-light)] rounded mb-6">
+            <div
+              className="h-1 rounded bg-[var(--primary)] transition-all"
+              style={{ width: `${((idx + 1) / steps.length) * 100}%` }}
+            />
+          </div>
+
+          <h3 className="font-semibold text-[var(--text)] mb-4">{step.title}</h3>
+
+          <div className="space-y-4">
+            {step.fields.map((f) => (
+              <div key={f.id}>
+                <label className="block text-sm font-medium text-[var(--text)] mb-1">
+                  {f.label}
+                  {f.required && <span className="text-red-600 ml-1">*</span>}
+                </label>
+                {f.kind === 'textarea' ? (
+                  <textarea
+                    rows={3}
+                    value={answers[f.id] || ''}
+                    onChange={(e) => update(f.id, e.target.value)}
+                    className="w-full border border-[var(--surface-light)] rounded px-3 py-2 bg-[var(--surface)]"
+                  />
+                ) : f.kind === 'select' ? (
+                  <select
+                    value={answers[f.id] || ''}
+                    onChange={(e) => update(f.id, e.target.value)}
+                    className="w-full border border-[var(--surface-light)] rounded px-3 py-2 bg-[var(--surface)]"
+                  >
+                    <option value="">—</option>
+                    {(f.options || []).map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    type="text"
+                    value={answers[f.id] || ''}
+                    onChange={(e) => update(f.id, e.target.value)}
+                    className="w-full border border-[var(--surface-light)] rounded px-3 py-2 bg-[var(--surface)]"
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+
+          {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+
+          <div className="mt-6 flex items-center justify-between gap-3">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setIdx(Math.max(0, idx - 1))}
+              disabled={idx === 0}
+            >
+              Atras
+            </Button>
+            {idx < steps.length - 1 ? (
+              <Button type="button" onClick={() => setIdx(idx + 1)} disabled={!canAdvance()}>
+                Siguiente
+              </Button>
+            ) : (
+              <Button type="button" onClick={onSubmit} disabled={submitting || !canAdvance()}>
+                {submitting ? 'Enviando...' : submitLabel}
+              </Button>
+            )}
+          </div>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/newsletter-signup-section.tsx
+++ b/web/components/sections/newsletter-signup-section.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Button } from '@/components/ui/button'
+import { useState } from 'react'
+
+export interface NewsletterSignupProps {
+  title?: string
+  subtitle?: string
+  placeholder?: string
+  submitLabel?: string
+  successMessage?: string
+  consentLabel?: string
+  /** POST target — defaults to /api/newsletter. */
+  submitEndpoint?: string
+  tenantSlug?: string
+}
+
+export function NewsletterSignupSection({
+  title = 'Recibe nuestras novedades',
+  subtitle,
+  placeholder = 'Tu email',
+  submitLabel = 'Suscribirme',
+  successMessage = 'Listo! Revisa tu correo para confirmar.',
+  consentLabel = 'Acepto recibir novedades.',
+  submitEndpoint = '/api/newsletter',
+  tenantSlug,
+}: NewsletterSignupProps) {
+  const [email, setEmail] = useState('')
+  const [consent, setConsent] = useState(false)
+  const [state, setState] = useState<'idle' | 'submitting' | 'ok' | 'err'>('idle')
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!consent || !email) return
+    setState('submitting')
+    try {
+      const res = await fetch(submitEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, consent, source: tenantSlug ? `${tenantSlug}-newsletter` : 'newsletter' }),
+      })
+      setState(res.ok ? 'ok' : 'err')
+    } catch {
+      setState('err')
+    }
+  }
+
+  return (
+    <section className="py-12 bg-[var(--surface)]">
+      <Container>
+        <div className="max-w-xl mx-auto text-center">
+          <Heading level={3}>{title}</Heading>
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+
+          {state === 'ok' ? (
+            <p className="mt-6 text-[var(--primary)] font-medium">{successMessage}</p>
+          ) : (
+            <form onSubmit={onSubmit} className="mt-4 flex flex-col gap-3">
+              <div className="flex flex-col sm:flex-row gap-2">
+                <input
+                  type="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder={placeholder}
+                  className="flex-1 border border-[var(--surface-light)] rounded px-3 py-2 bg-[var(--background)]"
+                />
+                <Button type="submit" disabled={!consent || state === 'submitting'}>
+                  {state === 'submitting' ? '...' : submitLabel}
+                </Button>
+              </div>
+              <label className="flex items-center justify-center gap-2 text-xs text-[var(--text-muted)]">
+                <input
+                  type="checkbox"
+                  checked={consent}
+                  onChange={(e) => setConsent(e.target.checked)}
+                />
+                <span>{consentLabel}</span>
+              </label>
+              {state === 'err' && <p className="text-xs text-red-600">Error. Intenta de nuevo.</p>}
+            </form>
+          )}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/open-hours-status-section.tsx
+++ b/web/components/sections/open-hours-status-section.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { useEffect, useState } from 'react'
+
+/**
+ * Open-now status — computes real-time open/closed state from an hours map.
+ *
+ * Hours format: keys like "Lunes", "Martes", ... with value "HH:MM - HH:MM"
+ * or "Cerrado". For multi-range days use comma-separated: "12:00 - 15:00, 19:00 - 23:00".
+ */
+
+const DAY_KEYS = ['Domingo', 'Lunes', 'Martes', 'Miercoles', 'Jueves', 'Viernes', 'Sabado']
+
+function parseRanges(value: string | undefined): Array<[number, number]> {
+  if (!value || /cerrado/i.test(value)) return []
+  return value.split(',').map((chunk) => {
+    const m = chunk.trim().match(/(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})/)
+    if (!m) return [0, 0] as [number, number]
+    return [Number(m[1]) * 60 + Number(m[2]), Number(m[3]) * 60 + Number(m[4])]
+  })
+}
+
+function isOpen(hours: Record<string, string>, now: Date): boolean {
+  const dayName = DAY_KEYS[now.getDay()]
+  const value = hours[dayName] || hours[Object.keys(hours).find((k) => k.includes(dayName)) || ''] || ''
+  const minutes = now.getHours() * 60 + now.getMinutes()
+  return parseRanges(value).some(([a, b]) => minutes >= a && minutes <= b)
+}
+
+export interface OpenHoursStatusProps {
+  hours: Record<string, string>
+  openLabel?: string
+  closedLabel?: string
+  showHours?: boolean
+}
+
+export function OpenHoursStatusSection({
+  hours,
+  openLabel = 'Abierto ahora',
+  closedLabel = 'Cerrado',
+  showHours = true,
+}: OpenHoursStatusProps) {
+  const [open, setOpen] = useState<boolean | null>(null)
+  useEffect(() => {
+    setOpen(isOpen(hours, new Date()))
+  }, [hours])
+
+  if (open === null) return null
+  return (
+    <section className="py-4 bg-[var(--surface)]">
+      <Container>
+        <div className="flex flex-wrap items-center justify-center gap-4 text-sm">
+          <span
+            className="inline-flex items-center gap-2 px-3 py-1 rounded-full"
+            style={{
+              backgroundColor: open ? '#DEF7EC' : '#FEE2E2',
+              color: open ? '#03543F' : '#991B1B',
+            }}
+          >
+            <span>●</span>
+            <span>{open ? openLabel : closedLabel}</span>
+          </span>
+          {showHours && (
+            <div className="text-[var(--text-muted)]">
+              {Object.entries(hours).map(([day, range], i) => (
+                <span key={i} className="mr-3">
+                  <strong>{day}:</strong> {range}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/pricing-range-section.tsx
+++ b/web/components/sections/pricing-range-section.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+
+/**
+ * Pricing range — "from X to Y" pricing with the factors that drive variation.
+ * For services where a fixed tier is misleading (photographers, architects,
+ * commission-based work).
+ */
+
+export interface PricingRangeProps {
+  title?: string
+  subtitle?: string
+  minPrice: string
+  maxPrice: string
+  factors: string[]
+  ctaText?: string
+  ctaHref?: string
+}
+
+export function PricingRangeSection({
+  title = 'Inversion estimada',
+  subtitle,
+  minPrice,
+  maxPrice,
+  factors,
+  ctaText = 'Solicitar cotizacion personalizada',
+  ctaHref = '#contacto',
+}: PricingRangeProps) {
+  return (
+    <section className="py-14 bg-[var(--surface)]">
+      <Container>
+        <div className="max-w-2xl mx-auto text-center">
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+
+          <div className="mt-6 flex items-baseline justify-center gap-2">
+            <span className="text-4xl font-bold text-[var(--primary)]">{minPrice}</span>
+            <span className="text-[var(--text-muted)]">—</span>
+            <span className="text-4xl font-bold text-[var(--primary)]">{maxPrice}</span>
+          </div>
+
+          <div className="mt-8 text-left bg-[var(--background)] rounded-lg p-4">
+            <p className="text-sm font-semibold text-[var(--text)] mb-2">
+              Lo que hace variar el precio:
+            </p>
+            <ul className="space-y-1 text-sm text-[var(--text-muted)]">
+              {factors.map((f, i) => (
+                <li key={i} className="flex gap-2">
+                  <span className="text-[var(--primary)]">·</span>
+                  <span>{f}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <a
+            href={ctaHref}
+            className="inline-block mt-6 bg-[var(--primary)] text-[var(--primary-foreground)] px-6 py-2 rounded"
+          >
+            {ctaText}
+          </a>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/regulatory-status-badge-section.tsx
+++ b/web/components/sections/regulatory-status-badge-section.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Badge } from '@/components/ui/badge'
+
+/**
+ * Regulatory status / certifications / licenses displayed as trust signals.
+ *
+ * Use cases:
+ *  - De Abasto a Casa: INAN food-safety habilitation status
+ *  - Dental / medical / vet: licenses, specialties
+ *  - Finance / insurance: SEC/FINRA, bar admissions, insurance broker license
+ *  - Real estate: realtor board, MLS, license numbers
+ *  - Nexa Paraguay: SEPRELAD AML compliance, attorney bar
+ *
+ * Each item has a status: "active" | "pending" | "in-progress" | "expired".
+ * The section is intentionally simple — its job is to surface the fact of
+ * regulation, not to render a full compliance dashboard.
+ */
+
+export type RegulatoryStatus = 'active' | 'pending' | 'in-progress' | 'expired'
+
+export interface RegulatoryItem {
+  name: string
+  /** Agency / issuer (INAN, SEPRELAD, FDA, FINRA, etc.). */
+  issuer?: string
+  /** License / registration number. */
+  number?: string
+  status: RegulatoryStatus
+  /** Optional date the status applies as of. */
+  since?: string
+  /** Link to public register if the issuer provides one. */
+  verifyUrl?: string
+  /** Custom human-readable label for the status (overrides default). */
+  statusLabel?: string
+  /** Optional short descriptor for the badge tooltip / subtitle. */
+  description?: string
+}
+
+export interface RegulatoryStatusBadgeSectionProps {
+  title?: string
+  subtitle?: string
+  items: RegulatoryItem[]
+  variant?: 'badge' | 'inline'
+  /** Footnote shown below. Use for legal language ("verifique en el registro oficial..."). */
+  footnote?: string
+}
+
+const STATUS_COLORS: Record<RegulatoryStatus, { bg: string; text: string; label: string }> = {
+  active: { bg: '#DEF7EC', text: '#03543F', label: 'Habilitado' },
+  'in-progress': { bg: '#FDF6B2', text: '#723B13', label: 'En tramite' },
+  pending: { bg: '#FEE2E2', text: '#991B1B', label: 'Pendiente' },
+  expired: { bg: '#E5E7EB', text: '#1F2937', label: 'Expirado' },
+}
+
+export function RegulatoryStatusBadgeSection({
+  title = 'Registros y Habilitaciones',
+  subtitle,
+  items,
+  variant = 'badge',
+  footnote,
+}: RegulatoryStatusBadgeSectionProps) {
+  if (!items?.length) return null
+
+  if (variant === 'inline') {
+    return (
+      <section className="py-6 bg-[var(--surface-light)]">
+        <Container>
+          <div className="flex flex-wrap items-center justify-center gap-3 text-sm text-[var(--text-muted)]">
+            {items.map((it, i) => (
+              <InlineItem key={i} item={it} />
+            ))}
+          </div>
+          {footnote && (
+            <p className="mt-3 text-center text-xs text-[var(--text-muted)] italic">{footnote}</p>
+          )}
+        </Container>
+      </section>
+    )
+  }
+
+  // Badge (grid) variant
+  return (
+    <section className="py-12 bg-[var(--background)]">
+      <Container>
+        <div className="text-center mb-8">
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="mt-2 text-[var(--text-muted)]">{subtitle}</p>}
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
+          {items.map((it, i) => (
+            <BadgeCard key={i} item={it} />
+          ))}
+        </div>
+
+        {footnote && (
+          <p className="mt-6 text-center text-xs text-[var(--text-muted)] italic">{footnote}</p>
+        )}
+      </Container>
+    </section>
+  )
+}
+
+function BadgeCard({ item }: { item: RegulatoryItem }) {
+  const palette = STATUS_COLORS[item.status]
+  return (
+    <div className="rounded-lg p-4 border border-[var(--surface-light)] bg-[var(--surface)]">
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <div className="font-semibold text-[var(--text)]">{item.name}</div>
+        <span
+          className="text-xs font-medium px-2 py-0.5 rounded-full"
+          style={{ backgroundColor: palette.bg, color: palette.text }}
+        >
+          {item.statusLabel || palette.label}
+        </span>
+      </div>
+      <div className="text-xs text-[var(--text-muted)] space-y-0.5">
+        {item.issuer && <div>{item.issuer}</div>}
+        {item.number && <div>N° {item.number}</div>}
+        {item.since && <div>Desde {item.since}</div>}
+        {item.description && <div className="mt-1 italic">{item.description}</div>}
+      </div>
+      {item.verifyUrl && (
+        <a
+          href={item.verifyUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-block text-xs text-[var(--primary)] underline"
+        >
+          Verificar en registro oficial
+        </a>
+      )}
+    </div>
+  )
+}
+
+function InlineItem({ item }: { item: RegulatoryItem }) {
+  const palette = STATUS_COLORS[item.status]
+  return (
+    <span
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs"
+      style={{ backgroundColor: palette.bg, color: palette.text }}
+      title={item.description}
+    >
+      <Badge variant="outline" className="!bg-transparent !border-0 !p-0 !text-inherit">
+        {item.name}
+      </Badge>
+      <span>· {item.statusLabel || palette.label}</span>
+    </span>
+  )
+}

--- a/web/components/sections/sample-week-preview-section.tsx
+++ b/web/components/sections/sample-week-preview-section.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Card, CardContent, CardImage } from '@/components/ui/card'
+
+/**
+ * Sample week preview — "esto es lo que recibiste la semana pasada".
+ * Gives concreteness before buyers subscribe. Reusable for CSAs, meal plans,
+ * box services.
+ */
+
+export interface SampleWeekPreviewProps {
+  title?: string
+  subtitle?: string
+  weekOf?: string
+  items: Array<{
+    name: string
+    description?: string
+    imageUrl?: string
+    quantity?: string
+    tag?: string
+  }>
+  footnote?: string
+}
+
+export function SampleWeekPreviewSection({
+  title = 'Asi se ve tu semana',
+  subtitle,
+  weekOf,
+  items,
+  footnote,
+}: SampleWeekPreviewProps) {
+  if (!items?.length) return null
+  return (
+    <section className="py-14 bg-[var(--surface)]">
+      <Container>
+        <div className="text-center mb-8">
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+          {weekOf && (
+            <p className="mt-1 text-xs uppercase tracking-wide text-[var(--primary)]">
+              Semana del {weekOf}
+            </p>
+          )}
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 max-w-6xl mx-auto">
+          {items.map((it, i) => (
+            <Card key={i}>
+              {it.imageUrl && <CardImage src={it.imageUrl} alt={it.name} />}
+              <CardContent className="p-4">
+                <div className="flex items-start justify-between gap-2">
+                  <h3 className="font-semibold text-[var(--text)]">{it.name}</h3>
+                  {it.quantity && (
+                    <span className="text-xs text-[var(--text-muted)] whitespace-nowrap">
+                      {it.quantity}
+                    </span>
+                  )}
+                </div>
+                {it.description && <p className="mt-1 text-xs text-[var(--text-muted)]">{it.description}</p>}
+                {it.tag && (
+                  <span className="mt-2 inline-block text-xs px-2 py-0.5 rounded-full bg-[var(--background)] text-[var(--text-muted)]">
+                    {it.tag}
+                  </span>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        {footnote && (
+          <p className="mt-6 text-center text-xs italic text-[var(--text-muted)]">{footnote}</p>
+        )}
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/service-area-map-zones-section.tsx
+++ b/web/components/sections/service-area-map-zones-section.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+
+/**
+ * Service-area map with named zones. Avoids Google Maps API cost by rendering
+ * a static embed; the real value is the zones list (pricing, transit time,
+ * on-demand vs scheduled, etc.).
+ */
+
+export interface ServiceAreaMapZonesProps {
+  title?: string
+  subtitle?: string
+  mapEmbedUrl?: string
+  zones: Array<{
+    name: string
+    neighborhoods?: string[]
+    price?: string
+    etaMinutes?: number
+    available?: boolean
+    note?: string
+  }>
+}
+
+export function ServiceAreaMapZonesSection({
+  title = 'Zonas de cobertura',
+  subtitle,
+  mapEmbedUrl,
+  zones,
+}: ServiceAreaMapZonesProps) {
+  return (
+    <section className="py-14 bg-[var(--background)]">
+      <Container>
+        <div className="text-center mb-8">
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+        </div>
+        <div className="grid md:grid-cols-2 gap-6 max-w-5xl mx-auto">
+          {mapEmbedUrl && (
+            <div className="aspect-video md:aspect-square rounded-lg overflow-hidden bg-[var(--surface-light)]">
+              <iframe
+                src={mapEmbedUrl}
+                className="w-full h-full"
+                loading="lazy"
+                referrerPolicy="no-referrer-when-downgrade"
+                title="Mapa de zonas"
+              />
+            </div>
+          )}
+          <div className="space-y-3">
+            {zones.map((z, i) => (
+              <div
+                key={i}
+                className="rounded-lg border border-[var(--surface-light)] bg-[var(--surface)] p-4"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="font-semibold text-[var(--text)]">{z.name}</div>
+                    {z.neighborhoods && z.neighborhoods.length > 0 && (
+                      <div className="text-xs text-[var(--text-muted)]">
+                        {z.neighborhoods.join(', ')}
+                      </div>
+                    )}
+                  </div>
+                  <div className="text-right text-sm">
+                    {z.price && <div className="font-semibold text-[var(--primary)]">{z.price}</div>}
+                    {z.etaMinutes !== undefined && (
+                      <div className="text-xs text-[var(--text-muted)]">{z.etaMinutes} min</div>
+                    )}
+                  </div>
+                </div>
+                {z.note && <p className="mt-2 text-xs text-[var(--text-muted)]">{z.note}</p>}
+                {z.available === false && (
+                  <p className="mt-2 text-xs text-red-600">Temporalmente no disponible</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/testimonial-video-section.tsx
+++ b/web/components/sections/testimonial-video-section.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+
+export interface TestimonialVideoProps {
+  title?: string
+  subtitle?: string
+  videos: Array<{
+    author: string
+    role?: string
+    /** YouTube/Vimeo/direct MP4 URL. */
+    src: string
+    poster?: string
+    caption?: string
+  }>
+}
+
+function embedUrl(src: string): string {
+  const yt = src.match(/youtu\.?be(?:\.com)?\/(?:watch\?v=|embed\/)?([A-Za-z0-9_-]{11})/)
+  if (yt) return `https://www.youtube-nocookie.com/embed/${yt[1]}`
+  const vm = src.match(/vimeo\.com\/(\d+)/)
+  if (vm) return `https://player.vimeo.com/video/${vm[1]}`
+  return src
+}
+
+export function TestimonialVideoSection({ title = 'Historias de clientes', subtitle, videos }: TestimonialVideoProps) {
+  if (!videos?.length) return null
+  return (
+    <section className="py-16 bg-[var(--surface)]">
+      <Container>
+        <div className="text-center mb-8">
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+        </div>
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 max-w-6xl mx-auto">
+          {videos.map((v, i) => {
+            const url = embedUrl(v.src)
+            const isEmbed = url !== v.src
+            return (
+              <figure key={i}>
+                <div className="aspect-video bg-black rounded-lg overflow-hidden">
+                  {isEmbed ? (
+                    <iframe
+                      src={url}
+                      className="w-full h-full"
+                      allowFullScreen
+                      loading="lazy"
+                      title={`Testimonio de ${v.author}`}
+                    />
+                  ) : (
+                    <video src={v.src} poster={v.poster} controls className="w-full h-full" />
+                  )}
+                </div>
+                <figcaption className="mt-2 text-sm">
+                  <div className="font-semibold text-[var(--text)]">{v.author}</div>
+                  {v.role && <div className="text-[var(--text-muted)]">{v.role}</div>}
+                  {v.caption && <p className="mt-1 italic text-[var(--text-muted)]">{v.caption}</p>}
+                </figcaption>
+              </figure>
+            )
+          })}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/tiered-service-ladder-section.tsx
+++ b/web/components/sections/tiered-service-ladder-section.tsx
@@ -1,0 +1,163 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Tiered service ladder — visualises progression between subscription/service
+ * levels. Different from pricing-table because it shows the UPGRADE PATH
+ * (L1 → L2 → L3), not just side-by-side options.
+ *
+ * Use cases:
+ *  - De Abasto a Casa: compras-only (L1) → mise-en-place (L2) → comidas-listas (L3)
+ *  - Gyms: drop-in → basic membership → unlimited + classes
+ *  - SaaS: starter → pro → enterprise
+ *
+ * Emphasises "what you get at this level that you didn't before" — the
+ * `upgradesFromPrevious` field carries the delta copy.
+ */
+
+export interface LadderTier {
+  level: number | string
+  name: string
+  subtitle?: string
+  price?: string
+  description?: string
+  features: string[]
+  /** Bullets describing what changes vs the previous tier. */
+  upgradesFromPrevious?: string[]
+  popular?: boolean
+  status?: 'available' | 'coming-soon' | 'wait-list'
+  statusLabel?: string
+  ctaText?: string
+}
+
+export interface TieredServiceLadderSectionProps {
+  title: string
+  subtitle?: string
+  tiers: LadderTier[]
+  whatsappPhone?: string
+  footerNote?: string
+}
+
+function statusBadge(tier: LadderTier) {
+  if (!tier.status || tier.status === 'available') return null
+  const label =
+    tier.statusLabel ||
+    (tier.status === 'coming-soon' ? 'Proximamente' : 'Lista de espera')
+  return <Badge variant="outline">{label}</Badge>
+}
+
+export function TieredServiceLadderSection({
+  title,
+  subtitle,
+  tiers,
+  whatsappPhone,
+  footerNote,
+}: TieredServiceLadderSectionProps) {
+  function contactCta(tier: LadderTier): string {
+    if (!whatsappPhone) return '#contacto'
+    const msg = `Hola, me interesa el nivel "${tier.name}". Quisiera mas informacion.`
+    return `https://wa.me/${whatsappPhone.replace(/\D/g, '')}?text=${encodeURIComponent(msg)}`
+  }
+
+  return (
+    <section className="py-16 bg-[var(--background)]">
+      <Container>
+        <div className="text-center mb-10">
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="mt-3 text-[var(--text-muted)]">{subtitle}</p>}
+        </div>
+
+        {/* Connector line (desktop only) */}
+        <div className="hidden md:block relative h-0 mb-[-1rem]">
+          <div className="absolute top-1/2 left-0 right-0 border-t-2 border-dashed border-[var(--surface-light)]" />
+        </div>
+
+        <div className="grid gap-5 md:grid-cols-3 relative">
+          {tiers.map((tier, idx) => (
+            <Card
+              key={`${tier.level}-${idx}`}
+              className={`relative h-full ${tier.popular ? 'ring-2 ring-[var(--primary)]' : ''} ${
+                tier.status && tier.status !== 'available' ? 'opacity-80' : ''
+              }`}
+            >
+              {/* Level indicator */}
+              <div
+                className="absolute -top-4 left-1/2 -translate-x-1/2 w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold"
+                style={{
+                  backgroundColor: 'var(--primary)',
+                  color: 'var(--primary-foreground)',
+                }}
+              >
+                {tier.level}
+              </div>
+
+              <CardContent className="pt-8 pb-6 px-5">
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <div>
+                    <Heading level={3}>{tier.name}</Heading>
+                    {tier.subtitle && (
+                      <p className="text-sm text-[var(--text-muted)]">{tier.subtitle}</p>
+                    )}
+                  </div>
+                  {statusBadge(tier)}
+                  {tier.popular && <Badge>Recomendado</Badge>}
+                </div>
+
+                {tier.price && (
+                  <div className="mb-3">
+                    <span className="text-2xl font-bold text-[var(--primary)]">{tier.price}</span>
+                  </div>
+                )}
+
+                {tier.description && (
+                  <p className="text-sm text-[var(--text-muted)] mb-4">{tier.description}</p>
+                )}
+
+                {tier.upgradesFromPrevious && tier.upgradesFromPrevious.length > 0 && (
+                  <div className="mb-4 pb-4 border-b border-[var(--surface-light)]">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)] mb-2">
+                      Sube al nivel {tier.level}:
+                    </p>
+                    <ul className="space-y-1 text-sm">
+                      {tier.upgradesFromPrevious.map((u, i) => (
+                        <li key={i} className="flex gap-2">
+                          <span className="text-[var(--primary)]">↑</span>
+                          <span>{u}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                <ul className="space-y-1.5 text-sm text-[var(--text)] mb-5">
+                  {tier.features.map((f, i) => (
+                    <li key={i} className="flex gap-2">
+                      <span className="text-[var(--success)]">✓</span>
+                      <span>{f}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <Button asChild className="w-full" variant={tier.popular ? 'primary' : 'secondary'}>
+                  <a href={contactCta(tier)} target="_blank" rel="noopener noreferrer">
+                    {tier.ctaText ||
+                      (tier.status === 'coming-soon' ? 'Pre-reservar' : 'Quiero este nivel')}
+                  </a>
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        {footerNote && (
+          <p className="mt-8 text-center text-sm text-[var(--text-muted)]">{footerNote}</p>
+        )}
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/timeline-history-section.tsx
+++ b/web/components/sections/timeline-history-section.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+
+export interface TimelineHistoryProps {
+  title?: string
+  subtitle?: string
+  milestones: Array<{ date: string; title: string; description?: string }>
+}
+
+export function TimelineHistorySection({ title = 'Nuestra historia', subtitle, milestones }: TimelineHistoryProps) {
+  if (!milestones?.length) return null
+  return (
+    <section className="py-16 bg-[var(--background)]">
+      <Container>
+        <div className="text-center mb-10">
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+        </div>
+        <div className="max-w-3xl mx-auto">
+          <div className="relative border-l-2 border-[var(--surface-light)] pl-6 space-y-8">
+            {milestones.map((m, i) => (
+              <div key={i} className="relative">
+                <div
+                  className="absolute -left-[33px] top-1 w-4 h-4 rounded-full"
+                  style={{ backgroundColor: 'var(--primary)' }}
+                />
+                <div className="text-xs font-semibold uppercase tracking-wide text-[var(--primary)]">
+                  {m.date}
+                </div>
+                <div className="font-semibold text-[var(--text)] mt-1">{m.title}</div>
+                {m.description && (
+                  <p className="text-sm text-[var(--text-muted)] mt-1">{m.description}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/trust-signals-logos-section.tsx
+++ b/web/components/sections/trust-signals-logos-section.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+
+export interface TrustSignalsLogosProps {
+  title?: string
+  logos: Array<{ name: string; src?: string; alt?: string; href?: string }>
+  grayscale?: boolean
+}
+
+export function TrustSignalsLogosSection({
+  title = 'Trabajamos con',
+  logos,
+  grayscale = true,
+}: TrustSignalsLogosProps) {
+  if (!logos?.length) return null
+  return (
+    <section className="py-10 bg-[var(--surface)]">
+      <Container>
+        {title && (
+          <p className="text-center text-sm uppercase tracking-wide text-[var(--text-muted)] mb-6">
+            {title}
+          </p>
+        )}
+        <div className="flex flex-wrap items-center justify-center gap-6 md:gap-10">
+          {logos.map((l, i) => {
+            const img = l.src ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={l.src}
+                alt={l.alt || l.name}
+                className={`h-8 md:h-10 opacity-80 hover:opacity-100 transition ${
+                  grayscale ? 'grayscale hover:grayscale-0' : ''
+                }`}
+              />
+            ) : (
+              <span className="text-sm font-medium text-[var(--text-muted)]">{l.name}</span>
+            )
+            return (
+              <div key={i} className="flex items-center">
+                {l.href ? (
+                  <a href={l.href} target="_blank" rel="noopener noreferrer">
+                    {img}
+                  </a>
+                ) : (
+                  img
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/weekly-cadence-calendar-section.tsx
+++ b/web/components/sections/weekly-cadence-calendar-section.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+
+/**
+ * Weekly cadence calendar — visualises a recurring weekly flow.
+ * Originally for De Abasto ("Lun: lista → Mar: compras → Mie-Jue: prep → Vie-Sab: entrega")
+ * but generic: any weekly-recurring service (CSA, laundry, cleaning sub).
+ */
+
+const DAYS = ['Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab', 'Dom']
+
+export interface WeeklyCadenceProps {
+  title?: string
+  subtitle?: string
+  /** Phases in order. Each phase maps to one or more days. */
+  phases: Array<{
+    id: string
+    label: string
+    days: number[] // 1=Lun … 7=Dom
+    description?: string
+    color?: string
+  }>
+  footnote?: string
+}
+
+export function WeeklyCadenceCalendarSection({
+  title = 'Tu semana con nosotros',
+  subtitle,
+  phases,
+  footnote,
+}: WeeklyCadenceProps) {
+  // Map day index → phase
+  const dayToPhase = new Array<number | undefined>(8)
+  phases.forEach((p, i) => {
+    for (const d of p.days) dayToPhase[d] = i
+  })
+
+  return (
+    <section className="py-14 bg-[var(--background)]">
+      <Container>
+        <div className="text-center mb-8">
+          <Heading level={2}>{title}</Heading>
+          {subtitle && <p className="text-[var(--text-muted)] mt-2">{subtitle}</p>}
+        </div>
+
+        <div className="grid grid-cols-7 gap-2 max-w-3xl mx-auto">
+          {DAYS.map((label, i) => {
+            const phaseIdx = dayToPhase[i + 1]
+            const phase = phaseIdx !== undefined ? phases[phaseIdx] : undefined
+            return (
+              <div
+                key={label}
+                className="rounded-lg p-3 text-center text-sm min-h-[90px] flex flex-col items-center justify-center"
+                style={{
+                  backgroundColor: phase?.color || 'var(--surface-light)',
+                  color: phase ? 'white' : 'var(--text-muted)',
+                }}
+              >
+                <div className="text-xs font-semibold uppercase tracking-wide">{label}</div>
+                {phase && <div className="mt-1 text-xs">{phase.label}</div>}
+              </div>
+            )
+          })}
+        </div>
+
+        {phases.some((p) => p.description) && (
+          <div className="mt-6 max-w-3xl mx-auto grid gap-2 sm:grid-cols-2">
+            {phases.map((p) => (
+              <div key={p.id} className="flex gap-3 items-start">
+                <span
+                  className="inline-block w-3 h-3 rounded-full mt-1.5 flex-shrink-0"
+                  style={{ backgroundColor: p.color || 'var(--primary)' }}
+                />
+                <div className="text-sm">
+                  <div className="font-semibold text-[var(--text)]">{p.label}</div>
+                  {p.description && <div className="text-[var(--text-muted)]">{p.description}</div>}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {footnote && (
+          <p className="mt-4 text-center text-xs text-[var(--text-muted)] italic">{footnote}</p>
+        )}
+      </Container>
+    </section>
+  )
+}

--- a/web/lib/currency.ts
+++ b/web/lib/currency.ts
@@ -1,0 +1,148 @@
+/**
+ * Multi-currency price formatting — single source of truth for how prices
+ * render across the catalog. Used by sections that display services, products,
+ * pricing tiers, and anything with a money amount.
+ *
+ * Covers the currencies real tenants actually use today: Guaranies (PYG),
+ * US dollars (USD), euros (EUR). Extend the CURRENCY_FORMAT map to add more.
+ *
+ * Behaviour:
+ *  - PYG (Guaranies) uses Paraguay's ad-hoc convention: "150.000 Gs" (period
+ *    as thousands separator, "Gs" suffix, no fractional part).
+ *  - USD / EUR / GBP use the browser's Intl.NumberFormat which renders the
+ *    native symbol in the correct locale ("$35", "€35", "£35").
+ *  - If the input is already a formatted string (e.g. "150.000 Gs" or "$35"),
+ *    pass through unchanged so content files that use human-authored prices
+ *    keep working.
+ *  - Unknown currency → returns input unchanged and logs a warning.
+ */
+
+export type SupportedCurrency = 'PYG' | 'USD' | 'EUR' | 'GBP' | 'BRL' | 'ARS' | 'UYU'
+
+export type PriceInput =
+  | number
+  | string
+  | null
+  | undefined
+  | { amount: number; currency: SupportedCurrency; period?: string }
+
+interface CurrencyFormatter {
+  format: (n: number) => string
+  /** Short-form suffix when the amount needs to show only the symbol or abbreviation. */
+  suffix?: string
+}
+
+/**
+ * Paraguay convention for Guaranies — no cents, period thousands separator,
+ * " Gs" suffix. Intl.NumberFormat would produce "PYG 150.000" which is not
+ * how anyone writes it locally.
+ */
+function formatPyg(amount: number): string {
+  const fixed = Math.round(amount).toLocaleString('es-PY', {
+    useGrouping: true,
+    maximumFractionDigits: 0,
+  })
+  // Spanish number format already uses "." as thousands separator.
+  return `${fixed} Gs`
+}
+
+/**
+ * Lazily build an Intl formatter per currency. Browser + Node both ship with
+ * full ICU data on modern Node 20+, so `Intl.NumberFormat` is safe server-side.
+ */
+function intlFormatter(currency: string, locale: string): CurrencyFormatter {
+  const f = new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    currencyDisplay: 'symbol',
+  })
+  return {
+    format: (n) => f.format(n),
+  }
+}
+
+const FORMATTERS_CACHE = new Map<string, CurrencyFormatter>()
+
+function getFormatter(currency: SupportedCurrency, locale: string): CurrencyFormatter {
+  const key = `${currency}:${locale}`
+  const cached = FORMATTERS_CACHE.get(key)
+  if (cached) return cached
+
+  let f: CurrencyFormatter
+  if (currency === 'PYG') {
+    f = { format: formatPyg }
+  } else {
+    f = intlFormatter(currency, locale)
+  }
+  FORMATTERS_CACHE.set(key, f)
+  return f
+}
+
+/**
+ * Format a price for display.
+ *
+ * - If `input` is already a string, it's assumed to be pre-formatted (e.g.
+ *   legacy content with `"150.000 Gs"` or `"$35"`). Returned unchanged.
+ * - If `input` is a number, requires `currency` (defaults to PYG).
+ * - If `input` is `{ amount, currency, period? }`, renders with the declared
+ *   currency and appends the optional period ("/mes", "/semana").
+ */
+export function formatPrice(
+  input: PriceInput,
+  opts?: { currency?: SupportedCurrency; locale?: string },
+): string {
+  if (input === null || input === undefined || input === '') return ''
+  const locale = opts?.locale || 'es-PY'
+
+  if (typeof input === 'string') return input
+  if (typeof input === 'number') {
+    const currency = opts?.currency || 'PYG'
+    return getFormatter(currency, locale).format(input)
+  }
+  // Structured input
+  const { amount, currency, period } = input
+  const base = getFormatter(currency, locale).format(amount)
+  return period ? `${base}/${period}` : base
+}
+
+/** Sugar: format a range "from – to" with currency suffix shared. */
+export function formatPriceRange(
+  from: number,
+  to: number,
+  opts: { currency: SupportedCurrency; locale?: string },
+): string {
+  const a = formatPrice(from, opts)
+  const b = formatPrice(to, opts)
+  return `${a} – ${b}`
+}
+
+/** Infer a safe default currency from a country code. Falls back to PYG. */
+export function defaultCurrencyForCountry(country: string | undefined): SupportedCurrency {
+  switch ((country || '').toLowerCase()) {
+    case 'paraguay':
+    case 'py':
+      return 'PYG'
+    case 'uruguay':
+    case 'uy':
+      return 'UYU'
+    case 'argentina':
+    case 'ar':
+      return 'ARS'
+    case 'brazil':
+    case 'brasil':
+    case 'br':
+      return 'BRL'
+    case 'united states':
+    case 'usa':
+    case 'us':
+      return 'USD'
+    case 'eu':
+    case 'europe':
+    case 'spain':
+    case 'germany':
+    case 'netherlands':
+      return 'EUR'
+    default:
+      return 'PYG'
+  }
+}

--- a/web/tests/unit/currency.test.ts
+++ b/web/tests/unit/currency.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { formatPrice, formatPriceRange, defaultCurrencyForCountry } from '@/lib/currency'
+
+describe('formatPrice', () => {
+  it('passes through pre-formatted strings (legacy content stays working)', () => {
+    expect(formatPrice('150.000 Gs')).toBe('150.000 Gs')
+    expect(formatPrice('$35')).toBe('$35')
+    expect(formatPrice('Consultar')).toBe('Consultar')
+  })
+
+  it('formats PYG as "<n> Gs" with period thousands separator', () => {
+    expect(formatPrice(150000, { currency: 'PYG' })).toBe('150.000 Gs')
+    expect(formatPrice(1200000, { currency: 'PYG' })).toBe('1.200.000 Gs')
+    expect(formatPrice(45000, { currency: 'PYG' })).toBe('45.000 Gs')
+  })
+
+  it('formats USD with native symbol', () => {
+    const result = formatPrice(35, { currency: 'USD', locale: 'en-US' })
+    expect(result).toContain('$')
+    expect(result).toContain('35')
+  })
+
+  it('formats EUR with native symbol', () => {
+    const result = formatPrice(35, { currency: 'EUR', locale: 'nl-NL' })
+    expect(result).toContain('€')
+  })
+
+  it('honours structured input with period suffix', () => {
+    expect(formatPrice({ amount: 150000, currency: 'PYG', period: 'mes' })).toBe('150.000 Gs/mes')
+    expect(formatPrice({ amount: 250000, currency: 'PYG', period: 'semana' })).toBe('250.000 Gs/semana')
+  })
+
+  it('returns empty for null/undefined/empty', () => {
+    expect(formatPrice(null)).toBe('')
+    expect(formatPrice(undefined)).toBe('')
+    expect(formatPrice('')).toBe('')
+  })
+
+  it('defaults currency to PYG if omitted', () => {
+    expect(formatPrice(150000)).toBe('150.000 Gs')
+  })
+
+  it('formatPriceRange formats both ends', () => {
+    const r = formatPriceRange(100000, 200000, { currency: 'PYG' })
+    expect(r).toContain('100.000 Gs')
+    expect(r).toContain('200.000 Gs')
+    expect(r).toContain('–')
+  })
+})
+
+describe('defaultCurrencyForCountry', () => {
+  it('maps Paraguay → PYG', () => {
+    expect(defaultCurrencyForCountry('Paraguay')).toBe('PYG')
+    expect(defaultCurrencyForCountry('PY')).toBe('PYG')
+  })
+
+  it('maps Uruguay → UYU', () => {
+    expect(defaultCurrencyForCountry('Uruguay')).toBe('UYU')
+  })
+
+  it('maps Netherlands → EUR', () => {
+    expect(defaultCurrencyForCountry('Netherlands')).toBe('EUR')
+  })
+
+  it('falls back to PYG for unknown country', () => {
+    expect(defaultCurrencyForCountry(undefined)).toBe('PYG')
+    expect(defaultCurrencyForCountry('Atlantis')).toBe('PYG')
+  })
+})


### PR DESCRIPTION
## Summary

Adds 22 new generic section components + registry/renderer wiring so tenants across verticals can compose new surface area without bespoke development.

## New sections (22)

Conversion: \`countdown-timer\`, \`multi-step-form\`, \`newsletter-signup\`, \`intake-questionnaire\`

Trust / proof: \`testimonial-video\`, \`google-reviews-widget\`, \`trust-signals-logos\`, \`timeline-history\`

Pricing / comparison: \`pricing-range\`, \`compare-plans-matrix\`, \`tiered-service-ladder\`, \`currency-toggle\`

Commerce: \`delivery-slot-picker\`, \`mortgage-calculator\`, \`service-area-map-zones\`, \`sample-week-preview\`, \`weekly-cadence-calendar\`

Content: \`faq-categorized\`, \`before-after-split\`, \`instagram-feed\`, \`open-hours-status\`, \`language-selector\`

Compliance-adjacent (used by compliance PR): \`compliance-disclaimer-footer\`, \`regulatory-status-badge\`

## Changes

- **New**: 24 section components under \`web/components/sections/\`
- **Deleted**: \`huevo-del-dia\`, \`nutritional-info\` (superseded by generic equivalents)
- **Modified existing**: \`before-after\`, \`class-schedule\`, \`event-venues\`, \`pricing-table\`, \`process-timeline\`, \`programs-comparison\`, \`testimonials\`, \`trust-signals\`, \`why-destination\`
- **Engine**: \`renderer.tsx\` imports + registers new sections; \`section-registry.ts\` variant registrations; \`demo-data.ts\` seed data
- **Registry/verticals**: \`relocation.type.json\`, new \`book_cover_designer.type.json\`, \`food-beverage/portfolio-professional/relocacion\` vertical section lists
- **Bundled dependency**: \`web/lib/currency.ts\` + tests (mortgage-calculator imports \`formatPrice\` / \`SupportedCurrency\`) — cannot split without breaking typecheck

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`currency.test.ts\` 12/12 passing
- [ ] Smoke-render each new section via visual-audit after merge
- [ ] Confirm existing tenants still render (Main section set unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)