### PR TITLE
chore(engine): port sushi-menu work from stray 'main' branch (unify single trunk)

### DIFF
--- a/web/components/icons/sushi-category.tsx
+++ b/web/components/icons/sushi-category.tsx
@@ -1,0 +1,37 @@
+import type { ComponentType, SVGProps } from 'react'
+import {
+  NigiriIcon,
+  MakiIcon,
+  SashimiIcon,
+  TemakiIcon,
+  SakeIcon,
+  TempuraIcon,
+  ChopsticksIcon,
+} from './sushi'
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>
+
+const CATEGORY_ICONS: Record<string, IconComponent> = {
+  nigiri: NigiriIcon,
+  maki: MakiIcon,
+  maki_rolls: MakiIcon,
+  specialty_rolls: MakiIcon,
+  sashimi: SashimiIcon,
+  hand_rolls: TemakiIcon,
+  temaki: TemakiIcon,
+  sake: SakeIcon,
+  beverages: SakeIcon,
+  tempura: TempuraIcon,
+  appetizers: TempuraIcon,
+  hibachi: ChopsticksIcon,
+  main_courses: ChopsticksIcon,
+}
+
+export function SushiCategoryIcon({
+  category,
+  ...props
+}: { category: string } & SVGProps<SVGSVGElement>) {
+  const key = category.toLowerCase().replace(/\s+/g, '_')
+  const Icon = CATEGORY_ICONS[key] ?? ChopsticksIcon
+  return <Icon {...props} />
+}

--- a/web/components/icons/sushi.tsx
+++ b/web/components/icons/sushi.tsx
@@ -1,0 +1,288 @@
+import type { SVGProps } from 'react'
+
+type IconProps = SVGProps<SVGSVGElement>
+
+export function NigiriIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 64 48" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <ellipse cx="32" cy="34" rx="26" ry="8" fill="currentColor" opacity="0.12" />
+      <path
+        d="M8 30c0-3 2-5 5-5h38c3 0 5 2 5 5v2c0 3-2 5-5 5H13c-3 0-5-2-5-5v-2z"
+        fill="currentColor"
+        opacity="0.35"
+      />
+      <path
+        d="M10 22c2-6 8-10 22-10s20 4 22 10c1 2 0 4-3 4H13c-3 0-4-2-3-4z"
+        fill="currentColor"
+      />
+      <path
+        d="M16 18c3-2 8-4 16-4s13 2 16 4"
+        stroke="currentColor"
+        strokeOpacity="0.3"
+        strokeWidth="1"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+export function MakiIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <circle cx="32" cy="32" r="28" fill="currentColor" opacity="0.1" />
+      <circle cx="32" cy="32" r="26" stroke="currentColor" strokeWidth="3" opacity="0.55" />
+      <circle cx="32" cy="32" r="18" fill="currentColor" opacity="0.15" />
+      <circle cx="32" cy="32" r="18" stroke="currentColor" strokeWidth="1.5" opacity="0.4" />
+      <circle cx="32" cy="32" r="8" fill="currentColor" />
+      <circle cx="32" cy="32" r="2.5" fill="currentColor" opacity="0.3" />
+    </svg>
+  )
+}
+
+export function SashimiIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 64 48" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M6 32c0-4 3-7 7-7h38c4 0 7 3 7 7s-3 7-7 7H13c-4 0-7-3-7-7z"
+        fill="currentColor"
+      />
+      <path
+        d="M4 20c0-4 3-7 7-7h38c4 0 7 3 7 7s-3 7-7 7H11c-4 0-7-3-7-7z"
+        fill="currentColor"
+        opacity="0.7"
+      />
+      <path
+        d="M8 10c0-3 2-5 5-5h34c3 0 5 2 5 5s-2 5-5 5H13c-3 0-5-2-5-5z"
+        fill="currentColor"
+        opacity="0.45"
+      />
+      <path
+        d="M14 32h32M12 20h36"
+        stroke="currentColor"
+        strokeOpacity="0.25"
+        strokeWidth="1"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+export function TemakiIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M12 8L52 24L28 56L12 8z"
+        fill="currentColor"
+        opacity="0.85"
+      />
+      <path
+        d="M18 16L44 26L28 48"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeOpacity="0.4"
+        fill="none"
+      />
+      <circle cx="34" cy="22" r="2" fill="currentColor" opacity="0.3" />
+      <circle cx="30" cy="30" r="1.5" fill="currentColor" opacity="0.3" />
+      <circle cx="38" cy="28" r="1.5" fill="currentColor" opacity="0.3" />
+    </svg>
+  )
+}
+
+export function SakeIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M24 8h16v4l-2 4v14c0 6-3 10-6 10s-6-4-6-10V16l-2-4V8z"
+        fill="currentColor"
+        opacity="0.85"
+      />
+      <path d="M24 8h16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <ellipse cx="32" cy="48" rx="16" ry="3" fill="currentColor" opacity="0.15" />
+      <path
+        d="M16 50c0 4 3 8 8 8h16c5 0 8-4 8-8l-1-6H17l-1 6z"
+        fill="currentColor"
+        opacity="0.4"
+      />
+      <path d="M17 44h30" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+export function TempuraIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M12 44c2-16 10-28 22-28s18 10 18 22"
+        stroke="currentColor"
+        strokeWidth="6"
+        strokeLinecap="round"
+        fill="none"
+      />
+      <path
+        d="M12 44c2-16 10-28 22-28s18 10 18 22"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeDasharray="2 3"
+        opacity="0.4"
+        fill="none"
+      />
+      <circle cx="12" cy="48" r="5" fill="currentColor" opacity="0.6" />
+      <circle cx="18" cy="50" r="3" fill="currentColor" opacity="0.4" />
+      <circle cx="52" cy="40" r="2" fill="currentColor" opacity="0.5" />
+      <circle cx="46" cy="20" r="1.5" fill="currentColor" opacity="0.5" />
+    </svg>
+  )
+}
+
+export function ChopsticksIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M10 56L48 8"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      <path
+        d="M18 56L56 8"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        opacity="0.6"
+      />
+    </svg>
+  )
+}
+
+export interface SushiPlateProps extends IconProps {
+  plateColor?: string
+  toppingVariant?: 'nigiri' | 'maki' | 'sashimi'
+}
+
+export function SushiPlate({
+  plateColor = 'currentColor',
+  toppingVariant = 'nigiri',
+  ...props
+}: SushiPlateProps) {
+  return (
+    <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <ellipse cx="50" cy="72" rx="44" ry="6" fill="black" opacity="0.08" />
+      <ellipse cx="50" cy="60" rx="42" ry="10" fill={plateColor} />
+      <ellipse cx="50" cy="58" rx="42" ry="10" fill={plateColor} />
+      <ellipse cx="50" cy="57" rx="34" ry="7" fill="white" opacity="0.25" />
+      <ellipse cx="50" cy="55" rx="30" ry="6" fill="#FAFAF5" />
+
+      {toppingVariant === 'nigiri' && (
+        <g transform="translate(30 32)">
+          <ellipse cx="20" cy="22" rx="18" ry="5" fill="#F5F0E5" />
+          <path
+            d="M4 20c0-4 2-7 16-7s16 3 16 7c0 1-1 2-3 2H7c-2 0-3-1-3-2z"
+            fill="#F5F0E5"
+          />
+          <path
+            d="M6 14c2-5 8-8 14-8s12 3 14 8c1 2-1 4-3 4H9c-2 0-4-2-3-4z"
+            fill="#E67E60"
+          />
+          <path
+            d="M10 10c3-2 6-3 10-3s7 1 10 3"
+            stroke="white"
+            strokeOpacity="0.55"
+            strokeWidth="1"
+            strokeLinecap="round"
+          />
+        </g>
+      )}
+
+      {toppingVariant === 'maki' && (
+        <g transform="translate(32 20)">
+          <circle cx="18" cy="18" r="16" fill="#1A1A1A" />
+          <circle cx="18" cy="18" r="13" fill="#F5F0E5" />
+          <circle cx="18" cy="18" r="6" fill="#E67E60" />
+          <circle cx="18" cy="18" r="1.5" fill="#6B4423" opacity="0.4" />
+        </g>
+      )}
+
+      {toppingVariant === 'sashimi' && (
+        <g transform="translate(28 28)">
+          <path d="M4 20c0-3 2-5 5-5h26c3 0 5 2 5 5s-2 5-5 5H9c-3 0-5-2-5-5z" fill="#E67E60" />
+          <path d="M6 12c0-3 2-5 5-5h22c3 0 5 2 5 5s-2 5-5 5H11c-3 0-5-2-5-5z" fill="#E67E60" opacity="0.75" />
+          <path d="M10 8h22" stroke="white" strokeOpacity="0.4" strokeWidth="0.8" />
+          <path d="M8 20h24" stroke="white" strokeOpacity="0.4" strokeWidth="0.8" />
+        </g>
+      )}
+    </svg>
+  )
+}
+
+export interface SeigaihaPatternProps {
+  color?: string
+  opacity?: number
+  className?: string
+  id?: string
+}
+
+export function SeigaihaPattern({
+  color = 'var(--primary)',
+  opacity = 0.08,
+  className,
+  id = 'seigaiha-default',
+}: SeigaihaPatternProps) {
+  return (
+    <svg
+      className={className}
+      width="100%"
+      height="100%"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <defs>
+        <pattern id={id} x="0" y="0" width="80" height="40" patternUnits="userSpaceOnUse">
+          <g fill="none" stroke={color} strokeWidth="1.5" strokeOpacity={opacity}>
+            <circle cx="0" cy="40" r="34" />
+            <circle cx="0" cy="40" r="22" />
+            <circle cx="0" cy="40" r="10" />
+            <circle cx="80" cy="40" r="34" />
+            <circle cx="80" cy="40" r="22" />
+            <circle cx="80" cy="40" r="10" />
+            <circle cx="40" cy="0" r="34" />
+            <circle cx="40" cy="0" r="22" />
+            <circle cx="40" cy="0" r="10" />
+            <circle cx="40" cy="80" r="34" />
+          </g>
+        </pattern>
+      </defs>
+      <rect width="100%" height="100%" fill={`url(#${id})`} />
+    </svg>
+  )
+}
+
+export interface SeigaihaDividerProps {
+  flip?: boolean
+  className?: string
+}
+
+export function SeigaihaDivider({ flip = false, className }: SeigaihaDividerProps) {
+  return (
+    <div
+      className={className}
+      style={{ transform: flip ? 'scaleY(-1)' : undefined }}
+      aria-hidden="true"
+    >
+      <svg viewBox="0 0 1200 60" preserveAspectRatio="none" className="h-12 w-full">
+        <path
+          d="M0 60 C 100 20, 200 20, 300 60 C 400 20, 500 20, 600 60 C 700 20, 800 20, 900 60 C 1000 20, 1100 20, 1200 60 L1200 0 L0 0 Z"
+          fill="var(--surface)"
+        />
+        <path
+          d="M0 60 C 100 30, 200 30, 300 60 C 400 30, 500 30, 600 60 C 700 30, 800 30, 900 60 C 1000 30, 1100 30, 1200 60"
+          stroke="var(--primary)"
+          strokeOpacity="0.2"
+          strokeWidth="1.5"
+          fill="none"
+        />
+      </svg>
+    </div>
+  )
+}

--- a/web/components/sections/color-coded-menu-section.tsx
+++ b/web/components/sections/color-coded-menu-section.tsx
@@ -1,0 +1,240 @@
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Card, CardContent, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { AnimateOnScroll, AnimatedSectionHeader } from '@/components/ui/animate-on-scroll'
+import { SushiPlate, SeigaihaPattern } from '@/components/icons/sushi'
+
+export interface ColorCodedPlate {
+  key: string
+  title: string
+  price: string
+  items: string[]
+  color: string
+  description?: string
+}
+
+export interface ColorCodedMenuSectionProps {
+  title: string
+  subtitle?: string
+  description?: string
+  plates: ColorCodedPlate[]
+  legendTitle?: string
+}
+
+const VARIANTS: Array<'nigiri' | 'maki' | 'sashimi'> = ['nigiri', 'maki', 'sashimi']
+
+export function ColorCodedMenuSection({
+  title,
+  subtitle,
+  description,
+  plates,
+  legendTitle = 'Cada color = un precio',
+}: ColorCodedMenuSectionProps) {
+  return (
+    <section
+      id="menu"
+      className="relative overflow-hidden bg-[var(--background)] py-16 sm:py-20"
+    >
+      <div className="pointer-events-none absolute inset-0">
+        <SeigaihaPattern id="color-menu-seigaiha" color="var(--primary)" opacity={0.04} />
+      </div>
+
+      <Container className="relative">
+        <AnimatedSectionHeader className="mb-8 text-center">
+          <Heading as="h2" level={2} className="mb-4">
+            {title}
+          </Heading>
+          {subtitle && (
+            <p className="mx-auto max-w-2xl text-lg text-[var(--secondary)]">{subtitle}</p>
+          )}
+          {description && (
+            <p className="mx-auto mt-4 max-w-2xl text-sm text-[var(--text-muted)]">
+              {description}
+            </p>
+          )}
+        </AnimatedSectionHeader>
+
+        <div className="mx-auto mb-10 flex max-w-3xl flex-wrap items-center justify-center gap-3 rounded-full bg-[var(--surface-light)] p-3 shadow-sm">
+          <span className="px-2 text-sm font-semibold text-[var(--text-muted)]">
+            {legendTitle}:
+          </span>
+          {plates.map((plate) => (
+            <div
+              key={plate.key}
+              className="flex items-center gap-2 rounded-full bg-[var(--background)] px-3 py-1.5"
+            >
+              <span
+                className="inline-block h-4 w-4 rounded-full ring-2 ring-white"
+                style={{ backgroundColor: plate.color }}
+              />
+              <span className="text-sm font-medium text-[var(--text)]">{plate.price}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {plates.map((plate, index) => (
+            <AnimateOnScroll key={plate.key} stagger={index}>
+              <Card className="group relative h-full overflow-hidden transition-all duration-300 hover:-translate-y-1 hover:shadow-xl">
+                <div
+                  className="h-1.5 w-full"
+                  style={{ backgroundColor: plate.color }}
+                />
+                <CardContent className="p-6">
+                  <div className="mb-4 flex items-center gap-4">
+                    <div className="h-14 w-14 shrink-0 transition-transform duration-300 group-hover:scale-110">
+                      <SushiPlate
+                        plateColor={plate.color}
+                        toppingVariant={VARIANTS[index % VARIANTS.length]}
+                        width="56"
+                        height="56"
+                      />
+                    </div>
+                    <div>
+                      <CardTitle className="text-xl">{plate.title}</CardTitle>
+                      <p
+                        className="text-2xl font-bold"
+                        style={{ color: plate.color }}
+                      >
+                        {plate.price}
+                      </p>
+                    </div>
+                  </div>
+                  {plate.description && (
+                    <p className="mb-3 text-sm text-[var(--text-muted)]">
+                      {plate.description}
+                    </p>
+                  )}
+                  <ul className="space-y-2">
+                    {plate.items.map((item, i) => (
+                      <li
+                        key={i}
+                        className="flex items-start gap-2 text-sm text-[var(--text-light)]"
+                      >
+                        <span
+                          className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                          style={{ backgroundColor: plate.color }}
+                        />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            </AnimateOnScroll>
+          ))}
+        </div>
+      </Container>
+    </section>
+  )
+}
+
+export interface SpecialOrderItem {
+  name: string
+  description?: string
+  price?: string
+}
+
+export interface SpecialOrderSectionProps {
+  title: string
+  description?: string
+  items: Array<SpecialOrderItem | string>
+  tabletLabel?: string
+}
+
+export function SpecialOrderSection({
+  title,
+  description,
+  items,
+  tabletLabel = 'Pide desde la tableta',
+}: SpecialOrderSectionProps) {
+  const normalized = items.map((item) =>
+    typeof item === 'string' ? { name: item } : item
+  )
+
+  return (
+    <section id="special-order" className="bg-[var(--surface)] py-16 sm:py-20">
+      <Container>
+        <div className="mx-auto max-w-5xl overflow-hidden rounded-2xl border border-[var(--primary)]/10 bg-[var(--background)] shadow-lg">
+          <div className="grid gap-0 md:grid-cols-[1fr_1.5fr]">
+            <div className="relative flex items-center justify-center bg-gradient-to-br from-[var(--primary)] to-[var(--secondary)] p-10 text-[var(--primary-foreground)]">
+              <div className="relative z-10 text-center">
+                <div className="mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-3xl bg-white/15 backdrop-blur-sm">
+                  <svg
+                    width="40"
+                    height="40"
+                    viewBox="0 0 40 40"
+                    fill="none"
+                    aria-hidden="true"
+                  >
+                    <rect
+                      x="6"
+                      y="4"
+                      width="28"
+                      height="32"
+                      rx="3"
+                      stroke="currentColor"
+                      strokeWidth="2.5"
+                    />
+                    <rect
+                      x="10"
+                      y="8"
+                      width="20"
+                      height="22"
+                      rx="1"
+                      fill="currentColor"
+                      opacity="0.3"
+                    />
+                    <circle cx="20" cy="33" r="1.5" fill="currentColor" />
+                  </svg>
+                </div>
+                <p className="text-sm uppercase tracking-wider opacity-80">
+                  {tabletLabel}
+                </p>
+              </div>
+              <div
+                className="pointer-events-none absolute inset-0 opacity-20"
+                style={{
+                  backgroundImage:
+                    'radial-gradient(circle at 30% 30%, white 0%, transparent 60%)',
+                }}
+              />
+            </div>
+
+            <div className="p-8 md:p-10">
+              <Heading as="h2" level={2} className="mb-3">
+                {title}
+              </Heading>
+              {description && (
+                <p className="mb-6 text-[var(--text-muted)]">{description}</p>
+              )}
+              <div className="grid gap-3 sm:grid-cols-2">
+                {normalized.map((item, i) => (
+                  <AnimateOnScroll key={i} stagger={i}>
+                    <div className="flex items-start gap-3 rounded-lg border border-[var(--surface-light)] p-3 transition-colors hover:border-[var(--primary)]/30 hover:bg-[var(--surface-light)]">
+                      <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--primary)]/10 text-xs font-bold text-[var(--primary)]">
+                        {i + 1}
+                      </div>
+                      <div className="flex-1">
+                        <p className="font-medium text-[var(--text)]">{item.name}</p>
+                        {item.description && (
+                          <p className="text-xs text-[var(--text-muted)]">
+                            {item.description}
+                          </p>
+                        )}
+                      </div>
+                      {item.price && (
+                        <Badge variant="outline">{item.price}</Badge>
+                      )}
+                    </div>
+                  </AnimateOnScroll>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/components/sections/conveyor-belt-strip.tsx
+++ b/web/components/sections/conveyor-belt-strip.tsx
@@ -1,0 +1,87 @@
+import { SushiPlate } from '@/components/icons/sushi'
+
+export interface ConveyorBeltStripPlate {
+  color: string
+  variant?: 'nigiri' | 'maki' | 'sashimi'
+}
+
+export interface ConveyorBeltStripProps {
+  plates: ConveyorBeltStripPlate[]
+  speed?: string
+  beltColor?: string
+  className?: string
+}
+
+export function ConveyorBeltStrip({
+  plates,
+  speed = '20s',
+  beltColor = '#37474F',
+  className,
+}: ConveyorBeltStripProps) {
+  if (plates.length === 0) return null
+  const loop = [...plates, ...plates]
+
+  return (
+    <div
+      className={`relative overflow-hidden ${className ?? ''}`}
+      aria-hidden="true"
+      style={
+        {
+          '--belt-speed': speed,
+          '--belt-color': beltColor,
+        } as React.CSSProperties
+      }
+    >
+      <div
+        className="absolute inset-x-0 top-1/2 h-20 -translate-y-1/2 rounded-md"
+        style={{
+          background: `linear-gradient(180deg, ${beltColor}DD 0%, ${beltColor} 50%, ${beltColor}CC 100%)`,
+        }}
+      />
+      <div
+        className="absolute inset-x-0 top-1/2 h-20 -translate-y-1/2 opacity-40"
+        style={{
+          background:
+            'repeating-linear-gradient(90deg, transparent 0 28px, rgba(255,255,255,0.15) 28px 30px)',
+        }}
+      />
+      <div className="absolute inset-x-0 top-[calc(50%-40px)] h-1 bg-black/25" />
+      <div className="absolute inset-x-0 top-[calc(50%+39px)] h-1 bg-black/40" />
+
+      <div className="conveyor-track relative flex items-center gap-6 py-12">
+        {loop.map((plate, i) => (
+          <div
+            key={i}
+            className="shrink-0"
+            style={{
+              width: '88px',
+              height: '88px',
+              filter: 'drop-shadow(0 6px 10px rgba(0,0,0,0.25))',
+            }}
+          >
+            <SushiPlate
+              plateColor={plate.color}
+              toppingVariant={plate.variant ?? 'nigiri'}
+              width="88"
+              height="88"
+            />
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        @keyframes conveyor-scroll {
+          from { transform: translateX(0); }
+          to { transform: translateX(-50%); }
+        }
+        .conveyor-track {
+          animation: conveyor-scroll var(--belt-speed, 20s) linear infinite;
+          width: max-content;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .conveyor-track { animation: none; }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/web/components/sections/sushi-menu-sections.tsx
+++ b/web/components/sections/sushi-menu-sections.tsx
@@ -1,0 +1,281 @@
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Card, CardContent, CardTitle, CardDescription } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { AnimateOnScroll, AnimatedSectionHeader } from '@/components/ui/animate-on-scroll'
+import { SushiCategoryIcon } from '@/components/icons/sushi-category'
+
+export interface MenuItem {
+  name: string
+  nameJa?: string
+  description?: string
+  price?: string
+  dietaryTags?: string[]
+  imageUrl?: string
+}
+
+export interface MenuCategory {
+  key: string
+  title: string
+  description?: string
+  items?: MenuItem[]
+}
+
+export interface FeaturedMenuSectionProps {
+  title: string
+  subtitle?: string
+  categories: MenuCategory[]
+  ctaText?: string
+  ctaHref?: string
+  dietaryLabels?: Record<string, string>
+}
+
+function DietaryBadge({ tag, label }: { tag: string; label?: string }) {
+  return (
+    <Badge variant="outline" className="text-[10px] uppercase">
+      {label ?? tag}
+    </Badge>
+  )
+}
+
+export function FeaturedMenuSection({
+  title,
+  subtitle,
+  categories,
+  ctaText,
+  ctaHref,
+  dietaryLabels,
+}: FeaturedMenuSectionProps) {
+  const filtered = categories.filter((c) => (c.items?.length ?? 0) > 0 || c.description)
+
+  return (
+    <section id="featured-menu" className="bg-[var(--background)] py-16 sm:py-20">
+      <Container>
+        <AnimatedSectionHeader className="mb-12 text-center">
+          <Heading as="h2" level={2} className="mb-4">
+            {title}
+          </Heading>
+          {subtitle && (
+            <p className="mx-auto max-w-2xl text-lg text-[var(--secondary)]">{subtitle}</p>
+          )}
+        </AnimatedSectionHeader>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((category, index) => (
+            <AnimateOnScroll key={category.key} stagger={index}>
+              <Card className="group h-full overflow-hidden transition-transform duration-300 hover:-translate-y-1 hover:shadow-xl">
+                <CardContent className="p-6">
+                  <div className="mb-4 flex items-center gap-3 text-[var(--primary)]">
+                    <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-[var(--primary)]/10 transition-transform duration-300 group-hover:scale-110">
+                      <SushiCategoryIcon
+                        category={category.key}
+                        width="32"
+                        height="32"
+                      />
+                    </div>
+                    <CardTitle className="text-xl">{category.title}</CardTitle>
+                  </div>
+
+                  {category.description && (
+                    <CardDescription className="mb-4">
+                      {category.description}
+                    </CardDescription>
+                  )}
+
+                  {category.items && category.items.length > 0 && (
+                    <ul className="space-y-2">
+                      {category.items.slice(0, 4).map((item, i) => (
+                        <li
+                          key={i}
+                          className="flex items-center justify-between gap-2 border-t border-[var(--surface-light)] pt-2 text-sm first:border-t-0 first:pt-0"
+                        >
+                          <div className="flex-1">
+                            <span className="font-medium text-[var(--text)]">
+                              {item.name}
+                            </span>
+                            {item.nameJa && (
+                              <span className="ml-1 text-xs text-[var(--text-muted)]">
+                                ({item.nameJa})
+                              </span>
+                            )}
+                            {item.dietaryTags && item.dietaryTags.length > 0 && (
+                              <span className="ml-2 inline-flex gap-1">
+                                {item.dietaryTags.map((t) => (
+                                  <DietaryBadge
+                                    key={t}
+                                    tag={t}
+                                    label={dietaryLabels?.[t]}
+                                  />
+                                ))}
+                              </span>
+                            )}
+                          </div>
+                          {item.price && (
+                            <span className="shrink-0 font-semibold text-[var(--primary)]">
+                              {item.price}
+                            </span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </CardContent>
+              </Card>
+            </AnimateOnScroll>
+          ))}
+        </div>
+
+        {ctaText && (
+          <div className="mt-12 text-center">
+            <a
+              href={ctaHref ?? '#menu'}
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--primary)] px-8 py-3 font-semibold text-[var(--primary-foreground)] shadow-lg transition-transform hover:-translate-y-0.5 hover:shadow-xl"
+            >
+              {ctaText}
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                <path
+                  d="M4 10h12m0 0l-4-4m4 4l-4 4"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </a>
+          </div>
+        )}
+      </Container>
+    </section>
+  )
+}
+
+export interface FullMenuSectionProps {
+  title: string
+  subtitle?: string
+  categories: MenuCategory[]
+  dietaryLabels?: Record<string, string>
+  japaneseTerms?: Record<string, string>
+}
+
+export function FullMenuSection({
+  title,
+  subtitle,
+  categories,
+  dietaryLabels,
+  japaneseTerms,
+}: FullMenuSectionProps) {
+  return (
+    <section id="full-menu" className="bg-[var(--background)] py-16 sm:py-20">
+      <Container>
+        <AnimatedSectionHeader className="mb-12 text-center">
+          <Heading as="h1" level={1} className="mb-4">
+            {title}
+          </Heading>
+          {subtitle && (
+            <p className="mx-auto max-w-2xl text-lg text-[var(--secondary)]">{subtitle}</p>
+          )}
+        </AnimatedSectionHeader>
+
+        {dietaryLabels && Object.keys(dietaryLabels).length > 0 && (
+          <div className="mx-auto mb-12 flex max-w-3xl flex-wrap items-center justify-center gap-3 rounded-2xl bg-[var(--surface-light)] p-4">
+            <span className="text-sm font-semibold text-[var(--text-muted)]">
+              Etiquetas:
+            </span>
+            {Object.entries(dietaryLabels).map(([tag, label]) => (
+              <div key={tag} className="flex items-center gap-1.5">
+                <Badge variant="outline" className="text-[10px] uppercase">
+                  {tag}
+                </Badge>
+                <span className="text-xs text-[var(--text-light)]">{label}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="mx-auto max-w-5xl space-y-12">
+          {categories.map((category, index) => (
+            <AnimateOnScroll key={category.key} stagger={Math.min(index, 5)}>
+              <div>
+                <div className="mb-6 flex items-center gap-4 border-b border-[var(--surface-light)] pb-4">
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-[var(--primary)]/10 text-[var(--primary)]">
+                    <SushiCategoryIcon category={category.key} width="28" height="28" />
+                  </div>
+                  <div>
+                    <Heading as="h2" level={3} className="mb-0">
+                      {category.title}
+                    </Heading>
+                    {category.description && (
+                      <p className="text-sm text-[var(--text-muted)]">
+                        {category.description}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {category.items && category.items.length > 0 ? (
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    {category.items.map((item, i) => (
+                      <div
+                        key={i}
+                        className="flex items-start justify-between gap-3 rounded-lg p-3 transition-colors hover:bg-[var(--surface-light)]"
+                      >
+                        <div className="flex-1">
+                          <div className="flex flex-wrap items-baseline gap-2">
+                            <p className="font-semibold text-[var(--text)]">
+                              {item.name}
+                            </p>
+                            {item.nameJa && (
+                              <p className="text-xs text-[var(--text-muted)]">
+                                {item.nameJa}
+                                {japaneseTerms?.[item.nameJa.toLowerCase()] && (
+                                  <span className="ml-1 italic">
+                                    ({japaneseTerms[item.nameJa.toLowerCase()]})
+                                  </span>
+                                )}
+                              </p>
+                            )}
+                          </div>
+                          {item.description && (
+                            <p className="mt-1 text-sm text-[var(--text-muted)]">
+                              {item.description}
+                            </p>
+                          )}
+                          {item.dietaryTags && item.dietaryTags.length > 0 && (
+                            <div className="mt-2 flex gap-1">
+                              {item.dietaryTags.map((t) => (
+                                <Badge
+                                  key={t}
+                                  variant="outline"
+                                  className="text-[10px] uppercase"
+                                >
+                                  {t}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                        {item.price && (
+                          <div className="shrink-0 text-right">
+                            <p className="font-semibold text-[var(--primary)]">
+                              {item.price}
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  category.description === undefined && (
+                    <p className="italic text-[var(--text-muted)]">
+                      Consulta con nuestro equipo por la selección del día.
+                    </p>
+                  )
+                )}
+              </div>
+            </AnimateOnScroll>
+          ))}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/lib/engine/renderer.tsx
+++ b/web/lib/engine/renderer.tsx
@@ -40,6 +40,14 @@ import { ProcessTimelineSection } from '@/components/sections/process-timeline-s
 import { OmakaseSection } from '@/components/sections/omakase-section'
 import { SakeMenuSection } from '@/components/sections/sake-menu-section'
 import { ConveyorBeltSection } from '@/components/sections/conveyor-belt-section'
+import {
+  ColorCodedMenuSection,
+  SpecialOrderSection,
+} from '@/components/sections/color-coded-menu-section'
+import {
+  FeaturedMenuSection,
+  FullMenuSection,
+} from '@/components/sections/sushi-menu-sections'
 import { MenuCategorizedPricedSection } from '@/components/sections/menu-categorized-priced-section'
 import { PropertyListingsSection } from '@/components/sections/property-listings-section'
 import { IntakeQuestionnaireSection } from '@/components/sections/intake-questionnaire-section'
@@ -99,6 +107,10 @@ const SECTION_COMPONENTS: Record<string, React.ComponentType<any>> = {
   omakase: OmakaseSection,
   'sake-menu': SakeMenuSection,
   'conveyor-belt': ConveyorBeltSection,
+  'featured-menu': FeaturedMenuSection,
+  'full-menu': FullMenuSection,
+  'color-coded-menu': ColorCodedMenuSection,
+  'special-order': SpecialOrderSection,
   // Catalog / menu (categorized + priced)
   'menu-categorized-priced': MenuCategorizedPricedSection,
   // Real estate


### PR DESCRIPTION
## Summary

This PR unifies the repo into a single trunk. The repo has been carrying both \`main\` (lowercase, stray) and \`Main\` (uppercase, default) branches. They diverged at \`2186add\` on 2026-04-17 and evolved independently. \`main\` accumulated only 2 merged PRs (#30, #31) — the rest of its content is already on Main via parallel work. Diff confirms:

- **main** has 5 files Main doesn't (all sushi-menu related, from PR #31)
- **Main** has 2,319 files main doesn't (all the modern work since divergence)

After this PR merges, \`main\` can be deleted — all its unique content will be on Main.

## Files ported from origin/main

- \`web/components/icons/sushi.tsx\` — themed sushi SVG library (nigiri, maki, sashimi, temaki, sake, tempura)
- \`web/components/icons/sushi-category.tsx\` — category icon glyphs
- \`web/components/sections/color-coded-menu-section.tsx\` — color-coded plate pricing + special-order form
- \`web/components/sections/conveyor-belt-strip.tsx\` — animated conveyor strip (prefers-reduced-motion aware)
- \`web/components/sections/sushi-menu-sections.tsx\` — \`FeaturedMenuSection\` + \`FullMenuSection\`

## Renderer wiring

\`web/lib/engine/renderer.tsx\` imports + registers 4 new kebab-case section types:
- \`featured-menu\`
- \`full-menu\`
- \`color-coded-menu\`
- \`special-order\`

## Architecture adaptation

\`main\` uses **camelCase** section keys (\`beforeAfter\`, \`classSchedule\`). \`Main\` uses **kebab-case** (\`before-after\`, \`class-schedule\`) — they diverged at the kebab migration. The ported registrations use kebab-case to match Main's convention. Tenant configs that reference these sections must use kebab-case.

## Post-merge cleanup

After this PR lands, \`main\` branch can be safely deleted:
\`\`\`bash
gh api -X DELETE repos/Ai-Whisperers/paragu-ai-builder/git/refs/heads/main
\`\`\`

## Test plan

- [x] \`tsc --noEmit\`: only pre-existing renderer errors (fixed by PR #34) — no new errors
- [ ] Smoke-render a sushi tenant page with \`featured-menu\` + \`color-coded-menu\` sections after merge
- [ ] Confirm kebab-case tenant JSON references match the registered keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)