### PR TITLE
docs: canonical north-star doc set (Diataxis + matklad ARCHITECTURE)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,185 @@
+# Architecture
+
+This document follows the [matklad ARCHITECTURE.md convention](https://matklad.github.io/2021/02/06/ARCHITECTURE.md.html): a bird's-eye view, a code map, cross-cutting concerns, and invariants. It's the first doc a new contributor should read after [README.md](./README.md).
+
+## 1. Bird's-eye view
+
+Paragu AI Builder is a **multi-tenant site generator**. A single Next.js app serves many tenants by reading per-tenant JSON at request time, merging it with vertical-level defaults and design tokens, and rendering a shared pool of React section components.
+
+There is **no per-tenant code** — tenants are pure configuration. A new tenant requires only:
+
+1. A `sites/<slug>/` directory with `site.json`, `pages/*.json`, `content/<locale>.json`, and optional `tokens.json`.
+2. Optionally, a new business type under `src/registry/` if the tenant's vertical isn't already supported.
+
+The application runs on **Cloudflare Workers** via [`@opennextjs/cloudflare`](https://opennext.js.org/cloudflare). Postgres lives in **Supabase**; observability in **Sentry + Cloudflare Analytics Engine + Axiom Logpush**. The admin dashboard is protected by Supabase Auth and gated in [`middleware.ts`](./web/middleware.ts).
+
+## 2. Code map
+
+### `src/` — the data layer (code-free)
+
+JSON schemas, design tokens, business-type registry, vertical catalogs, content templates, compliance templates. All code-free and tenant-agnostic — the only things that change per-tenant live under `sites/`.
+
+```
+src/
+├── schemas/         JSON Schema definitions (base + per-business-type)
+├── tokens/          31 token files — base + per-vertical overrides
+├── registry/        Business-type definitions (sections, features, SEO)
+├── verticals/       23 verticals — each groups related business types
+├── content/         34 content templates with {{placeholder}} keys
+└── compliance/      5 legal templates (privacy-py, terms, AML, INAN, cookies)
+```
+
+### `sites/` — the tenant layer
+
+One directory per tenant. Everything a tenant customises lives here; nothing else.
+
+```
+sites/<slug>/
+├── site.json              hostname, locales, businessType, integrations
+├── tokens.json            brand-colour overrides
+├── pages/                 page-by-page section ordering
+│   └── <page>.json        `{ sections: [ { id, variant, content } ] }`
+├── content/               locale-keyed copy
+│   ├── es.json
+│   ├── en.json
+│   └── …                  up to 4 locales per tenant today
+├── blog/                  per-locale markdown blog posts (optional)
+├── assets/                tenant-owned images (optional)
+└── docs/                  stakeholder + ops docs (optional; tenant-specific)
+```
+
+Six tenants are live clients: `nexa-paraguay`, `nexaparaguay`, `nexa-uruguay`, `nexa-propiedades`, `de-abasto-a-casa`, `dayah-litworks`. Everything else under `sites/` is a demo that exercises the engine.
+
+### `web/app/` — Next.js App Router
+
+Two routing patterns coexist:
+
+- **`[business]/`** — legacy flat pattern (`/gymfit-py`, `/salon-maria`). Still used by demo tenants.
+- **`s/[locale]/[siteSlug]/`** — modern locale-prefixed pattern (`/s/es/nexa-paraguay/programas`). All new tenants use this. The locale segment drives `hreflang`, copy selection, and locale-scoped sitemaps.
+
+Tenant hostnames are mapped to the modern pattern in [`middleware.ts`](./web/middleware.ts) — `nexaparaguay.com` is rewritten internally to `/s/<defaultLocale>/nexa-paraguay/…`.
+
+Administrative surfaces are under `app/admin/` (auth-gated) and `app/api/` (21 routes — see [docs/reference/API.md](./docs/reference/API.md)).
+
+### `web/components/sections/` — the section pool (83 components)
+
+Every section is a self-contained React component that accepts a typed data shape. Sections are registered in [`web/lib/engine/section-registry.ts`](./web/lib/engine/section-registry.ts) and rendered via [`web/lib/engine/renderer.tsx`](./web/lib/engine/renderer.tsx). Tenants reference sections by kebab-case id in their `pages/*.json`.
+
+Full catalog: [docs/reference/SECTIONS.md](./docs/reference/SECTIONS.md).
+
+### `web/lib/` — library modules
+
+| Subdir | Role |
+|---|---|
+| `engine/` | Composition pipeline: `site-loader` → `resolve-copy` → `resolve-site-tokens` → `site-renderer`. The heart. |
+| `supabase/` | DB clients. `server.ts`, `client.ts`, `admin.ts`, and **`scoped.ts`** (which enforces per-tenant filtering). |
+| `integrations/` | Registry-driven adapters: booking (Calendly, Cal.com), CRM (HubSpot, Pipedrive, Notion), email (Mailchimp, Resend), analytics (GA4, Plausible). |
+| `obs/` | Structured logger, request-ID / traceparent propagation, Sentry, metrics, PII redaction. ECS-aligned field names. |
+| `tokens/` | Token → CSS-variable resolver + Google Fonts URL builder. |
+| `i18n/` | Locale config + routing helpers. |
+| `leads/` | Lead dedup + enrichment (device, referrer, geo) before insert. |
+| `seo/`, `perf/` | JSON-LD builders, LCP preload, Lighthouse budgets. |
+| `security/` | DOMPurify sanitizer for any user-provided HTML. |
+| `generation/`, `outreach/`, `reminders/` | Supporting logic for page composition, outreach templates, reminder scheduling. |
+
+## 3. Request lifecycle
+
+A tenant request flows like this:
+
+```
+Request (host: nexaparaguay.com, path: /programas)
+    │
+    ▼
+middleware.ts ──► correlation id (traceparent / x-request-id)
+    │              ├─ hostname→slug rewrite
+    │              ├─ security headers (CSP et al. via next.config.mjs)
+    │              ├─ admin auth guard (if /admin/*)
+    │              └─ optional rate-limit (Upstash)
+    ▼
+app/s/[locale]/[siteSlug]/page.tsx
+    │
+    ▼
+site-loader ──► sites/nexa-paraguay/site.json
+                sites/nexa-paraguay/pages/programas.json
+                sites/nexa-paraguay/content/<locale>.json
+                src/registry/relocation.type.json          (vertical defaults)
+                src/verticals/real-estate-relocation/…
+    │
+    ▼
+resolve-copy (merge copy, fill {{placeholders}})
+resolve-site-tokens (merge base tokens + vertical tokens + tenant tokens)
+    │
+    ▼
+renderer.tsx (map section ids → React components, inject CSS vars)
+    │
+    ▼
+HTML response (+ JSON-LD, sitemap links, hreflangs)
+```
+
+Every step logs to the ECS logger with `trace.id`, `labels.business_id`, `http.method`, `url.path`. Sentry captures exceptions; metrics writes flow counters to Analytics Engine.
+
+## 4. Cross-cutting concerns
+
+### Tenant isolation
+
+- **Frontend**: every tenant route is scoped by `siteSlug` — a section that leaks into another tenant's route is a bug.
+- **Backend**: every Supabase query MUST pass through [`scopedQueries(supabase, businessId)`](./web/lib/supabase/scoped.ts). This is enforced by a dedicated test: `web/tests/unit/scoped-query-audit.test.ts`. RLS policies reinforce it at the DB layer.
+
+### Observability
+
+- **Logger**: ECS-aligned fields (`@timestamp`, `log.level`, `trace.id`, `labels.*`, `http.*`, `error.*`). Defined in `web/lib/obs/logger.ts`. Console output is pretty-printed locally, JSON in production.
+- **Tracing**: upstream W3C `traceparent` / `x-request-id` headers are honoured — correlation IDs propagate end-to-end. Fresh IDs generated only if none supplied.
+- **Context**: [AsyncLocalStorage](https://nodejs.org/api/async_context.html) in `web/lib/obs/context.ts` propagates the request context to any code called during a request, without threading it through every signature.
+- **PII**: `web/lib/obs/redact.ts` sanitises log fields with an allowlist + pattern matchers (email, JWT, bearer, card).
+- **Sentry**: initialised in `web/instrumentation.ts` (server) and `web/instrumentation-client.ts` (browser). DSN is optional — absent DSN ⇒ silent no-op.
+
+### Theming
+
+Tokens flow: `base.tokens.json` → `<vertical>.tokens.json` → `sites/<slug>/tokens.json` → CSS custom properties on `:root`. Section components use only `var(--*)` — **never** hard-coded colors. [Enforced by ESLint](./web/eslint.config.mjs).
+
+### i18n
+
+Locales are declared per-tenant in `site.json`. A tenant may support 1–4 locales today; the engine resolves copy from `sites/<slug>/content/<locale>.json` and falls back to the tenant's `defaultLocale` for missing keys. Server components read the locale from route params; client components use `NEXT_LOCALE` cookie.
+
+### Compliance
+
+Legal documents are templates under `src/compliance/` (privacy-py, terms, AML-Nexa, INAN-food, cookie-classification). A tenant opts in via its `site.json`; the copy is spliced into the privacy page at render time. `web/scripts/legal-review-gate.ts` is a pre-deploy check that every tenant ships the required docs.
+
+## 5. Architectural invariants
+
+These are the rules that should never be broken. If you find yourself tempted to violate one, stop and open an issue.
+
+1. **Every Supabase query filters by `business_id`.** Use `scopedQueries()`. No exceptions. (Enforced by `scoped-query-audit.test.ts`.)
+2. **No hardcoded colours in components.** Only `var(--primary)` / `var(--surface)` / etc. (Enforced by ESLint.)
+3. **No `console.*` in production code.** Use `logger` from `@/lib/logger` (a thin re-export of the obs logger). (Enforced by ESLint.)
+4. **No raw `<h1>/<h2>/<h3>` in sections.** Use the shared `Heading` component for consistent semantics + styling. (Enforced by ESLint.)
+5. **Server-first by default.** Client components must declare `'use client'` explicitly and should only wrap interactive leaves — not whole pages.
+6. **Tailwind stays at 3.4.19.** v4 breaks the JSON-scan step. Do not upgrade.
+7. **All API routes use `withRequestLog`.** It wires the logger, ALS context, and perf tracker. Never hand-roll.
+8. **Errors are logged and re-thrown or returned as structured errors.** Never silently caught. (See [CLAUDE.md › Error Handling](./CLAUDE.md#error-handling-mandatory).)
+9. **All generated-site UI text is Spanish.** The builder admin UI is English; tenant-facing content is per-tenant locale configuration.
+
+## 6. Boundaries
+
+- **`src/` vs `sites/`**: `src/` is tenant-agnostic. If something varies per-tenant, it belongs under `sites/`, not in `src/`.
+- **`web/lib/engine/` vs `web/components/sections/`**: the engine composes; sections render. Sections never import from `engine/` except for types.
+- **Integration adapters (`web/lib/integrations/`)**: all outbound third-party calls go through an adapter. Routes call adapters; they never import third-party SDKs directly.
+- **Schema validation at boundaries only**: Zod validates user input (form bodies, API payloads) and external responses. Internal code trusts its types.
+
+## 7. Deployment topology
+
+- Production: single Cloudflare Worker (global edge).
+- Database: one Supabase project, shared across tenants, isolated by `business_id` + RLS.
+- Assets: per-tenant images in `sites/<slug>/assets/` (checked into Git today; TODO: move to Supabase Storage or R2 for scale).
+- CI/CD: GitHub Actions → build with OpenNext → publish to Cloudflare.
+
+## 8. What this architecture does NOT do (yet)
+
+- **Tenant self-service.** Adding a tenant is a developer task today. An admin UI to add tenants without code exists in skeletal form under `app/admin/`; not feature-complete.
+- **Asset CDN per tenant.** Assets are currently bundled with the Worker.
+- **Per-tenant database.** Everything is shared schema + `business_id`. A schema-per-tenant or DB-per-tenant model is not needed yet and not planned.
+- **Plugin system.** New section types require code. Sections are a finite, curated pool, not a plugin API.
+
+---
+
+_Keep this document short (≤500 lines). When a topic grows, split it into its own file under `docs/explanation/`._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,174 @@
+# Contributing
+
+Thanks for working on Paragu AI Builder. This doc covers the day-to-day workflow: how we branch, commit, open PRs, and gate merges. For system concepts see [ARCHITECTURE.md](./ARCHITECTURE.md); for agent-specific instructions see [CLAUDE.md](./CLAUDE.md).
+
+## Setup
+
+```bash
+git clone https://github.com/Ai-Whisperers/paragu-ai-builder.git
+cd paragu-ai-builder/web
+npm install
+cp .env.example .env.local    # fill in Supabase + integration keys
+npm run dev                   # http://localhost:3000
+```
+
+Node 20+ required. We deploy on Cloudflare Workers; the dev server uses the Next.js Node runtime.
+
+## Branch naming
+
+| Prefix | Use for | Example |
+|---|---|---|
+| `feat/` | new feature | `feat/subscription-pause-portal` |
+| `fix/` | bug fix | `fix/middleware-csp-google-fonts` |
+| `docs/` | docs-only | `docs/canonical-north-star-set` |
+| `chore/` | tooling, refactor, cleanup | `chore/ops-scripts` |
+| `refactor/` | non-behavioural change | `refactor/extract-site-loader` |
+| `test/` | tests only | `test/scoped-query-audit` |
+| `wip/` | work-in-progress backup | `wip/apr-20-snapshot` |
+
+One branch = one focused change. If you find yourself scope-creeping, open a second branch.
+
+## Commit messages
+
+We follow **Conventional Commits**. The commit linter is in `commitlint.config.js`.
+
+```
+<type>(<scope>): <short summary>
+
+<body — optional, wrap at 72 cols>
+
+<footer — optional, e.g. "Closes #123">
+```
+
+Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `perf`, `build`, `ci`.
+
+Scope is optional but helpful for large areas: `engine`, `api`, `sites`, `middleware`, `obs`, `compliance`.
+
+Messages focus on **why**, not what. The diff shows what.
+
+## Pull requests
+
+1. **Rebase on `Main` before opening.** We squash-merge, so linear history matters.
+2. **Use the [PR template](./.github/pull_request_template.md).**
+3. **Keep PRs small.** If it's >500 lines of non-test code, split it unless you can justify the bundle.
+4. **Declare dependencies.** If PR B needs PR A merged first, say so at the top of the description.
+5. **Reference issues.** `Closes #123` / `Refs #456` / `Follow-up to #789`.
+6. **No auto-merge.** Every PR waits for review. `docs/*` and `chore/*` PRs can self-approve if trivial.
+7. **Drafts are fine.** Open early with `[WIP]` in the title if you want feedback before it's ready.
+
+## Quality gates
+
+All of these run in CI (`.github/workflows/ci.yml`) and must pass before merge:
+
+| Gate | Command | Threshold |
+|---|---|---|
+| Typecheck | `npm run typecheck` | zero errors |
+| Lint | `npm run lint` | zero errors |
+| Unit tests | `npm test` | all pass |
+| Integration tests | `npm run test:integration` | all pass |
+| Coverage | `npm run test:coverage` | ≥ configured (see `vitest.config.ts`) |
+| E2E (on `main` merge) | `npm run test:e2e` | all pass |
+| A11y (on PR) | `npx tsx web/scripts/a11y-audit.ts` | no new issues |
+| Lighthouse (on PR) | `lhci autorun` | meets `lighthouserc.json` budgets |
+
+Run the local gauntlet before pushing:
+
+```bash
+cd web
+npm run typecheck && npm run lint && npm test
+```
+
+## Pre-commit hooks
+
+Husky runs lint-staged + typecheck on every commit (`.husky/pre-commit`). Don't bypass with `--no-verify` unless truly necessary; investigate the failure instead.
+
+If a pre-commit hook fails, the commit **did not happen** — fix the issue, re-stage, and commit again. Do not `--amend` a non-existent commit.
+
+## Testing patterns
+
+- **Unit tests** live next to or under `web/tests/unit/` mirroring the module path. Use Vitest + `@testing-library/react`.
+- **Integration tests** hit real subsystems (the loader reads real tenant JSON from disk). See `web/tests/integration/`.
+- **E2E tests** drive a browser via Playwright. See `web/tests/e2e/`. Keep them smoke-scoped — visual regression is separate.
+- **Do NOT mock Supabase in tests that exercise the scoped-query boundary.** Use the integration layer or a real test project.
+- **The `scoped-query-audit` test is the load-bearing one.** It enforces that every tenant-table query goes through `scopedQueries()`. Don't weaken it.
+
+## Adding sections
+
+Every new section:
+
+1. Lives at `web/components/sections/<kebab-name>-section.tsx`.
+2. Exports a typed Props interface.
+3. Uses only `var(--*)` tokens for colors. Typography via the shared `Heading` + `Text` components.
+4. Is imported and registered in `web/lib/engine/renderer.tsx` under the kebab-case key.
+5. Is added to [`docs/reference/SECTIONS.md`](./docs/reference/SECTIONS.md) with a one-line description + intended category.
+6. Has at least a snapshot test if stateless, or component test if interactive.
+
+## Adding tenants
+
+See [docs/how-to/add-tenant.md](./docs/how-to/add-tenant.md) _(planned — for now, copy an existing tenant under `sites/` and adapt)_.
+
+The short version:
+
+```
+sites/<slug>/
+├── site.json      # hostname, locales, integrations, defaultLocale
+├── tokens.json    # optional brand-colour overrides
+├── pages/         # at minimum home.json
+└── content/       # at minimum <defaultLocale>.json
+```
+
+Validate with `npx tsx web/scripts/validate-sites.ts` before opening a PR.
+
+## Adding business types
+
+See [web/docs/ADDING_BUSINESS_TYPES.md](./web/docs/ADDING_BUSINESS_TYPES.md). Short version:
+
+1. `src/registry/<type>.type.json` — section list, SEO config, default features
+2. `src/tokens/<type>.tokens.json` — optional colour overrides (usually inherit base)
+3. `src/content/<type>.content.json` — Spanish copy templates with `{{placeholders}}`
+4. Update `src/verticals/<vertical>/vertical.json` if it belongs to a new vertical.
+
+## Observability conventions
+
+- Use the logger, not `console.*`. ESLint will catch it.
+- Log at `info` for normal successful operations, `warn` for recoverable/expected failures, `error` for bugs.
+- Use ECS field names: `trace.id`, `labels.business_id`, `http.method`, `url.path`, `error.message`, `error.stack`.
+- Never log raw tokens, PII, or request bodies without running them through `redact()`.
+
+See [ARCHITECTURE.md › Observability](./ARCHITECTURE.md#observability) for details.
+
+## Documentation
+
+When your change affects how the system is used, update the relevant doc in the same PR. See [docs/README.md](./docs/README.md) for the layout.
+
+New docs should fit the Diataxis framework:
+- **Tutorial** (learn by doing): `docs/tutorials/`
+- **How-to** (task-focused): `docs/how-to/`
+- **Reference** (factual lookup): `docs/reference/`
+- **Explanation** (conceptual): `docs/explanation/`
+
+Status/progress/completion notes belong in the PR description or [CHANGELOG.md](./CHANGELOG.md) _(planned)_, not as new markdown files.
+
+## Security
+
+- Never commit `.env*`, keys, tokens, or credentials.
+- Report vulnerabilities privately to the maintainers per [SECURITY.md](./SECURITY.md) _(planned)_.
+- Fix, don't bypass. If `npm audit` reports high/critical, resolve before merging.
+
+## Common pitfalls
+
+- **Forgetting `scopedQueries()`.** → `scoped-query-audit.test.ts` will fail.
+- **Importing from `@/components/sections/*` into engine code.** → circular, breaks build.
+- **Hardcoding colors.** → ESLint error.
+- **Using `<h1>/<h2>/<h3>` in sections directly.** → ESLint error; use `Heading`.
+- **Upgrading Tailwind to v4.** → build breaks on JSON scan. Pinned at 3.4.19.
+
+## Who to ask
+
+- Product / tenants / clients: Nyx (repo owner).
+- Architecture / engine: read [ARCHITECTURE.md](./ARCHITECTURE.md) first, then ask in PR.
+- Ops / deploy: see `docs/03_ARCHITECTURE/DEPLOYMENT.md` and `CLOUDFLARE_DEPLOY.md`.
+
+---
+
+_Last reviewed: April 2026._

--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+# Paragu AI Builder
+
+A **multi-tenant marketing-site generator**. Ships a single Next.js 15 + Supabase + Cloudflare Workers app that renders a library of reusable section components against per-tenant JSON configuration — so new sites are _configured_, not _built_.
+
+```
+[ tenant JSON ]  +  [ vertical copy ]  +  [ design tokens ]
+        ─────────────────────────────────────────────────►
+                          composition engine
+                                  │
+                                  ▼
+                      React sections (shared pool)
+                                  │
+                                  ▼
+                Static HTML / Edge-rendered route
+```
+
+## Live tenants
+
+| Tenant | Slug | Vertical | Hostname | Locales |
+|---|---|---|---|---|
+| Nexa Paraguay | `nexa-paraguay` | relocation | nexaparaguay.com | nl · en · de · es |
+| Nexa Paraguay (ES landing) | `nexaparaguay` | relocation | nexaparaguay.com | es |
+| Nexa Uruguay | `nexa-uruguay` | relocation | nexauruguay.com | en · es |
+| Nexa Propiedades | `nexa-propiedades` | real-estate | nexapropiedades.com | es · en · pt |
+| De Abasto a Casa | `de-abasto-a-casa` | meal-prep | deabastoacasa.com.py | es |
+| Dayah Litworks | `dayah-litworks` | portfolio (design) | dayah-litworks.com | es |
+
+Demo tenants (salon-maria, gymfit-py, spa-serenidad, etc.) live alongside real tenants under `sites/` to exercise the engine across verticals.
+
+## Start here
+
+- **New to the repo?** → [ARCHITECTURE.md](./ARCHITECTURE.md) (the 5-minute system tour)
+- **Contributing code?** → [CONTRIBUTING.md](./CONTRIBUTING.md) (branch, commit, PR, quality gates)
+- **Looking for something specific?** → [docs/README.md](./docs/README.md) (docs hub — every reference, how-to, and explainer)
+- **Adding a new tenant?** → [docs/how-to/add-tenant.md](./docs/how-to/add-tenant.md) _(planned — see [consolidation plan](./docs/DOCS_CONSOLIDATION_PLAN.md))_
+- **AI-agent-oriented context?** → [CLAUDE.md](./CLAUDE.md) (the instructions LLMs read)
+
+## Quick start
+
+```bash
+git clone https://github.com/Ai-Whisperers/paragu-ai-builder.git
+cd paragu-ai-builder/web
+npm install
+cp .env.example .env.local    # fill Supabase, integration keys
+npm run dev                    # http://localhost:3000
+```
+
+Then open:
+- `/` — builder landing
+- `/s/es/nexa-paraguay` — a tenant rendered via locale-prefixed route
+- `/admin/leads` — admin dashboard (auth required)
+
+## Tech stack
+
+| Layer | Choice |
+|---|---|
+| Framework | Next.js 15 (App Router) |
+| Language | TypeScript 5.x |
+| Styling | Tailwind **3.4.19** (do not upgrade to v4 — see [warnings](./CLAUDE.md#critical-warnings)) |
+| Database | Supabase (Postgres + RLS) |
+| Edge | Cloudflare Workers via `@opennextjs/cloudflare` |
+| Observability | Structured logger (ECS-aligned) + Sentry + Cloudflare Analytics Engine |
+| Testing | Vitest (unit + integration) + Playwright (e2e + visual) |
+| CI | GitHub Actions: lint, typecheck, test, Lighthouse, a11y |
+
+## Repository map
+
+```
+src/                  Data layer (JSON — tenant-agnostic)
+  schemas/              JSON schemas (base + per-business-type)
+  tokens/               Design tokens (base + per-vertical)
+  registry/             Business-type definitions
+  verticals/            Vertical catalogs (relocation, food-beverage, …)
+  content/              Content templates with {{placeholders}}
+  compliance/           Legal templates (privacy, ToS, AML, INAN)
+
+sites/                Tenant layer (one dir per tenant)
+  <slug>/
+    site.json             hostname, locales, integrations
+    tokens.json           brand-colour overrides
+    pages/*.json          page-by-page section lists
+    content/<locale>.json per-locale copy overrides
+
+web/                  Application layer (Next.js)
+  app/                    App Router
+    [business]/             flat-pattern legacy tenant routes
+    s/[locale]/[siteSlug]/  locale-prefixed modern tenant routes
+    admin/                  protected dashboard
+    api/                    21 REST routes
+  components/
+    sections/               83 reusable section components
+    ui/                     primitives (Button, Card, Badge via CVA)
+  lib/
+    engine/                 composition pipeline
+    supabase/               DB clients (server / client / admin / scoped)
+    integrations/           booking · crm · email · analytics adapters
+    obs/                    logger · tracer · metrics · sentry
+    tokens/                 token → CSS var resolver
+    i18n/                   locale config + routing
+  tests/                  unit · integration · e2e · a11y
+  scripts/                ops toolbox (see web/scripts/)
+
+docs/                 Long-form documentation (see docs/README.md)
+```
+
+## License
+
+See [LICENSE](./LICENSE) _(to be added — currently inherited from parent org)_.
+
+---
+
+_Last reviewed: April 2026. Keep this file at ≤200 lines; long-form belongs in `docs/`._

--- a/docs/DOCS_CONSOLIDATION_PLAN.md
+++ b/docs/DOCS_CONSOLIDATION_PLAN.md
@@ -1,0 +1,304 @@
+# Docs Consolidation Plan
+
+An inventory of all 141 markdown files in the repo (April 2026 audit) with a proposed target location under the [Diataxis](https://diataxis.fr/) hierarchy described in [`docs/README.md`](./README.md).
+
+**This is a plan, not the execution.** Nothing moves until a follow-up PR implements each section below. The plan lives in the repo so the migration can be completed incrementally without losing track.
+
+The goal is to go from **141 scattered files → ~40 canonical docs** under clear Diataxis headings, with the rest archived (not deleted).
+
+---
+
+## Principles
+
+1. **Archive over delete.** Completed plans, status snapshots, one-time reports all move to `docs/archive/YYYY-MM/`. Nothing is lost.
+2. **Status → git/CHANGELOG.** Anything titled `*_COMPLETE`, `*_SUMMARY`, `WINS_*`, `DEPLOY_STATUS` belongs in a CHANGELOG entry or PR description, not the repo.
+3. **Merge duplicates.** Where 2–4 docs cover the same topic from different angles, one canonical doc wins.
+4. **Move tenant-specific to `sites/<slug>/docs/`.** Per-client planning artifacts (e.g. Laura egg farm) move to the tenant directory or an external CRM.
+5. **Keep root clean.** Only the canonical set at repo root: `README`, `CONTRIBUTING`, `ARCHITECTURE`, `CHANGELOG`, `SECURITY`, `CODE_OF_CONDUCT`, `LICENSE`, `CLAUDE`, `AGENTS`.
+
+---
+
+## Proposed end state
+
+```
+/                                    ≤ 9 canonical files
+  README.md            ✓ (added this PR)
+  ARCHITECTURE.md      ✓ (added this PR)
+  CONTRIBUTING.md      ✓ (added this PR)
+  CLAUDE.md            (keep — agent instructions)
+  AGENTS.md            (keep — agent config)
+  CHANGELOG.md         (add — rolling change log)
+  SECURITY.md          (add — vulnerability reporting)
+  CODE_OF_CONDUCT.md   (add)
+  LICENSE              (add)
+
+docs/
+  README.md                          ✓ (rewritten this PR)
+  DOCS_CONSOLIDATION_PLAN.md         ✓ (this file)
+
+  tutorials/
+    first-tenant-site.md             (new — guided walk-through)
+
+  how-to/
+    add-tenant.md                    (merge: existing per-tenant notes)
+    add-business-type.md             (keep: web/docs/ADDING_BUSINESS_TYPES.md link)
+    deploy.md                        (MERGE: QUICK_DEPLOY + CLOUDFLARE_DEPLOY + HOSTINGER_CLOUDFLARE_SETUP + DEPLOY_STATUS + docs/03_ARCHITECTURE/DEPLOYMENT.md)
+    run-tests.md                     (keep: web/docs/TESTING.md link)
+    generate-images.md               (merge: GEMINI_*.md)
+    set-up-github-projects.md        (keep: 04_IMPLEMENTATION/GITHUB_PROJECTS_SETUP.md)
+
+  reference/
+    SECTIONS.md                      ✓ (added this PR)
+    BUSINESS_TYPES.md                ✓ (added this PR)
+    API.md                           ✓ (added this PR)
+    TENANTS.md                       (move: docs/03_ARCHITECTURE/TENANTS.md + refresh)
+    TOKENS.md                        (move: web/docs/TOKEN_SYSTEM.md)
+    ENV_VARS.md                      (new — from web/lib/env.ts schema)
+
+  explanation/
+    multi-tenancy.md                 (new — how isolation actually works end-to-end)
+    composition-pipeline.md          (new — site.json → HTML)
+    theming.md                       (new — tokens → CSS variables)
+    why-next-15-cf-workers.md        (new — architectural rationale)
+
+  observability/
+    logging.md                       (move: docs/03_ARCHITECTURE/OBSERVABILITY.md + split)
+    tracing.md                       (split from above)
+    metrics.md                       (split from above)
+
+  runbooks/
+    _placeholder.md                  (one file per pageable alert, added as alerts are defined)
+
+  archive/
+    2026-04/                         (one-time dump of completion/summary docs)
+
+  legacy/                            (existing 01–08 structure preserved until migrated)
+    01_BUSINESS_MODEL/                 → keep as-is, link from README
+    02_STRATEGY/                       → keep current; archive done plans
+    03_ARCHITECTURE/                   → source docs for new reference/explanation
+    04_IMPLEMENTATION/                 → each → how-to/
+    05_RESEARCH/                       → keep as research archive
+    06_REFERENCE/                      → split: refs → reference/, status → archive/
+    08_CLIENTS/                        → move to sites/<slug>/docs/ or CRM
+
+web/docs/                            application-specific keeps its own nested docs
+  README.md                          (add: index for dev docs)
+  ADDING_BUSINESS_TYPES.md           (keep)
+  ADMIN_GUIDE.md                     (keep)
+  API_ENDPOINTS.md                   (merge: → docs/reference/API.md)
+  COMPONENT_LIBRARY.md               (merge: → docs/reference/SECTIONS.md, keep a slim index here)
+  DEPLOYMENT_CHECKLIST.md            (keep — dev-facing checklist distinct from how-to/deploy)
+  TESTING.md, TESTING_PATTERNS.md    (keep both)
+  TOKEN_SYSTEM.md                    (move: → docs/reference/TOKENS.md)
+  TROUBLESHOOTING.md                 (keep — dev-facing)
+  VS_CODE_SNIPPETS.md                (keep — dev-facing)
+
+sites/<slug>/docs/                   per-tenant, no changes needed
+```
+
+---
+
+## Per-file disposition (141 files)
+
+### Root-level (16 files)
+
+| File | Current status | Target |
+|---|---|---|
+| `README.md` | — | **Rewritten ✓ (this PR)** |
+| `CLAUDE.md` | current | Keep at root |
+| `AGENTS.md` | current | Keep at root |
+| `CLIENTS_TENANTS.md` | current | Review → merge into `docs/reference/BUSINESS_TYPES.md` (this PR consolidates the tenant section there) |
+| `PROMPTS.md` | current | Move → `docs/legacy/prompts.md` (not part of Diataxis) |
+| `QUICK_COMMANDS.md` | current | Move → `docs/reference/cli-commands.md` |
+| `QUICK_DEPLOY.md` | current | Merge → `docs/how-to/deploy.md` |
+| `CLOUDFLARE_DEPLOY.md` | current | Merge → `docs/how-to/deploy.md` |
+| `HOSTINGER_CLOUDFLARE_SETUP.md` | current | Merge → `docs/how-to/deploy.md` (DNS section) |
+| `DEPLOY_STATUS.md` | historical | Archive → `docs/archive/2026-04/` |
+| `DISABLE_PAGES_BUILD.md` | draft workaround | Archive or delete (verify still needed) |
+| `BUNDLE_OPTIMIZATION.md` | historical | Archive → `docs/archive/2026-04/` |
+| `IMAGES_START_HERE.md` | current | Move → `docs/how-to/generate-images.md` (merge with GEMINI docs) |
+| `IMPLEMENTATION_SUMMARY.md` | current | **Archive** → `docs/archive/2026-04/` (status report, belongs in CHANGELOG) |
+| `IMPLEMENTATION_COMPLETE.md` | current | **Archive** → `docs/archive/2026-04/` (duplicate of above) |
+| `TRANSFORMATION_SUMMARY.md` | current | **Archive** → `docs/archive/2026-04/` |
+| `WINS_76_100_SUMMARY.md` | historical | **Archive** → `docs/archive/2026-04/` |
+
+### `docs/01_BUSINESS_MODEL/` (7 files) — **keep as-is**, link from README
+
+Cohesive set, no duplicates. Value proposition, targeting, pricing, tiers, bundles, acquisition, operations. These are business-strategy docs, not technical — they are their own target.
+
+### `docs/02_STRATEGY/` (13 files) — keep current, archive completed plans
+
+| File | Target |
+|---|---|
+| `100_EASY_WINS.md` | Merge with `100_WINS_COMPLETE.md` → `docs/legacy/100_wins.md` or CHANGELOG |
+| `100_WINS_COMPLETE.md` | Merge (above) |
+| `20_DOLLAR_BEST_VALUE.md` | Archive (pricing analysis; superseded by 01_BUSINESS_MODEL/03_PRICING_MODEL.md) |
+| `ADDITIONAL_FEATURES_ROADMAP.md` | Keep — roadmap is live |
+| `BUSINESS_ANALYSIS_COMPLETE.md` | Archive (point-in-time audit) |
+| `COMPLETE_REMEDIATION_PLAN.md` | Archive if executed (1,896 lines of a completed 6-week plan) |
+| `EPIC_PLAN.md` | Keep — backlog |
+| `EPIC_PLANNING_SUMMARY.md` | Merge into `EPIC_PLAN.md` intro |
+| `FEATURE_GAP_ANALYSIS.md` | Archive (historical analysis) |
+| `HOMEPAGE_IMPROVEMENT_PLAN.md` | Archive (completed) |
+| `REAL_CLIENTS_ROADMAP.md` | Keep — client pipeline |
+| `RESTAURANT_TEMPLATE_PLAN.md` | Keep — template roadmap |
+| `STRATEGY_NEXT_STEPS.md` | Review; merge into `ADDITIONAL_FEATURES_ROADMAP.md` |
+
+### `docs/03_ARCHITECTURE/` (8 files) — mine for new reference/explanation docs
+
+| File | Target |
+|---|---|
+| `DEPLOYMENT.md` | Merge → `docs/how-to/deploy.md` |
+| `OBSERVABILITY.md` | Split → `docs/observability/{logging,tracing,metrics}.md` |
+| `SUPABASE_OPTIMIZATION_REPORT.md` | Keep (analysis; rename → `docs/explanation/supabase-connection-pool.md`) |
+| `SUPABASE_OPTIMIZATION_COMPLETE.md` | Archive (implementation done; fold key takeaways into above) |
+| `TENANTS.md` | Expand → `docs/reference/TENANTS.md` + `docs/explanation/multi-tenancy.md` |
+| `TENANTS_STATUS_AND_IMAGE_REQUIREMENTS.md` | Split — status part to archive, image-requirements to `docs/how-to/generate-images.md` |
+| `UNIVERSAL_COMPONENTS.md` | Merge into `docs/reference/SECTIONS.md` (as the "primitives" appendix) |
+| `UNIVERSAL_COMPONENTS_SUMMARY.md` | Archive (summary of above) |
+
+### `docs/04_IMPLEMENTATION/` (8 files) — each → `docs/how-to/`
+
+| File | Target |
+|---|---|
+| `API_GENERATION_GUIDE.md` | Review — if still relevant, → `docs/how-to/generate-apis.md` |
+| `GEMINI_IMAGE_GENERATION_GUIDE.md` | Merge → `docs/how-to/generate-images.md` |
+| `GEMINI_TO_DRIVE_WORKFLOW.md` | Merge → `docs/how-to/generate-images.md` |
+| `GEMINI_USAGE_GUIDE.md` | Merge → `docs/how-to/generate-images.md` |
+| `GITHUB_PROJECTS_SETUP.md` | → `docs/how-to/set-up-github-projects.md` |
+| `IMAGE_PROMPTS_QUICK_REFERENCE.md` | → `docs/reference/image-prompts.md` |
+| `IMPLEMENTATION_CHECKLIST.md` | Archive (point-in-time tracker) |
+| `IMPLEMENTATION_COMPLETE_SUMMARY.md` | Archive |
+
+### `docs/05_RESEARCH/` (7 files) — keep as research archive, no movement
+
+Taxonomies, competitor scrapes, analysis. Historical-but-useful. Add a `docs/05_RESEARCH/README.md` index if missing.
+
+### `docs/06_REFERENCE/` (18 files) — split: refs → `reference/`, status → `archive/`
+
+| File | Target |
+|---|---|
+| `README.md` | Keep as legacy index |
+| `AI_BUG_HUNTING_GUIDE.md` | Keep in this folder (agent-facing) |
+| `AI_SELF_CONFIGURATION.md` | Keep |
+| `BUG_HUNT_REPORT_2026-04-20.md` | Archive → `docs/archive/2026-04/` |
+| `COMMIT_STRATEGY.md` | Merge into `CONTRIBUTING.md` |
+| `COMPREHENSIVE_AUDIT_REPORT.md` | Archive (completed audit) |
+| `CRITICAL_FIXES_QUICK_REFERENCE.md` | Archive (point-in-time) |
+| `DEBUGGING.md` | Move → `docs/how-to/debug.md` |
+| `IMPROVEMENT_DOCUMENTATION_SUMMARY.md` | Archive |
+| `PREMIUM_QUALITY_GUIDE.md` | Merge into `CONTRIBUTING.md` (quality standards section) |
+| `PROJECT_STATUS_SUMMARY.md` | Archive |
+| `PROJECT_TRANSFORMATION_COMPLETE.md` | Archive |
+| `QUICK_REFERENCE.md` | Move → `docs/reference/cli-commands.md` |
+| `SECURITY_REMEDIATION_COMPLETE.md` | Archive (completed); summarize into `SECURITY.md` |
+| `UXUI_BEAUTIFICATION.md` | Merge into new `docs/explanation/design-system.md` |
+| `UXUI_IMPLEMENTATION_SUMMARY.md` | Archive |
+| `UX_UI_REDESIGN_PLAN.md` | Archive (completed) |
+
+### `docs/08_CLIENTS/` (4 files) — move to tenant dir
+
+| File | Target |
+|---|---|
+| `LAURA_EGG_FARM_WEBSITE_PLAN.md` | Move → `sites/laura-egg-farm/docs/plan.md` (once the tenant exists) OR external CRM |
+| `LAURA_FEATURES_ROADMAP.md` | Move (same) |
+| `LAURA_QUESTIONNAIRE.md` | Move (same) |
+| `LAURA_QUESTIONNAIRE_SUMMARY.md` | Merge into the questionnaire |
+
+### Business model questionnaires (top-level)
+
+| File | Target |
+|---|---|
+| `BUSINESS_MODEL_QUESTIONNAIRE.md` | Archive (shorter variant superseded) |
+| `BUSINESS_MODEL_QUESTIONNAIRE_ENHANCED.md` | Keep as the canonical — rename → `docs/legacy/business-model-questionnaire.md` |
+| `BUSINESS_MODEL_SIMPLE.md` | Archive |
+| `BUSINESS_MODEL_QUESTIONNAIRE_BASE.md` | Merge into enhanced |
+| `PRICING_STRATEGY_INCOME_BASED.md` | Keep → `docs/01_BUSINESS_MODEL/08_PRICING_STRATEGY_INCOME_BASED.md` |
+
+### `sites/*/docs/` (9 files) — **keep as-is**
+
+Per-tenant stakeholder docs. Already in the right place. `sites/nexa-paraguay/docs/STAKEHOLDER-QA.md` etc. Verify `sites/nexa-uruguay/docs/SPIKE.md` is still relevant.
+
+### `web/docs/` (10 files) — mostly keep; cross-link to canonical
+
+| File | Target |
+|---|---|
+| `ADDING_BUSINESS_TYPES.md` | Keep — dev-facing runbook |
+| `ADMIN_GUIDE.md` | Keep |
+| `API_ENDPOINTS.md` | Deprecate → point to `docs/reference/API.md` |
+| `COMPONENT_LIBRARY.md` | Deprecate → point to `docs/reference/SECTIONS.md` |
+| `DEPLOYMENT_CHECKLIST.md` | Keep — dev-facing pre-deploy checklist |
+| `TESTING.md` | Keep |
+| `TESTING_PATTERNS.md` | Keep |
+| `TOKEN_SYSTEM.md` | Move → `docs/reference/TOKENS.md` |
+| `TROUBLESHOOTING.md` | Keep — dev-facing |
+| `VS_CODE_SNIPPETS.md` | Keep — dev-facing |
+
+### `src/compliance/` (4 templates) — **leave alone**
+
+These aren't docs, they're data — legal templates that get spliced into tenant pages at render time. Keep where they are.
+
+### `.firecrawl/` (10 files) — move out of repo root
+
+Raw web scrapes used for research. Options:
+1. Move → `docs/archive/firecrawl-scrapes/` (keeps history)
+2. Add to `.gitignore` and rely on external research tooling to regenerate
+
+Recommendation: **option 1** for the ones actively referenced by docs (sushi-feature-analysis), **option 2** for one-off scrapes.
+
+### `.agents/` (2 files), `.github/` (1 file) — **leave alone**
+
+Infrastructure; not user-facing docs.
+
+---
+
+## Migration sequencing
+
+Don't try to do this all at once. Proposed phases:
+
+**Phase A (this PR)** — Canonical foundation:
+- ✓ Root `README`, `ARCHITECTURE`, `CONTRIBUTING`
+- ✓ `docs/README.md` (hub)
+- ✓ `docs/reference/SECTIONS.md`, `BUSINESS_TYPES.md`, `API.md`
+- ✓ `docs/DOCS_CONSOLIDATION_PLAN.md` (this file)
+
+**Phase B** — High-value consolidations:
+- Create `docs/how-to/deploy.md` merging the 4 deploy docs
+- Create `docs/archive/2026-04/` and move the 10 status/completion docs
+- Split `03_ARCHITECTURE/OBSERVABILITY.md` into `docs/observability/{logging,tracing,metrics}.md`
+
+**Phase C** — Reference completion:
+- Move `03_ARCHITECTURE/TENANTS.md` → `docs/reference/TENANTS.md` + expand `docs/explanation/multi-tenancy.md`
+- Move `web/docs/TOKEN_SYSTEM.md` → `docs/reference/TOKENS.md`
+- Generate `docs/reference/ENV_VARS.md` from `web/lib/env.ts`
+
+**Phase D** — How-to harvest:
+- Consolidate 4 GEMINI docs → `docs/how-to/generate-images.md`
+- Move `04_IMPLEMENTATION/*` to `docs/how-to/`
+
+**Phase E** — Cleanup:
+- Archive questionnaire duplicates
+- Move Laura client docs to tenant dir
+- Move `.firecrawl/` out of root
+- Delete the `docs/legacy/` pointer when the legacy folder is empty
+
+**Phase F** — Add what's missing:
+- `CHANGELOG.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `LICENSE`
+- `docs/tutorials/first-tenant-site.md`
+- First `docs/runbooks/<alert>.md` as alerts are defined
+- Adopt `next-openapi-gen` and auto-generate `docs/reference/api-spec.json`
+
+Each phase is a standalone PR. None should be bundled.
+
+---
+
+## What NOT to do
+
+- **Don't delete anything yet.** Everything is preserved either in a canonical location or under `docs/archive/`. Deletion is a separate later decision.
+- **Don't break cross-links.** When moving a doc, leave a stub behind pointing to the new location, or update all referring docs in the same PR.
+- **Don't create new root-level `.md` files.** If it's a new status report, put it in the PR description. If it's reference, put it under `docs/reference/`.
+- **Don't introduce 5th "audit" or "transformation" doc.** Existing ones already cover it; update them instead.
+
+---
+
+_Consolidation plan last reviewed: April 2026. Updates: open a PR against this file whenever a phase is executed, so we can tick off what's done._

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,203 +1,121 @@
-# 📚 Documentation Index
+# Documentation Hub
 
-> Complete guide to all project documentation  
-> Last Updated: April 20, 2026
+This is the documentation index. Docs are organised by **audience and intent**, following the [Diataxis framework](https://diataxis.fr/):
 
----
+- **Tutorials** — guided learning. "Walk me through X for the first time."
+- **How-to** — task recipes. "I know what I want; how do I do it?"
+- **Reference** — factual lookup. "What sections exist? What does this config field mean?"
+- **Explanation** — conceptual understanding. "Why is the system built this way?"
 
-## 🚀 START HERE
+The repo today has 141 markdown files — many predating this structure. The [docs consolidation plan](./DOCS_CONSOLIDATION_PLAN.md) maps each legacy doc to its target home. Until that migration is complete, both this canonical layout and the legacy numbered folders (`docs/01_BUSINESS_MODEL/` … `docs/08_CLIENTS/`) coexist.
 
-| Document | Purpose | Audience |
-|----------|---------|----------|
-| [PROJECT_TRANSFORMATION_COMPLETE.md](./PROJECT_TRANSFORMATION_COMPLETE.md) | Summary of all changes | Everyone |
-| [QUICK_REFERENCE.md](./QUICK_REFERENCE.md) | Quick commands & links | Developers |
-| [README.md](../README.md) | Project overview | New team members |
+## Start here
 
----
+| If you are… | Read first |
+|---|---|
+| New to the repo | [/README.md](../README.md) → [/ARCHITECTURE.md](../ARCHITECTURE.md) |
+| Contributing code | [/CONTRIBUTING.md](../CONTRIBUTING.md) |
+| An AI agent working here | [/CLAUDE.md](../CLAUDE.md) + [/AGENTS.md](../AGENTS.md) |
+| Onboarding a new tenant | [how-to/add-tenant.md](./how-to/add-tenant.md) _(planned)_ |
+| Onboarding a new business type | [/web/docs/ADDING_BUSINESS_TYPES.md](../web/docs/ADDING_BUSINESS_TYPES.md) |
+| Looking up an API route | [reference/API.md](./reference/API.md) |
+| Looking up a section component | [reference/SECTIONS.md](./reference/SECTIONS.md) |
+| Looking up a business type or tenant | [reference/BUSINESS_TYPES.md](./reference/BUSINESS_TYPES.md) |
+| Shipping to production | `03_ARCHITECTURE/DEPLOYMENT.md`, `/CLOUDFLARE_DEPLOY.md` _(legacy — will collapse into `how-to/deploy.md`)_ |
+| Investigating an incident | [/ARCHITECTURE.md § Observability](../ARCHITECTURE.md#observability) + `03_ARCHITECTURE/OBSERVABILITY.md` |
 
-## 🚨 Security & Remediation
+## Canonical layout (target)
 
-### Critical (Must Read)
-| Document | Description | Priority |
-|----------|-------------|----------|
-| [COMPREHENSIVE_AUDIT_REPORT.md](./COMPREHENSIVE_AUDIT_REPORT.md) | Full security audit with 25 issues | 🔴 CRITICAL |
-| [CRITICAL_FIXES_QUICK_REFERENCE.md](./CRITICAL_FIXES_QUICK_REFERENCE.md) | Copy-paste fixes for security issues | 🔴 CRITICAL |
-| [COMPLETE_REMEDIATION_PLAN.md](./COMPLETE_REMEDIATION_PLAN.md) | 6-week plan to fix everything | 🔴 CRITICAL |
-| [SECURITY_REMEDIATION_COMPLETE.md](./SECURITY_REMEDIATION_COMPLETE.md) | What was fixed today | 🔴 CRITICAL |
-| [IMPLEMENTATION_CHECKLIST.md](./IMPLEMENTATION_CHECKLIST.md) | Daily task tracker | 🟠 HIGH |
+```
+docs/
+├── README.md                         (this file)
+├── DOCS_CONSOLIDATION_PLAN.md        (migration roadmap for the 141 legacy docs)
+│
+├── tutorials/                         step-by-step learning
+│   └── first-tenant-site.md          (planned)
+│
+├── how-to/                           task recipes
+│   ├── add-tenant.md                 (planned)
+│   ├── add-business-type.md          (→ web/docs/ADDING_BUSINESS_TYPES.md)
+│   ├── deploy.md                     (planned — merges 4 legacy deploy docs)
+│   └── run-tests.md                  (→ web/docs/TESTING.md)
+│
+├── reference/                        factual catalogs
+│   ├── SECTIONS.md                   83 section components
+│   ├── BUSINESS_TYPES.md             types + verticals + tenants
+│   ├── API.md                        21 API routes
+│   ├── TENANTS.md                    tenant model reference
+│   ├── TOKENS.md                     design tokens
+│   └── ENV_VARS.md                   env vars (planned)
+│
+├── explanation/                      conceptual
+│   ├── multi-tenancy.md
+│   ├── composition-pipeline.md
+│   └── theming.md
+│
+├── observability/
+│   ├── logging.md
+│   ├── tracing.md
+│   └── metrics.md
+│
+├── runbooks/                         one file per alert
+│
+└── archive/                          completed plans, status reports, historical
+    └── 2026-04/
+```
 
-### Status Reports
-| Document | Description | Updated |
-|----------|-------------|---------|
-| [PROJECT_STATUS_SUMMARY.md](./PROJECT_STATUS_SUMMARY.md) | Current project state | April 20, 2026 |
-| [100_WINS_COMPLETE.md](./100_WINS_COMPLETE.md) | Summary of 100 easy wins | April 20, 2026 |
+## What's live today (April 2026)
 
----
+**Canonical docs written in this PR:**
+- [/README.md](../README.md) — repo entry + map
+- [/ARCHITECTURE.md](../ARCHITECTURE.md) — matklad-style system tour
+- [/CONTRIBUTING.md](../CONTRIBUTING.md) — dev workflow
+- [docs/README.md](./README.md) — this file
+- [docs/reference/SECTIONS.md](./reference/SECTIONS.md) — 83 sections
+- [docs/reference/BUSINESS_TYPES.md](./reference/BUSINESS_TYPES.md) — types + verticals + tenants
+- [docs/reference/API.md](./reference/API.md) — 21 routes
+- [docs/DOCS_CONSOLIDATION_PLAN.md](./DOCS_CONSOLIDATION_PLAN.md) — migration map
 
-## ⚡ Performance & Optimization
+**Existing structure preserved as legacy (see the consolidation plan for per-file migration):**
 
-| Document | Description | Status |
-|----------|-------------|--------|
-| [SUPABASE_OPTIMIZATION_REPORT.md](./SUPABASE_OPTIMIZATION_REPORT.md) | Full Supabase analysis | ✅ Complete |
-| [SUPABASE_OPTIMIZATION_COMPLETE.md](./SUPABASE_OPTIMIZATION_COMPLETE.md) | Optimizations implemented | ✅ Complete |
-| [FEATURE_GAP_ANALYSIS.md](./FEATURE_GAP_ANALYSIS.md) | Missing features analysis | 🟡 Ongoing |
+| Legacy folder | What it holds | Fate |
+|---|---|---|
+| `docs/01_BUSINESS_MODEL/` | value prop, pricing, tiers, acquisition | Keep — link from README |
+| `docs/02_STRATEGY/` | roadmaps, plans, epics | Keep current; archive completed plans |
+| `docs/03_ARCHITECTURE/` | deployment, observability, tenants, components | Source of truth for explanations — move gradually to `explanation/` + `reference/` |
+| `docs/04_IMPLEMENTATION/` | how-to guides (Gemini, GitHub Projects, images) | Each → `how-to/` |
+| `docs/05_RESEARCH/` | taxonomies, competitor analysis | Keep as research archive |
+| `docs/06_REFERENCE/` | audit reports, AI guides, quick refs | Split — refs to `reference/`, status to `archive/` |
+| `docs/08_CLIENTS/` | per-client docs (Laura egg farm) | Move to `sites/<slug>/docs/` or external CRM |
 
----
+Per-tenant docs live under `sites/<slug>/docs/` (example: `sites/nexa-paraguay/docs/STAKEHOLDER-QA.md`). Application/developer docs live under `web/docs/`.
 
-## 🏗️ Architecture & Technical
+## Known redundancies
 
-### System Design
-| Document | Description | Audience |
-|----------|-------------|----------|
-| [TENANTS.md](./TENANTS.md) | Multi-tenancy model | Architects |
-| [VETE_PATTERNS_ANALYSIS.md](./VETE_PATTERNS_ANALYSIS.md) | Patterns from Vete project | Developers |
-| [UNIVERSAL_COMPONENTS.md](./UNIVERSAL_COMPONENTS.md) | Component architecture | Frontend devs |
-| [OBSERVABILITY.md](./OBSERVABILITY.md) | Monitoring & logging | DevOps |
+Tracked in [DOCS_CONSOLIDATION_PLAN.md](./DOCS_CONSOLIDATION_PLAN.md). Summary:
 
-### Development Guides
-| Document | Description | Audience |
-|----------|-------------|----------|
-| [DEBUGGING.md](./DEBUGGING.md) | Debugging guide | Developers |
-| [API_GENERATION_GUIDE.md](./API_GENERATION_GUIDE.md) | API documentation | Backend devs |
-| [DEPLOYMENT.md](./DEPLOYMENT.md) | Deployment procedures | DevOps |
+| Cluster | Files | Resolution |
+|---|---|---|
+| Deploy guides | `QUICK_DEPLOY.md`, `CLOUDFLARE_DEPLOY.md`, `HOSTINGER_CLOUDFLARE_SETUP.md`, `DEPLOY_STATUS.md` | Collapse → `how-to/deploy.md` |
+| Transformation/completion | `TRANSFORMATION_SUMMARY`, `IMPLEMENTATION_COMPLETE`, `IMPLEMENTATION_SUMMARY`, `PROJECT_TRANSFORMATION_COMPLETE`, `WINS_76_100_SUMMARY` | Archive — future summaries go in CHANGELOG or PR descriptions |
+| UX/UI | `UXUI_BEAUTIFICATION`, `UXUI_IMPLEMENTATION_SUMMARY`, `UX_UI_REDESIGN_PLAN` | Single design-system doc |
+| Business-model questionnaires | `BUSINESS_MODEL_QUESTIONNAIRE.md`, `BUSINESS_MODEL_QUESTIONNAIRE_ENHANCED.md`, `BUSINESS_MODEL_SIMPLE.md` | Keep one canonical, archive the others |
+| Win checklists | `100_EASY_WINS.md`, `100_WINS_COMPLETE.md` | Merge into a progress ledger or move to CHANGELOG |
+| Supabase optimization pair | `SUPABASE_OPTIMIZATION_REPORT.md`, `SUPABASE_OPTIMIZATION_COMPLETE.md` | Keep both (analysis + result) but mark completion as historical |
+| Universal components pair | `UNIVERSAL_COMPONENTS.md`, `UNIVERSAL_COMPONENTS_SUMMARY.md` | Keep both (reference + summary) |
 
----
+`.firecrawl/` contains 10 raw web scrapes used for research. They should move to `docs/archive/firecrawl-scrapes/` or be gitignored.
 
-## 🎨 UI/UX Design
+## Principles for new docs
 
-| Document | Description | Status |
-|----------|-------------|--------|
-| [UX_UI_REDESIGN_PLAN.md](./UX_UI_REDESIGN_PLAN.md) | Complete redesign plan | 🟡 Planned |
-| [UXUI_BEAUTIFICATION.md](./UXUI_BEAUTIFICATION.md) | UI improvements | 🟡 Ongoing |
-| [UXUI_IMPLEMENTATION_SUMMARY.md](./UXUI_IMPLEMENTATION_SUMMARY.md) | What was implemented | ✅ Complete |
-| [HOMEPAGE_IMPROVEMENT_PLAN.md](./HOMEPAGE_IMPROVEMENT_PLAN.md) | Homepage redesign | 🟡 Planned |
-
----
-
-## 📝 Business & Strategy
-
-### Planning
-| Document | Description | Audience |
-|----------|-------------|----------|
-| [STRATEGY_NEXT_STEPS.md](./STRATEGY_NEXT_STEPS.md) | Strategic roadmap | Leadership |
-| [100_EASY_WINS.md](./100_EASY_WINS.md) | List of quick improvements | Developers |
-| [SUBSCRIPTION_COST_ANALYSIS.md](./SUBSCRIPTION_COST_ANALYSIS.md) | Pricing analysis | Business |
-
-### Templates & Guides
-| Document | Description | Audience |
-|----------|-------------|----------|
-| [RESTAURANT_TEMPLATE_PLAN.md](./RESTAURANT_TEMPLATE_PLAN.md) | Restaurant vertical | Product |
-| [20_DOLLAR_BEST_VALUE.md](./20_DOLLAR_BEST_VALUE.md) | Value proposition | Marketing |
-| [PREMIUM_QUALITY_GUIDE.md](./PREMIUM_QUALITY_GUIDE.md) | Quality standards | Design |
-
----
-
-## 🔧 Implementation Guides
-
-### Image Generation
-| Document | Description | Tool |
-|----------|-------------|------|
-| [GEMINI_IMAGE_GENERATION_GUIDE.md](./GEMINI_IMAGE_GENERATION_GUIDE.md) | Gemini image prompts | Gemini |
-| [GEMINI_USAGE_GUIDE.md](./GEMINI_USAGE_GUIDE.md) | How to use Gemini | Gemini |
-| [GEMINI_TO_DRIVE_WORKFLOW.md](./GEMINI_TO_DRIVE_WORKFLOW.md) | Image workflow | Gemini + Drive |
-| [IMAGE_PROMPTS_QUICK_REFERENCE.md](./IMAGE_PROMPTS_QUICK_REFERENCE.md) | Prompt reference | All |
-
-### Data & Leads
-| Document | Description | Audience |
-|----------|-------------|----------|
-| [LEADS_REPO_ANALYSIS.md](./LEADS_REPO_ANALYSIS.md) | Leads data analysis | Data team |
-| [TENANTS_ANALYSIS_AND_IMAGES.md](./TENANTS_ANALYSIS_AND_IMAGES.md) | Tenant analysis | Product |
-| [TENANTS_STATUS_AND_IMAGE_REQUIREMENTS.md](./TENANTS_STATUS_AND_IMAGE_REQUIREMENTS.md) | Image requirements | Design |
-
----
-
-## 📊 By Category
-
-### 🔴 CRITICAL (Security)
-- COMPREHENSIVE_AUDIT_REPORT.md
-- CRITICAL_FIXES_QUICK_REFERENCE.md
-- COMPLETE_REMEDIATION_PLAN.md
-- SECURITY_REMEDIATION_COMPLETE.md
-
-### 🟠 HIGH (Implementation)
-- IMPLEMENTATION_CHECKLIST.md
-- SUPABASE_OPTIMIZATION_REPORT.md
-- SUPABASE_OPTIMIZATION_COMPLETE.md
-
-### 🟡 MEDIUM (Planning)
-- STRATEGY_NEXT_STEPS.md
-- UX_UI_REDESIGN_PLAN.md
-- FEATURE_GAP_ANALYSIS.md
-
-### 🟢 LOW (Reference)
-- DEBUGGING.md
-- API_GENERATION_GUIDE.md
-- IMAGE_PROMPTS_QUICK_REFERENCE.md
+1. **One topic per file.** If two docs overlap, merge them.
+2. **Follow Diataxis.** Is this teaching (tutorial), a recipe (how-to), a lookup (reference), or a concept (explanation)?
+3. **Status reports are not docs.** Implementation summaries belong in PR descriptions or CHANGELOG.
+4. **Archive rather than delete.** Move outdated docs to `docs/archive/YYYY-MM/` with a one-line "superseded by X" header.
+5. **Cross-link.** Every reference doc links back to the relevant explanation; every how-to links to the reference it uses.
+6. **Short.** Individual docs ≤1000 lines. If one grows longer, split it.
+7. **No decorative emoji.** Tables and code blocks do the work.
 
 ---
 
-## 🔍 Quick Find
-
-### For Security Issues
-→ Start with [CRITICAL_FIXES_QUICK_REFERENCE.md](./CRITICAL_FIXES_QUICK_REFERENCE.md)
-
-### For Performance
-→ Read [SUPABASE_OPTIMIZATION_COMPLETE.md](./SUPABASE_OPTIMIZATION_COMPLETE.md)
-
-### For Status
-→ Check [PROJECT_STATUS_SUMMARY.md](./PROJECT_STATUS_SUMMARY.md)
-
-### For Next Steps
-→ See [STRATEGY_NEXT_STEPS.md](./STRATEGY_NEXT_STEPS.md)
-
----
-
-## 📈 Document Status
-
-| Category | Total | Complete | In Progress |
-|----------|-------|----------|-------------|
-| Security | 5 | 5 | 0 |
-| Performance | 2 | 2 | 0 |
-| Architecture | 4 | 2 | 2 |
-| UI/UX | 4 | 1 | 3 |
-| Business | 3 | 1 | 2 |
-| Implementation | 8 | 5 | 3 |
-| **TOTAL** | **36** | **21** | **12** |
-
----
-
-## 🎯 Recommended Reading Order
-
-### For New Team Members
-1. PROJECT_TRANSFORMATION_COMPLETE.md
-2. README.md
-3. TENANTS.md
-4. QUICK_REFERENCE.md
-
-### For Security Review
-1. COMPREHENSIVE_AUDIT_REPORT.md
-2. SECURITY_REMEDIATION_COMPLETE.md
-3. CRITICAL_FIXES_QUICK_REFERENCE.md
-
-### For Development
-1. DEBUGGING.md
-2. API_GENERATION_GUIDE.md
-3. SUPABASE_OPTIMIZATION_COMPLETE.md
-4. UNIVERSAL_COMPONENTS.md
-
-### For Leadership
-1. PROJECT_STATUS_SUMMARY.md
-2. STRATEGY_NEXT_STEPS.md
-3. SUBSCRIPTION_COST_ANALYSIS.md
-
----
-
-## 📝 Maintenance
-
-**Last Updated:** April 20, 2026  
-**Maintained by:** Development Team  
-**Update Frequency:** After major releases
-
----
-
-> 💡 **Tip:** Use Ctrl+F (Cmd+F on Mac) to search this index for keywords
+_Last reviewed: April 2026. Supersedes the previous 01–08 numbered index; that index lives on as the legacy navigation until consolidation completes._

--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -1,0 +1,163 @@
+# API Reference
+
+All routes under `web/app/api/`. Every route is wrapped by `withRequestLog` (`web/lib/api/with-request-log.ts`) which provides:
+
+- Structured request/response logging (ECS fields)
+- AsyncLocalStorage context for downstream code
+- Perf timer
+- Correlation id from upstream `traceparent` or `x-request-id`
+
+Multi-tenant routes filter by `site_slug` or `business_id` on every query — enforced by [`scopedQueries()`](../../web/lib/supabase/scoped.ts) and the `scoped-query-audit.test.ts` test.
+
+**21 routes** across 6 functional areas.
+
+---
+
+## Lead intake & management
+
+| Route | Method | Purpose | DB | External |
+|---|---|---|---|---|
+| `/api/leads` | POST | Ingest a lead from a form — validate, dedupe, route to CRM | `leads`, `lead_submissions` | HubSpot, Pipedrive, Notion (via adapter registry) |
+| `/api/leads/[id]/notes` | POST | Add/update internal notes on an existing lead | `leads` | — |
+| `/api/leads/bulk-update` | POST | Batch update lead fields (status, tags, assignee) | `leads` | — |
+
+Dedup logic: `web/lib/leads/duplicate-detection.ts` (Levenshtein on email+phone). Enrichment before insert: `web/lib/leads/enrich.ts` (device, referrer, geo).
+
+## Analytics
+
+| Route | Method | Purpose | DB | External |
+|---|---|---|---|---|
+| `/api/analytics/track` | POST | Log a page-view or UI event | `analytics_events` | GA4, Plausible (via adapter) |
+| `/api/admin/daily-metrics` | GET | Aggregate daily stats (leads, conversions, traffic) | `analytics_events`, `lead_submissions` | — |
+
+Event schemas live in `web/lib/analytics/events.ts`.
+
+## Integration webhooks (inbound)
+
+| Route | Method | Purpose | DB | External |
+|---|---|---|---|---|
+| `/api/calendly-webhook` | POST | Booking events → create lead + record booking | `bookings`, `leads` | Calendly |
+| `/api/whatsapp-webhook` | POST | Inbound WhatsApp messages → conversation thread | `messages`, `conversations` | WhatsApp Business API |
+| `/api/mailchimp-journey-import` | POST | Batch import contacts from a Mailchimp journey | `contacts`, `lead_submissions` | Mailchimp |
+| `/api/hubspot-cron-sync` | POST | Scheduled sync of HubSpot deals/contacts | `leads`, `deals` | HubSpot |
+
+## Customer self-serve (subscriptions portal)
+
+| Route | Method | Purpose | DB | External |
+|---|---|---|---|---|
+| `/api/subscriptions/pause` | POST | Pause a recurring subscription | `subscriptions` | — |
+| `/api/subscriptions/skip` | POST | Skip the next delivery | `subscriptions` | — |
+| `/api/subscriptions/preferences` | POST | Update dietary / delivery preferences | `subscriptions` | — |
+| `/api/newsletter` | POST | Double opt-in newsletter subscription | — | Mailchimp, Resend |
+
+## Properties (real estate)
+
+| Route | Method | Purpose | DB | External |
+|---|---|---|---|---|
+| `/api/properties` | GET / POST | List or create properties | `properties` | — |
+| `/api/properties/[id]` | GET / PUT | Get or update a single property | `properties` | — |
+
+## Compliance & data requests
+
+| Route | Method | Purpose | DB | External |
+|---|---|---|---|---|
+| `/api/data-request` | POST | GDPR data-subject request (access / delete / export) | `data_requests`, `leads`, `lead_submissions` | — |
+
+Privacy policy + AML disclosures are rendered from `src/compliance/*.template.md` into the relevant tenant's privacy page.
+
+## System
+
+| Route | Method | Purpose | Notes |
+|---|---|---|---|
+| `/api/generate` | POST | Compose a page from business config + vertical template (builder-side) | Used by admin dashboard |
+| `/api/og-image/[slug]` | GET | Dynamic OpenGraph image | `next/og` + tenant tokens |
+| `/api/reminders` | POST | Schedule a reminder (email/SMS) | `reminders` table + email/SMS adapter |
+| `/api/health` | GET | Liveness + readiness probe | `?deep=1` checks DB connectivity |
+| `/api/diagnostics` | GET | Debug: env presence, version, Supabase status, integration adapter health | Admin-only |
+
+---
+
+## Conventions
+
+### Request id / tracing
+
+Every response carries `x-request-id` + `traceparent`. Incoming headers are honoured; fresh ids generated only if none supplied. See [/ARCHITECTURE.md § observability](../../ARCHITECTURE.md#observability).
+
+### Validation
+
+All POST / PUT bodies validate with **Zod**. Schemas live next to the route or in a `schema.ts` sibling file. Validation errors return `400` with a structured error body:
+
+```json
+{
+  "error": "ValidationError",
+  "details": [ { "path": ["email"], "message": "Invalid email" } ]
+}
+```
+
+### Errors
+
+- `400` — validation failure (zod)
+- `401` — missing/invalid auth (admin routes)
+- `403` — auth present but insufficient scope
+- `404` — resource not found
+- `429` — rate-limited (via Upstash in middleware)
+- `500` — unexpected; always logged + captured in Sentry
+
+The route's catch block logs with `logger.error(message, { error })` and rethrows, or returns a structured error response. **Never silently caught** (ESLint enforces — see [CLAUDE.md § error handling](../../CLAUDE.md#error-handling-mandatory)).
+
+### Rate limiting
+
+Optional. When `UPSTASH_REDIS_URL` is configured, `middleware.ts` applies a sliding-window rate limit to `/api/*` routes. Disabled in dev.
+
+### Auth
+
+- **Public routes** (leads intake, webhooks, health) — no auth. Webhooks validate the signing secret.
+- **Admin routes** (`/api/admin/*`, `/api/diagnostics`) — require Supabase session; checked in `middleware.ts`.
+- **Self-serve** (`/api/subscriptions/*`) — require a customer token (email + subscription id signature).
+
+### Multi-tenancy
+
+Every tenant-scoped query goes through `scopedQueries(supabase, businessId)`. Example:
+
+```ts
+import { createClient } from '@/lib/supabase/server'
+import { scopedQueries } from '@/lib/supabase/scoped'
+
+const supabase = await createClient()
+const scoped = scopedQueries(supabase, businessId)
+const { data } = await scoped.from('leads').select('*').limit(10)
+```
+
+`site_slug` vs `business_id`: newer tables use `site_slug` (matches `sites/<slug>/`), older tables use `business_id` (legacy). The scoped wrapper handles both.
+
+---
+
+## OpenAPI (proposed)
+
+There is no generated OpenAPI spec today. The [docs consolidation plan](../DOCS_CONSOLIDATION_PLAN.md) proposes adopting [`next-openapi-gen`](https://github.com/tazo90/next-openapi-gen) since we already use Zod for validation. That would generate a live spec from the route handlers and host it under `/api-docs` using Scalar. See the plan for the phase-in.
+
+---
+
+## Adding a new route
+
+1. File: `web/app/api/<name>/route.ts` (or `[param]/route.ts` for dynamic).
+2. Export HTTP method handlers (`GET`, `POST`, etc.) wrapped in `withRequestLog`:
+
+   ```ts
+   import { NextResponse } from 'next/server'
+   import { withRequestLog } from '@/lib/api/with-request-log'
+
+   export const POST = withRequestLog(async (req, ctx) => {
+     // ctx.logger, ctx.requestId, etc.
+     return NextResponse.json({ ok: true })
+   })
+   ```
+
+3. Validate the body with Zod.
+4. If DB-facing: use `scopedQueries()`.
+5. Add the route to this file (one line, which functional area).
+6. Add tests under `web/tests/integration/` if the route has business logic.
+
+---
+
+_Last reviewed: April 2026 — after PR #37 landed 9 new routes (subscriptions portal + webhooks + properties + GDPR)._

--- a/docs/reference/BUSINESS_TYPES.md
+++ b/docs/reference/BUSINESS_TYPES.md
@@ -1,0 +1,162 @@
+# Business Types, Verticals, and Tenants
+
+The tenant model has three levels:
+
+1. **Vertical** — a broad industry cluster (e.g. `real-estate-relocation`, `food-beverage`, `portfolio-professional`). Defined in `src/verticals/<vertical>/vertical.json`.
+2. **Business type** — a specific kind of business within a vertical (e.g. `peluqueria`, `meal_prep`, `relocation`). Defined in `src/registry/<type>.type.json`. Each type declares the sections it uses and SEO defaults.
+3. **Tenant** — an actual client site. Defined under `sites/<slug>/`.
+
+```
+vertical ⬅ one-to-many ⬅ business type ⬅ one-to-many ⬅ tenant
+```
+
+Tokens and copy flow down this chain: **base → vertical → business type → tenant**, with later layers overriding earlier ones.
+
+See [/ARCHITECTURE.md § code map](../../ARCHITECTURE.md#2-code-map) for where these fit.
+
+---
+
+## Verticals (23)
+
+| Vertical id | Member types | Default locales | Notable features |
+|---|---|---|---|
+| `portfolio-professional` | `diseno_grafico`, `fotografia`, `book_cover_designer`, freelance professionals | es | Portfolio, case studies, quote forms, before-after |
+| `food-beverage` | `meal_prep`, restaurants, cafes, bakeries, `kaiten_zushi`, `sushi_bar`, `restaurant` | es, en | Menu, reservations, delivery, business hours, regulatory badges |
+| `real-estate-relocation` | `relocation`, `inmobiliaria` | es, en, de, nl | Booking, multi-page process, trust signals, mortgage calc |
+| `relocacion` | (alias folder) | es, en, pt | Same as above |
+| `beauty-personal-care` | `peluqueria`, `salon_belleza`, `barberia`, `unas`, `pestanas`, `maquillaje`, `depilacion`, `estetica` | es | Booking, staff selector, service menu |
+| `fitness-wellness` | `gimnasio`, `spa` | es | Class schedule, membership plans |
+| `professional-services` | `legal`, `consultoria`, `inversiones`, `educacion`, `salud` | es | Intake questionnaire, tiered service ladder |
+| `creative-arts` | `tatuajes` | es | Portfolio, gallery, before-after |
+| `agriculture` | egg-farm types | es | Stock indicator, delivery calculator, recipe |
+| _(~14 more)_ | automotive, pets, retail, sports, tech, trades, etc. | varies | Varies |
+
+Verticals are additive — adding a new business type to an existing vertical costs nothing; the vertical's defaults apply.
+
+---
+
+## Business types
+
+Business types are defined in `src/registry/<id>.type.json`. Each declares:
+
+- `type` — kebab- or snake-case id
+- `displayName` — Spanish human label
+- `verticalId` — parent vertical (optional — inherits if missing)
+- `sections` — ordered list of section ids to render on the default home page
+- `seo` — title/description templates with placeholders
+- `features` — feature flags (booking? catalog? blog?)
+
+### Core catalog (~30 types)
+
+| Type id | Display name (ES) | Vertical | Status |
+|---|---|---|---|
+| `peluqueria` | Peluquería | beauty-personal-care | supported |
+| `salon_belleza` | Salón de Belleza | beauty-personal-care | supported |
+| `gimnasio` | Gimnasio | fitness-wellness | supported |
+| `spa` | Spa | fitness-wellness | supported |
+| `unas` | Uñas | beauty-personal-care | supported |
+| `tatuajes` | Tatuajes | creative-arts | supported |
+| `barberia` | Barbería | beauty-personal-care | supported |
+| `estetica` | Estética | beauty-personal-care | supported |
+| `maquillaje` | Maquillaje | beauty-personal-care | supported |
+| `depilacion` | Depilación | beauty-personal-care | supported |
+| `pestanas` | Pestañas | beauty-personal-care | supported |
+| `diseno_grafico` | Diseño Gráfico | portfolio-professional | supported |
+| `fotografia` | Fotografía | portfolio-professional | supported |
+| `book_cover_designer` | Diseño de Portadas | portfolio-professional | supported (used by dayah-litworks) |
+| `relocation` | Servicios de Reubicación | real-estate-relocation | supported (Nexa Paraguay/Uruguay) |
+| `inmobiliaria` | Inmobiliaria | real-estate-relocation | supported (falls through to relocacion defaults) |
+| `meal_prep` | Meal Prep & Compras | food-beverage | supported (De Abasto a Casa) |
+| `restaurant` | Restaurante | food-beverage | supported |
+| `sushi_bar` | Sushi Bar | food-beverage | supported |
+| `kaiten_zushi` | Kaiten Zushi | food-beverage | supported |
+| `educacion` | Educación | professional-services | supported |
+| `salud` | Salud | professional-services | supported |
+| `inversiones` | Inversiones | professional-services | supported |
+| `legal` | Legal | professional-services | supported |
+| `consultoria` | Consultoría | professional-services | supported |
+
+The full listing is generated from `src/registry/*.type.json`. Run `ls src/registry/` for a live list.
+
+### Adding a business type
+
+1. Create `src/registry/<id>.type.json` — section list, SEO, features.
+2. If the type needs brand colors, add `src/tokens/<id>.tokens.json` (otherwise it inherits vertical defaults).
+3. Add `src/content/<id>.content.json` with Spanish copy templates using `{{placeholder}}` keys.
+4. Add the type to its parent vertical's `vertical.json` if the vertical lists members explicitly.
+
+See [web/docs/ADDING_BUSINESS_TYPES.md](../../web/docs/ADDING_BUSINESS_TYPES.md) for the full runbook.
+
+---
+
+## Live tenants (6 real clients, April 2026)
+
+| Slug | Display | Type | Vertical | Hostname | Locales | Integrations | Status |
+|---|---|---|---|---|---|---|---|
+| `nexa-paraguay` | Nexa Paraguay (4-locale) | `relocation` | real-estate-relocation | nexaparaguay.com | nl · en · de · es | Calendly, HubSpot, Mailchimp, GA4 | Staging; pre-cutover |
+| `nexaparaguay` | Nexa Paraguay (ES landing) | `relocation` | real-estate-relocation | nexaparaguay.com | es | HubSpot, Mailchimp, GA4 | Staging |
+| `nexa-uruguay` | Nexa Uruguay | `relocation` (variant) | relocacion | nexauruguay.com | en · es | Calendly, HubSpot, Mailchimp, GA4 | Spike |
+| `nexa-propiedades` | Nexa Propiedades | real-estate (custom) | relocacion | nexapropiedades.com | es · en · pt | HubSpot, Mailchimp, GA4, Google Maps | In progress |
+| `de-abasto-a-casa` | De Abasto a Casa | `meal_prep` | food-beverage | deabastoacasa.com.py | es | HubSpot, Mailchimp, GA4 | In progress |
+| `dayah-litworks` | Dayah Litworks | `diseno_grafico` → `book_cover_designer` | portfolio-professional | dayah-litworks.com | es | HubSpot, Mailchimp, GA4 | In progress |
+
+## Demo tenants (~15 under `sites/`)
+
+Demo tenants exercise the engine across verticals and are not client work: `salon-maria` (peluqueria), `gymfit-py` (gimnasio), `spa-serenidad` (spa), and sushi / restaurant / egg-farm demos. They live alongside real tenants in `sites/` and follow the same schema. They ship in production behind the `/` landing for marketing showcase.
+
+---
+
+## Compliance templates per vertical
+
+| Vertical / tenant concern | Template | Regulation |
+|---|---|---|
+| All Paraguay tenants | `src/compliance/privacy-policy-py.template.md` | Ley 1.682/01, 5.543/15, 6.534/20 |
+| All tenants (generic) | `src/compliance/terms-of-service.template.md` | N/A (standard ToS) |
+| Relocation / real-estate / financial | `src/compliance/aml-disclosure-nexa.template.md` | SEPRELAD (Paraguay AML) |
+| Food-beverage | `src/compliance/inan-food-disclaimer.template.md` | INAN (Paraguay food safety) |
+| GDPR-scope tenants | `src/compliance/cookie-classification.json` | GDPR Art. 6, CNIL, ePrivacy |
+
+A tenant declares which compliance docs to include in its `site.json`; `src/compliance/` provides the master text.
+
+---
+
+## Tenant directory schema
+
+```
+sites/<slug>/
+├── site.json              required
+│   ├── slug                tenant id (must match dir name)
+│   ├── displayName
+│   ├── hostnames           [ "nexaparaguay.com" ]
+│   ├── businessType         e.g. "relocation"
+│   ├── verticalId           optional — inherited from businessType if missing
+│   ├── defaultLocale        e.g. "es"
+│   ├── locales              [ "es", "en", "de", "nl" ]
+│   ├── features             { booking: true, blog: true, … }
+│   └── integrations         { booking: "calendly", crm: "hubspot", email: "mailchimp", analytics: "ga4" }
+│
+├── tokens.json            optional  — brand-color overrides
+│
+├── pages/                 required — at minimum home.json
+│   └── <page>.json
+│       ├── slug            ""  for home, else path segment
+│       ├── titleKey        i18n key (resolved from content/)
+│       ├── descriptionKey
+│       └── sections[]      ordered list: { id, variant, content }
+│
+├── content/               required — at minimum <defaultLocale>.json
+│   └── <locale>.json       deeply-keyed copy; referenced by content keys in pages/
+│
+├── blog/                  optional — per-locale markdown
+│   └── <locale>/*.md
+│
+├── assets/                optional — tenant-owned images
+│
+└── docs/                  optional — stakeholder / ops docs for this tenant
+```
+
+See a live example: `sites/nexa-paraguay/` (4-locale relocation site with 10 blog posts).
+
+---
+
+_Last reviewed: April 2026. When adding a tenant or business type, update this file in the same PR._

--- a/docs/reference/SECTIONS.md
+++ b/docs/reference/SECTIONS.md
@@ -1,0 +1,213 @@
+# Section Component Reference
+
+Every section in `web/components/sections/` is listed here. Sections are the building blocks tenants compose into pages via `sites/<slug>/pages/*.json`. All are referenced by **kebab-case id** in tenant JSON; the renderer normalizes camelCase aliases for backwards compatibility (see `resolveSectionAlias` in `web/lib/engine/section-registry.ts`).
+
+**Total: 83 sections** across 10 functional groups. Every section is theme-driven (`var(--*)` tokens only), Server Component by default unless interactive.
+
+See [ARCHITECTURE.md § request lifecycle](../../ARCHITECTURE.md#3-request-lifecycle) for where sections fit in the pipeline.
+
+---
+
+## Conventions
+
+- **Section id**: kebab-case, matches the registered key in `renderer.tsx`.
+- **File**: `web/components/sections/<id>-section.tsx` (except when a file exports multiple sections, e.g. `sushi-menu-sections.tsx` → `featured-menu` + `full-menu`).
+- **Props**: each section exports a typed Props interface; the renderer passes `section.data` as props.
+- **Tokens**: components consume `var(--primary)`, `var(--surface)`, etc. — never hardcoded colors.
+
+---
+
+## 1. Navigation & Layout
+
+| Id | File | Purpose |
+|---|---|---|
+| `header` | `header-section.tsx` | Sticky top bar with logo, nav links, primary CTA |
+| `footer` | `footer-section.tsx` | Footer with link columns, contact block, compliance strip |
+| `whatsapp-float` | `whatsapp-float.tsx` | Floating WhatsApp CTA button (all pages) |
+| `smart-whatsapp` | `smart-whatsapp-section.tsx` | WhatsApp CTA with context-aware pre-filled message |
+| `language-selector` | `language-selector-section.tsx` | Locale switcher (updates `NEXT_LOCALE` cookie) |
+
+## 2. Hero & Landing
+
+| Id | File | Purpose |
+|---|---|---|
+| `hero` | `hero-section.tsx` | Full-width hero — headline, subhead, CTA, background image or video |
+| `cta-banner` | `cta-banner-section.tsx` | Horizontal promo banner |
+| `landing` | `landing-section.tsx` | Generic top-of-page block |
+
+## 3. Features & Services
+
+| Id | File | Purpose |
+|---|---|---|
+| `features` | `features-section.tsx` | Icon-led feature list (3–6 items) |
+| `services` | `services-section.tsx` | Service cards with image + description + CTA |
+| `process` | `process-section.tsx` | Step-by-step process (horizontal) |
+| `process-timeline` | `process-timeline-section.tsx` | Vertical timeline with milestones |
+| `timeline-history` | `timeline-history-section.tsx` | Company history timeline |
+| `tiered-service-ladder` | `tiered-service-ladder-section.tsx` | Escalating service levels (Bronze → Gold) |
+| `programs-comparison` | `programs-comparison-section.tsx` | Side-by-side programme comparison (relocation) |
+| `why-destination` | `why-destination-section.tsx` | "Why choose this destination" block (relocation) |
+
+## 4. Pricing & Commerce
+
+| Id | File | Purpose |
+|---|---|---|
+| `pricing` | `pricing-table-section.tsx` | Plan comparison table |
+| `pricing-range` | `pricing-range-section.tsx` | "From X to Y" price display |
+| `membership-plans` | `membership-plans-section.tsx` | Tier cards with features + CTA |
+| `subscription` | `subscription-section.tsx` | Subscription management UI (customer portal) |
+| `compare-plans-matrix` | `compare-plans-matrix-section.tsx` | Feature-by-feature matrix |
+| `product-catalog` | `product-catalog-section.tsx` | Product grid with variants |
+| `price-list` | `price-list-section.tsx` | Itemised line-by-line price list |
+| `currency-toggle` | `currency-toggle-section.tsx` | Multi-currency selector |
+
+## 5. Booking & Scheduling
+
+| Id | File | Purpose |
+|---|---|---|
+| `booking` | `booking-section.tsx` | Calendly / Cal.com embed |
+| `class-schedule` | `class-schedule-section.tsx` | Weekly class timetable (gyms, yoga) |
+| `room-booking` | `room-booking-section.tsx` | Room/table reservation form |
+| `delivery-slot-picker` | `delivery-slot-picker-section.tsx` | Delivery time selection (meal prep) |
+| `preorder` | `preorder-calendar-section.tsx` | Pre-order calendar (egg farm, meal prep) |
+| `weekly-cadence-calendar` | `weekly-cadence-calendar-section.tsx` | Recurring delivery cadence |
+| `sample-week-preview` | `sample-week-preview-section.tsx` | Trial-week preview before subscribing |
+
+## 6. Calculators & Tools
+
+| Id | File | Purpose |
+|---|---|---|
+| `bulk-calculator` | `bulk-calculator-section.tsx` | Bulk-order pricing |
+| `delivery-calculator` | `delivery-calculator-section.tsx` | Delivery cost estimator |
+| `mortgage-calculator` | `mortgage-calculator-section.tsx` | Real-estate mortgage calc |
+| `savings-calculator` | `savings-calculator-section.tsx` | Savings / ROI estimator |
+
+## 7. Forms & Lead Capture
+
+| Id | File | Purpose |
+|---|---|---|
+| `lead-form` | `lead-form-section.tsx` | Basic lead form (name, email, phone) |
+| `contact` | `contact-section.tsx` | Contact form with message |
+| `newsletter-signup` | `newsletter-signup-section.tsx` | Email-only subscription |
+| `quote-form` | `quote-form-section.tsx` | Quote-request form |
+| `multi-step-form` | `multi-step-form-section.tsx` | Wizard form |
+| `intake-questionnaire` | `intake-questionnaire-section.tsx` | Multi-step intake (health, service onboarding) |
+
+## 8. Content & Media
+
+| Id | File | Purpose |
+|---|---|---|
+| `gallery` | `gallery-section.tsx` | Image carousel / lightbox |
+| `photo-gallery` | `photo-gallery-section.tsx` | Grid photo gallery |
+| `portfolio` | `portfolio-section.tsx` | Portfolio project cards |
+| `before-after` | `before-after-section.tsx` | Slider comparison |
+| `before-after-split` | `before-after-split-section.tsx` | Split-screen comparison |
+| `recipes` | `recipe-section.tsx` | Recipe card (ingredients + steps) |
+| `blog-index` | `blog-index-section.tsx` | Blog post list |
+| `blog-post` | `blog-post-section.tsx` | Single blog-post view |
+| `conveyor-belt` | `conveyor-belt-section.tsx` | Auto-scrolling item belt (sushi) |
+| _(shared)_ `conveyor-belt-strip.tsx` | Reusable strip inside the above |
+
+## 9. Trust & Social Proof
+
+| Id | File | Purpose |
+|---|---|---|
+| `testimonials` | `testimonials-section.tsx` | Testimonial cards / carousel |
+| `testimonial-video` | `testimonial-video-section.tsx` | Embedded video testimonials |
+| `reviews` | `reviews-section.tsx` | Star ratings + review text |
+| `google-reviews-widget` | `google-reviews-widget-section.tsx` | Google-Reviews embed |
+| `trust-signals` | `trust-signals-section.tsx` | Badges + certifications |
+| `trust-signals-logos` | `trust-signals-logos-section.tsx` | Client-logo carousel |
+| `team` | `team-section.tsx` | Team-member profile cards |
+| `referral` | `referral-section.tsx` | Referral-rewards programme |
+
+## 10. Status & Real-time
+
+| Id | File | Purpose |
+|---|---|---|
+| `open-hours-status` | `open-hours-status-section.tsx` | Live open/closed + hours |
+| `stock-indicator` | `stock-indicator-section.tsx` | Inventory level (egg farm) |
+| `emergency-indicator` | `emergency-indicator-section.tsx` | Emergency-service alert banner |
+| `regulatory-status-badge` | `regulatory-status-badge-section.tsx` | Licensing / compliance badge |
+| `countdown-timer` | `countdown-timer-section.tsx` | Offer / event countdown |
+| `instagram-feed` | `instagram-feed-section.tsx` | Instagram embed |
+| `service-area-map-zones` | `service-area-map-zones-section.tsx` | Delivery / service-area map |
+
+## 11. Food & Menu
+
+| Id | File | Purpose |
+|---|---|---|
+| `menu-categorized-priced` | `menu-categorized-priced-section.tsx` | Categorised priced menu |
+| `featured-menu` | `sushi-menu-sections.tsx` | Featured dishes with glyph icons (sushi) |
+| `full-menu` | `sushi-menu-sections.tsx` | Full menu (sushi) |
+| `color-coded-menu` | `color-coded-menu-section.tsx` | Plate-colour-based pricing |
+| `special-order` | `color-coded-menu-section.tsx` | Special-order builder |
+| `omakase` | `omakase-section.tsx` | Tasting-menu card |
+| `sake-menu` | `sake-menu-section.tsx` | Sake pairings |
+| `nutritional-info` | `nutritional-info-section.tsx` | Nutritional facts display |
+| `huevo-del-dia` | `huevo-del-dia-section.tsx` | Daily-special (legacy egg farm) |
+
+## 12. FAQ & Info
+
+| Id | File | Purpose |
+|---|---|---|
+| `faq` | `faq-section.tsx` | Accordion FAQ |
+| `faq-categorized` | `faq-categorized-section.tsx` | Tab-grouped FAQ |
+| `faq-chatbot` | `faq-chatbot-section.tsx` | AI chatbot interface |
+
+## 13. Real Estate & Hospitality
+
+| Id | File | Purpose |
+|---|---|---|
+| `property-listings` | `property-listings-section.tsx` | Property grid with filters |
+| `event-venues` | `event-venues-section.tsx` | Venue cards |
+
+## 14. Compliance
+
+| Id | File | Purpose |
+|---|---|---|
+| `compliance-disclaimer-footer` | `compliance-disclaimer-footer-section.tsx` | Regulatory disclaimer footer |
+
+## 15. Booking internals
+
+| Id | File | Purpose |
+|---|---|---|
+| `booking-embed` | `booking-embed-section.tsx` | Third-party booking widget embed |
+| `service-selector` | (in `web/components/booking/`) | Step: choose service |
+| `date-time-picker` | (in `web/components/booking/`) | Step: choose slot |
+| `staff-selector` | (in `web/components/booking/`) | Step: choose staff |
+| `booking-form` | (in `web/components/booking/`) | Step: contact + confirm |
+| `booking-wizard` | (in `web/components/booking/`) | Orchestrates the above four |
+
+_Booking components are not sections; they live under `components/booking/` and are composed by the `booking` section via variant prop._
+
+---
+
+## Adding a new section
+
+1. Create `web/components/sections/<kebab-name>-section.tsx` with a typed Props interface.
+2. Use only `var(--*)` tokens.
+3. Import + register in `web/lib/engine/renderer.tsx`:
+   ```tsx
+   import { NewSection } from '@/components/sections/new-section'
+   // …
+   'new-section': NewSection,
+   ```
+4. Add an entry to this file with one-line purpose.
+5. Snapshot or component test under `web/tests/unit/components/`.
+6. If the section is vertical-specific, add it to the relevant `src/verticals/<vertical>/vertical.json` and any business types that use it.
+
+See [CONTRIBUTING.md § Adding sections](../../CONTRIBUTING.md#adding-sections).
+
+---
+
+## Deprecated / under review
+
+| Id | Reason |
+|---|---|
+| `huevo-del-dia` | Vertical-specific (egg farm); evaluating whether to deprecate in favour of generic `product-of-the-day` |
+| `nutritional-info` | Was deleted in PR #34 then restored — conflicting signals; confirm with egg-farm tenant before cleanup |
+
+---
+
+_Last reviewed: April 2026 — after PR #34 (+22 sections) and PR #40 (+4 sushi sections)._


### PR DESCRIPTION
## Summary

Establishes the canonical documentation structure for the repo. **Phase A** of the migration described in [\`docs/DOCS_CONSOLIDATION_PLAN.md\`](./docs/DOCS_CONSOLIDATION_PLAN.md); future phases will consolidate the remaining 141 legacy markdown files incrementally.

## Why

Audit found **141 markdown files, ~25,000 lines**, with significant sprawl:
- 16 files at repo root (deploy status, implementation completion, wins 76–100 summaries)
- 6+ near-duplicate clusters (4 deploy guides, 3 UX/UI docs, 3 business-model questionnaires, paired "plan + complete" docs)
- Research artifacts (\`.firecrawl/\`) mixed with docs
- No canonical root-level set (README only, no ARCHITECTURE, no CONTRIBUTING)

External research (Next.js, Supabase, shadcn-ui, Prisma, Saleor, AWS SaaS reference) confirms the industry pattern:
- **Diataxis framework** — tutorials / how-to / reference / explanation
- **Canonical 5–7 root files only** — README, CONTRIBUTING, ARCHITECTURE, CHANGELOG, SECURITY, CODE_OF_CONDUCT, LICENSE
- **Archive over delete** — status reports go to \`archive/\` or CHANGELOG

## New files

| File | Basis | What it does |
|---|---|---|
| [\`README.md\`](./README.md) | repo entry convention | System map, live-tenants table, quick start, tech stack, repo map |
| [\`ARCHITECTURE.md\`](./ARCHITECTURE.md) | [matklad convention](https://matklad.github.io/2021/02/06/ARCHITECTURE.md.html) | Bird's-eye view, code map, request lifecycle, cross-cutting concerns, **9 architectural invariants**, boundaries |
| [\`CONTRIBUTING.md\`](./CONTRIBUTING.md) | OSS norm | Branch naming, Conventional Commits, PR checklist, quality gates, adding sections/tenants/types |
| [\`docs/README.md\`](./docs/README.md) | Diataxis | Hub index with tutorial / how-to / reference / explanation layout |
| [\`docs/DOCS_CONSOLIDATION_PLAN.md\`](./docs/DOCS_CONSOLIDATION_PLAN.md) | audit output | Per-file disposition of all 141 markdowns across 6 migration phases |
| [\`docs/reference/SECTIONS.md\`](./docs/reference/SECTIONS.md) | shadcn-ui style | Catalog of **83 section components** grouped by function |
| [\`docs/reference/BUSINESS_TYPES.md\`](./docs/reference/BUSINESS_TYPES.md) | — | **23 verticals**, ~30 business types, **6 real tenants**, tenant directory schema |
| [\`docs/reference/API.md\`](./docs/reference/API.md) | — | **21 API routes** grouped by functional area; conventions for tracing, validation, errors, auth, multi-tenancy |

## Unchanged

The 141 legacy markdown files are **untouched**. Migration is staged across phases B–F so no cross-reference breaks in a single commit:

- **Phase B** — high-value consolidations (merge 4 deploy docs; archive 10 status reports; split observability)
- **Phase C** — reference completion (TENANTS, TOKENS, ENV_VARS)
- **Phase D** — how-to harvest (GEMINI × 3 → \`generate-images.md\`; \`04_IMPLEMENTATION/*\`)
- **Phase E** — cleanup (questionnaire duplicates; Laura client docs; \`.firecrawl/\`)
- **Phase F** — fill gaps (CHANGELOG, SECURITY, CODE_OF_CONDUCT, LICENSE; OpenAPI spec; first runbook)

## Principles adopted (see \`CONTRIBUTING.md\` + \`docs/README.md\`)

1. Status reports belong in CHANGELOG or PR descriptions, not markdown files at root
2. Archive rather than delete
3. One topic per file; merge duplicates; short (≤1000 lines)
4. Cross-link reference ↔ explanation ↔ how-to
5. No decorative emoji

## Test plan

- [x] Docs render on GitHub (markdown-only PR, zero code)
- [x] Internal links resolve (spot-checked)
- [ ] Reviewer confirms the 5-phase migration plan is the right sequencing
- [ ] Reviewer confirms the tenant + business-type + section catalogs are accurate (they were generated from the live repo state post-9-PR-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)