### PR TITLE
docs: Phase F — CHANGELOG, SECURITY, CODE_OF_CONDUCT, first tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project are documented here. Format follows [Common Changelog](https://common-changelog.org/). Versions are currently date-tagged (calendar releases) rather than semver — the project is pre-1.0 and pushes to production continuously.
+
+## 2026-04-20
+
+### Added
+- Canonical doc set: `README.md`, `ARCHITECTURE.md`, `CONTRIBUTING.md` at repo root, `docs/README.md` as hub, and `docs/reference/{SECTIONS,BUSINESS_TYPES,API,TENANTS,TOKENS,ENV_VARS}.md` as lookup catalogs (PRs #41, #45)
+- `docs/how-to/deploy.md` — canonical deploy guide consolidating 4 legacy docs (PR #43)
+- `docs/how-to/generate-images.md` — canonical image pipeline consolidating 4 legacy GEMINI/IMAGES docs (PR #46)
+- `docs/observability/{README,logging,tracing,metrics}.md` — per-signal observability docs (PR #44)
+- 83-section component library: PR #34 added 22 reusable sections; PR #40 added 4 sushi-menu sections ported from legacy `main` branch
+- 21-route API surface: PR #37 added integration webhooks (Calendly, HubSpot, Mailchimp, WhatsApp), customer-portal self-serve (subscriptions pause/skip/preferences), properties catalog, GDPR data-request handler
+- Locale-prefixed tenant routing `/s/[locale]/[siteSlug]/` + 4 real tenants (`nexaparaguay`, `dayah-litworks`, `de-abasto-a-casa`, `nexa-propiedades`) (PR #38)
+- SEO JSON-LD builders, perf budget, Lighthouse CI, Google Fonts URL utility (PR #35)
+- Compliance templates (PY privacy, AML-Nexa, INAN-food, ToS, cookie classification) + legal-review-gate script (PR #36)
+- Ops scripts: a11y-audit, audit-duplicates, cli-ops, migrate-demo-to-site, new-tenant, tenant-health (PR #39)
+- Business model + AI workflow documentation (7 + 3 files, PR #33)
+
+### Changed
+- **Single trunk**: unified `main` and `Main` branches. `main` (stale lowercase) is deleted; `Main` is the sole canonical trunk (PR #40 ported the 5 unique files `main` had)
+- CSP: removed duplicate CSP in `middleware.ts` that was blocking Google Fonts on tenant sites; canonical CSP lives in `next.config.mjs → headers()` (PR #32)
+- Docs organisation: adopted [Diataxis framework](https://diataxis.fr/) + [matklad ARCHITECTURE.md convention](https://matklad.github.io/2021/02/06/ARCHITECTURE.md.html). `docs/` now structured as `reference/`, `how-to/`, `observability/`, `archive/`. Legacy numbered folders preserved until the [consolidation plan](./docs/DOCS_CONSOLIDATION_PLAN.md) completes.
+
+### Moved / Archived
+- 15 status/completion reports → `docs/archive/2026-04/` (PR #42)
+- 4 legacy deploy docs (`QUICK_DEPLOY`, `CLOUDFLARE_DEPLOY`, `HOSTINGER_CLOUDFLARE_SETUP`, `docs/DEPLOYMENT`) → archive + replaced by `docs/how-to/deploy.md` (PR #43)
+- 4 legacy image-gen docs → archive + replaced by `docs/how-to/generate-images.md` (PR #46)
+- Monolithic `docs/OBSERVABILITY.md` → archive + split into per-signal files (PR #44)
+- Questionnaire duplicates (`BUSINESS_MODEL_QUESTIONNAIRE.md`, `BUSINESS_MODEL_SIMPLE.md`) → archive; `ENHANCED` variant renamed as canonical (PR #47)
+- 4 Laura-egg-farm client docs → `docs/archive/2026-04/clients/laura/` (pending tenant creation) (PR #47)
+- 15 `.firecrawl/` research scrapes → `docs/archive/2026-04/firecrawl-scrapes/` (PR #47)
+
+### Security
+- Discovered 2 Supabase publishable keys hard-coded in archived deploy docs (`okddppczckbjdotrxiev` + `qyvokpribmbrosafntqa`). Publishable keys are client-exposed by design (RLS enforces at DB), so risk is low — but rotating the key is recommended as a hygiene step if either project is still active. See PR #43 description.
+
+---
+
+## Prior history (pre-changelog)
+
+Before 2026-04-20 the project tracked work via status-report markdown files at repo root (`IMPLEMENTATION_COMPLETE.md`, `TRANSFORMATION_SUMMARY.md`, `WINS_76_100_SUMMARY.md`, etc.). Those are archived under [`docs/archive/2026-04/`](./docs/archive/2026-04/) for historical audit. From this changelog onward, user-visible changes belong here.
+
+For the full commit-level history, see `git log`. For merged PR descriptions, see the [GitHub PR list](https://github.com/Ai-Whisperers/paragu-ai-builder/pulls?q=is%3Apr+is%3Aclosed).
+
+---
+
+## Maintenance
+
+- Add entries at the **top** under a new date heading (or version heading once we tag releases).
+- Group entries as: **Added · Changed · Deprecated · Removed · Fixed · Security · Moved/Archived**.
+- Link PRs with `(PR #N)`.
+- Be specific: "added" beats "implemented"; mention the user-visible outcome.
+- Keep entries terse — one sentence each where possible.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+# Code of Conduct
+
+## Our pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the project and community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- Trolling, insulting or derogatory comments, personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our responsibilities
+
+Project maintainers are responsible for clarifying standards of acceptable behavior and will take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, PRs, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for behaviors they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — the repository, issue trackers, discussions, pull requests, and any communications about the project — as well as in public spaces when an individual is representing the project.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainer at **weissvanderpol.ivan@gmail.com**. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,105 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you discover a security issue in this repo, **please do not open a public issue**. Instead:
+
+1. Email **weissvanderpol.ivan@gmail.com** with subject `[SECURITY] paragu-ai-builder: <short summary>`.
+2. Include reproduction steps, affected versions/commits, and the impact you've assessed.
+3. Allow up to **5 business days** for acknowledgment and up to **30 days** for a fix before public disclosure.
+
+For general bugs (not security-sensitive), use the public [GitHub Issues](https://github.com/Ai-Whisperers/paragu-ai-builder/issues) tracker.
+
+---
+
+## Scope
+
+### In scope
+
+- The application code under `web/` (Next.js app, API routes, middleware, admin dashboard)
+- Tenant configuration under `sites/` (schema validation, injection vectors)
+- The composition engine and section rendering
+- Integration adapters (`web/lib/integrations/*`) — CRM, booking, email, analytics
+- Supabase schema + RLS policies (`web/db/migrations/*`)
+- Observability pipeline (log redaction effectiveness)
+- Compliance templates (`src/compliance/*`)
+
+### Out of scope
+
+- Third-party services the app integrates with (Supabase, Cloudflare, Sentry, Axiom, HubSpot, Calendly, Mailchimp, GA4). Report those to their respective security teams.
+- Self-hosted instances / forks run outside our deployment.
+- Known accepted risks documented here (see [Known risks](#known-risks) below).
+- Security issues in archived content (`docs/archive/*`) that don't reflect current deployments.
+
+---
+
+## Supported versions
+
+The project is pre-1.0 and ships from `Main`. Only the current `Main` is security-supported. Old commits on merged feature branches are not patched.
+
+---
+
+## Architectural invariants (security-relevant)
+
+Enforced by tests and lint rules — see [`ARCHITECTURE.md § architectural invariants`](./ARCHITECTURE.md#5-architectural-invariants):
+
+1. **Every Supabase query filters by `business_id`.** Multi-tenant isolation is non-negotiable. Enforced by `web/tests/unit/scoped-query-audit.test.ts`. If you find a query that bypasses `scopedQueries()`, treat as security issue.
+2. **Service-role key never ships to the browser.** `SUPABASE_SERVICE_ROLE_KEY` is server-only. Anon/publishable keys are RLS-gated.
+3. **PII redaction on every log line.** `web/lib/obs/redact.ts` sanitises emails, JWTs, bearer tokens, card numbers. If you find unredacted PII in logs, that's a fix.
+4. **All API routes wrap through `withRequestLog`** — provides structured logging + ALS context. Bypassing it means no audit trail.
+5. **CSP is canonical in `next.config.mjs`** — the middleware removed its duplicate (PR #32). Do not re-add a stricter CSP in middleware without coordinating with tenant font/image CSP requirements.
+
+---
+
+## Known risks
+
+Tracked here for transparency. None are exploitable as shipped; all are documented tradeoffs or work-in-progress.
+
+### Publishable Supabase keys in archived docs
+
+Two Supabase publishable (anon) keys appear in `docs/archive/2026-04/QUICK_DEPLOY.md` and `docs/archive/2026-04/HOSTINGER_CLOUDFLARE_SETUP.md`:
+- `okddppczckbjdotrxiev.supabase.co` + `sb_publishable_OUyNICSV7NILUISky8xVBA_zckVFHmP`
+- `qyvokpribmbrosafntqa.supabase.co` + `sb_publishable_KQ-sFNr7r6AauoG0B4nyTg_vuPHmeCm`
+
+These keys are **publishable (client-safe)** by Supabase design — RLS enforces at the DB layer. Risk: low. Action: verify which (if either) project is live and rotate the publishable key as a hygiene measure. See [`docs/archive/2026-04/README.md`](./docs/archive/2026-04/README.md).
+
+### Admin dashboard auth
+
+Admin routes (`/admin/*`) are gated by Supabase Auth in `web/middleware.ts`. When `NEXT_PUBLIC_SUPABASE_URL` is a placeholder (local dev), the auth check is bypassed. **Make sure production deployments have the real Supabase URL set** — a placeholder leaves `/admin` open.
+
+### No rate limiting by default
+
+`middleware.ts` applies rate-limiting via Upstash only when `UPSTASH_REDIS_REST_URL` is set. Absent that, `/api/*` routes accept unbounded requests. Enable in production for any tenant exposing forms or integrations.
+
+### Assets bundled with Worker
+
+Tenant images live in `sites/<slug>/assets/` and ship with the Worker bundle. Risk: a malicious image file can't execute, but a large bundle raises cold-start time. Planned mitigation: move to R2 or Cloudinary per [`docs/reference/ENV_VARS.md`](./docs/reference/ENV_VARS.md).
+
+---
+
+## Secure development practices
+
+Contributors are expected to follow the practices in [`CONTRIBUTING.md`](./CONTRIBUTING.md). Security-specific reminders:
+
+- **Never commit `.env*`, keys, tokens, or credentials.** Pre-commit hooks catch common patterns; do not bypass.
+- **Use `scopedQueries()` for every tenant-table access.** The audit test will fail otherwise.
+- **Validate all API input with Zod.** Boundary validation is the only place untrusted input enters trusted code.
+- **Sanitize HTML** via `web/lib/security/sanitize.ts` before rendering any user-provided content.
+- **Redact before logging** any user-provided field.
+- **Run `npm audit` on dependency changes.** Fix high/critical severities before merging.
+
+---
+
+## Response process
+
+Upon receiving a vulnerability report:
+
+1. Acknowledge within 5 business days.
+2. Assess severity (CVSS 3.1).
+3. For critical/high: patch + deploy within 14 days; coordinate disclosure with reporter.
+4. For medium/low: patch in the next regular release cycle.
+5. Credit the reporter publicly (in `CHANGELOG.md` under Security) unless anonymity is requested.
+
+---
+
+_Last reviewed: April 2026._

--- a/docs/tutorials/first-tenant-site.md
+++ b/docs/tutorials/first-tenant-site.md
@@ -1,0 +1,260 @@
+# Tutorial: build your first tenant site
+
+In this tutorial you'll create a complete tenant from scratch — a fictional **Mi Café** coffee shop in Asunción — and see it render at `http://localhost:3000/s/es/mi-cafe`. No code changes; pure JSON configuration.
+
+**Time:** ~15 minutes.
+
+**Prerequisites:** you've [installed and run the dev server](../../CONTRIBUTING.md#setup) at least once. You have `npm run dev` working.
+
+By the end you'll understand:
+- How tenants are structured under `sites/<slug>/`
+- How the composition engine merges vertical defaults + tenant config + content
+- How to add and reorder sections on a page
+- How to validate a tenant before committing
+
+If you want the full reference for any step, follow the links to the [reference docs](../reference/).
+
+---
+
+## Step 1 — Create the tenant directory
+
+```bash
+cd sites
+mkdir -p mi-cafe/{pages,content,assets}
+```
+
+Your new tenant has an empty skeleton. The engine needs a minimum of `site.json` + one page + one content locale to render.
+
+---
+
+## Step 2 — Declare the tenant
+
+Create `sites/mi-cafe/site.json`:
+
+```json
+{
+  "slug": "mi-cafe",
+  "displayName": "Mi Café",
+  "hostnames": ["mi-cafe.local"],
+  "businessType": "restaurant",
+  "verticalId": "food-beverage",
+  "defaultLocale": "es",
+  "locales": ["es"],
+  "features": {
+    "booking": false,
+    "blog": false,
+    "contact": true
+  },
+  "integrations": {
+    "analytics": null
+  }
+}
+```
+
+Notes:
+- `slug` **must** match the directory name.
+- `businessType` must exist in [`src/registry/`](../../src/registry/) — `restaurant.type.json` is already there.
+- `hostnames` is used by [`middleware.ts`](../../web/middleware.ts) to map production domains → tenant. For local dev any placeholder works.
+- `defaultLocale` + `locales` determine which `content/<locale>.json` files are expected.
+
+Full schema reference: [`docs/reference/BUSINESS_TYPES.md § tenant directory schema`](../reference/BUSINESS_TYPES.md#tenant-directory-schema).
+
+---
+
+## Step 3 — Define the home page
+
+Create `sites/mi-cafe/pages/home.json`:
+
+```json
+{
+  "slug": "",
+  "titleKey": "home.seo.title",
+  "descriptionKey": "home.seo.description",
+  "sections": [
+    { "id": "header", "variant": "standard", "content": "navigation" },
+    { "id": "hero", "variant": "image", "content": "home.hero" },
+    { "id": "menu-categorized-priced", "variant": "standard", "content": "home.menu" },
+    { "id": "open-hours-status", "variant": "standard", "content": "home.hours" },
+    { "id": "contact", "variant": "split", "content": "home.contact" },
+    { "id": "footer", "variant": "standard", "content": "footer" },
+    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+  ]
+}
+```
+
+- Each `sections[]` entry tells the renderer: use section `id`, variant `variant`, hydrated from content key `content`.
+- All section ids here are kebab-case keys registered in [`web/lib/engine/renderer.tsx`](../../web/lib/engine/renderer.tsx).
+- The full list of 83 available sections with one-line descriptions: [`docs/reference/SECTIONS.md`](../reference/SECTIONS.md).
+
+---
+
+## Step 4 — Write the Spanish copy
+
+Create `sites/mi-cafe/content/es.json`:
+
+```json
+{
+  "home": {
+    "seo": {
+      "title": "Mi Café | Asunción",
+      "description": "Café de especialidad en el corazón de Asunción. Desayunos, almuerzos y postres."
+    },
+    "hero": {
+      "headline": "Un buen café cambia el día",
+      "subhead": "Abierto de 7h a 20h. Asunción, Avda. Mariscal López 1234.",
+      "ctaText": "Ver menú",
+      "ctaHref": "#menu"
+    },
+    "menu": {
+      "title": "Nuestro menú",
+      "categories": [
+        {
+          "name": "Café de especialidad",
+          "items": [
+            { "name": "Espresso",      "price": "PYG 12.000" },
+            { "name": "Cortado",       "price": "PYG 15.000" },
+            { "name": "Flat white",    "price": "PYG 18.000" },
+            { "name": "Latte",         "price": "PYG 20.000" }
+          ]
+        },
+        {
+          "name": "Para acompañar",
+          "items": [
+            { "name": "Medialuna",     "price": "PYG 8.000" },
+            { "name": "Tostada de palta", "price": "PYG 25.000" },
+            { "name": "Cheesecake",    "price": "PYG 22.000" }
+          ]
+        }
+      ]
+    },
+    "hours": {
+      "label": "Abierto ahora",
+      "schedule": "Lunes a sábado: 7:00 — 20:00. Domingo: 8:00 — 14:00."
+    },
+    "contact": {
+      "title": "Visitános",
+      "address": "Avda. Mariscal López 1234, Asunción",
+      "phone": "+595 21 555-0123",
+      "email": "hola@mi-cafe.com.py",
+      "hours": "Lun–Sáb 7:00–20:00 · Dom 8:00–14:00"
+    }
+  },
+  "navigation": {
+    "logo": "Mi Café",
+    "links": [
+      { "label": "Menú",    "href": "#menu" },
+      { "label": "Contacto", "href": "#contacto" }
+    ],
+    "cta": { "label": "Cómo llegar", "href": "#contacto" }
+  },
+  "footer": {
+    "copyright": "© Mi Café · Asunción, Paraguay",
+    "links": []
+  },
+  "whatsapp": {
+    "number": "595975550123",
+    "message": "Hola, tengo una pregunta sobre Mi Café."
+  }
+}
+```
+
+The content-key paths in `pages/home.json` (`home.hero`, `home.menu`, etc.) resolve into this JSON. Each section gets the object at its key as props.
+
+---
+
+## Step 5 — (Optional) Override brand colors
+
+The `restaurant` business type inherits tokens from the `food-beverage` vertical. To override:
+
+Create `sites/mi-cafe/tokens.json`:
+
+```json
+{
+  "colors": {
+    "primary": "#6F4E37",
+    "primary-foreground": "#FFFFFF",
+    "accent": "#D4A574",
+    "surface": "#FAF5EE"
+  },
+  "fonts": {
+    "heading": "Playfair Display",
+    "body": "Inter"
+  }
+}
+```
+
+These merge into `var(--primary)`, `var(--accent)`, etc. that section components consume. Full token reference: [`docs/reference/TOKENS.md`](../reference/TOKENS.md).
+
+---
+
+## Step 6 — Validate
+
+```bash
+cd web
+npx tsx scripts/validate-sites.ts
+```
+
+If everything is correct you'll see `mi-cafe ✓`. If not, the script lists missing content keys, unknown section ids, or locale mismatches.
+
+---
+
+## Step 7 — Render
+
+Start the dev server if it isn't running:
+
+```bash
+npm run dev
+```
+
+Open <http://localhost:3000/s/es/mi-cafe>.
+
+You should see a full café site: hero with the Playfair Display headline, categorized menu with prices, open-hours indicator, contact block, WhatsApp float button, footer.
+
+Inspect the HTML — note:
+- `<html lang="es">`
+- A JSON-LD script tag with a `LocalBusiness` / `Restaurant` schema (generated by `web/lib/seo/json-ld.ts`)
+- CSS variables on `:root` matching your `tokens.json`
+
+---
+
+## Step 8 — Experiment
+
+Try any of these. Each is a pure JSON change; no restart needed (Next.js hot-reloads):
+
+- **Reorder sections** — swap `menu` and `hours` in `pages/home.json` and watch the page change.
+- **Add a new section** — grab any id from [SECTIONS.md](../reference/SECTIONS.md) (say, `testimonials`) and wire its content under a new key in `content/es.json`.
+- **Add an English locale** — create `content/en.json` with the same key structure, add `"en"` to `site.json/locales`. Visit `/s/en/mi-cafe`.
+- **Change primary color** — tweak `tokens.json` and refresh. Every section that uses `var(--primary)` updates.
+
+---
+
+## What just happened
+
+The composition engine:
+1. Matched `/s/es/mi-cafe` to `sites/mi-cafe/site.json`.
+2. Loaded `restaurant.type.json` + `food-beverage` vertical defaults.
+3. Merged tokens: `base.tokens.json` → `food-beverage.tokens.json` → `restaurant.tokens.json` → `sites/mi-cafe/tokens.json`. Later layers override earlier.
+4. Loaded `pages/home.json` and `content/es.json`.
+5. For each section in `pages/home.json`:
+   - Resolved the content key from `content/es.json`.
+   - Looked up the React component by kebab id in `renderer.tsx`.
+   - Rendered with the resolved props + CSS-var tokens.
+6. Shipped SSR HTML + JSON-LD + alternate hreflang tags.
+
+The full request lifecycle: [`/ARCHITECTURE.md § request lifecycle`](../../ARCHITECTURE.md#3-request-lifecycle).
+
+---
+
+## Next steps
+
+- Add a second page (`pages/about.json`) — repeat Steps 3 + 4 with a new slug like `"about"`.
+- Add more locales — duplicate `content/es.json` as `content/en.json`, translate, add to `site.json/locales`.
+- Put real images in `sites/mi-cafe/assets/` and reference them. See [`docs/how-to/generate-images.md`](../how-to/generate-images.md).
+- Enable a real integration — add `"analytics": "ga4"` to `site.json` + set `GA4_MEASUREMENT_ID` in env. See [`docs/reference/API.md`](../reference/API.md).
+- Deploy — see [`docs/how-to/deploy.md`](../how-to/deploy.md).
+
+If something didn't work, run `npx tsx web/scripts/tenant-health.ts` against your tenant — it'll report any config or rendering issues.
+
+---
+
+_Last reviewed: April 2026._


### PR DESCRIPTION
## Summary

**Phase F** — the final consolidation phase. Adds the canonical root-level files a mature OSS repo expects, plus the first Diataxis tutorial.

## New at repo root

- **\`CHANGELOG.md\`** — Common Changelog format. Includes full 2026-04-20 entry covering the 9 merged feature PRs + 6 docs consolidation phases A–F. Points to archive for prior history.
- **\`SECURITY.md\`** — reporting policy, scope, architectural invariants (security-relevant), known risks (including the publishable-key archive-hygiene item), response process.
- **\`CODE_OF_CONDUCT.md\`** — Contributor Covenant v2.1.

## New tutorial

- **\`docs/tutorials/first-tenant-site.md\`** — 8-step walkthrough building a fictional "Mi Café" tenant from scratch. ~280 lines. Cross-links to every reference doc.

## Not in this PR (consolidation plan § Phase F)

- **\`LICENSE\`** — requires org-level decision on license choice (MIT / Apache 2.0 / proprietary). Left for you to add.
- **OpenAPI spec via \`next-openapi-gen\`** — separate feature PR.
- **First \`docs/runbooks/*\` entry** — to be added when the first real alert is defined.

## Consolidation plan status

Phase A ✓ · B.1 ✓ · B.2 ✓ · B.3 ✓ · C ✓ · D ✓ · E ✓ · **F (this PR)** ✓

After this merges, the docs reorg described in \`docs/DOCS_CONSOLIDATION_PLAN.md\` is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)