### PR TITLE
fix(deploy): use FETCH_HEAD after targeted fetch; check in deploy-vps.sh

### DIFF
--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Deploy the paragu-ai Next.js app to the Hostinger VPS swarm.
+#
+# Used by .github/workflows/deploy.yml (SSHed in) and by humans on the VPS.
+# Pulls the latest of a given branch, rebuilds the Docker image, and rolls
+# the swarm service in place (zero-downtime via update_config.order=start-first
+# declared on the service spec).
+#
+# Layout on the VPS:
+#   /opt/stacks/paragu-ai-builder/   repo clone — ref is rewritten on each run
+#   /etc/paragu-ai/env                secrets (chmod 600), sourced here
+#   /opt/stacks/paragu-ai-builder/stack-prod.yml
+#   /opt/stacks/paragu-ai-builder/stack-staging.yml
+#
+# Canonical copy of this script lives at the same path on the VPS — CI
+# invokes the on-VPS copy; this file is the source of truth when it needs
+# updating. Copy to the VPS with:
+#   scp scripts/deploy-vps.sh root@72.61.44.159:/opt/stacks/paragu-ai-builder/deploy.sh
+#
+# Usage on the VPS:
+#   ./deploy.sh prod                 # Main → paragu-ai_web
+#   ./deploy.sh staging              # staging branch → paragu-ai-staging_web
+#   ./deploy.sh staging <branch>     # deploy any branch to staging (hotfix previews)
+set -euo pipefail
+
+ENV=${1:-prod}
+BRANCH=${2:-}
+if [ -z "$BRANCH" ]; then
+  if [ "$ENV" = "prod" ]; then BRANCH=Main; else BRANCH=staging; fi
+fi
+echo "[deploy] env=$ENV branch=$BRANCH"
+
+REPO_DIR=${REPO_DIR:-/opt/stacks/paragu-ai-builder}
+SECRETS=${SECRETS:-/etc/paragu-ai/env}
+
+cd "$REPO_DIR"
+
+# Fetch only the ref we want. --prune drops stale tracking refs (e.g.
+# the feature branch that got deleted on merge). FETCH_HEAD is the
+# canonical pointer to "what we just fetched" — using it avoids stale
+# refs/remotes/origin/<branch> indirection.
+git fetch --prune origin "$BRANCH"
+git reset --hard FETCH_HEAD
+echo "[deploy] HEAD: $(git log --oneline -1)"
+
+TAG="paragu-ai:$ENV"
+APP_URL="https://paragu-ai.com"
+[ "$ENV" = "staging" ] && APP_URL="https://staging.paragu-ai.com"
+
+# shellcheck disable=SC1090
+set -a; source "$SECRETS"; set +a
+
+docker build -f web/Dockerfile \
+  --build-arg NEXT_PUBLIC_SUPABASE_URL="$NEXT_PUBLIC_SUPABASE_URL" \
+  --build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY="$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
+  --build-arg SUPABASE_SERVICE_ROLE_KEY="$SUPABASE_SERVICE_ROLE_KEY" \
+  --build-arg NEXT_PUBLIC_APP_URL="$APP_URL" \
+  -t "$TAG" . 2>&1 | tail -5
+
+SERVICE="paragu-ai_web"
+[ "$ENV" = "staging" ] && SERVICE="paragu-ai-staging_web"
+
+# --force triggers a new task even when tag is reused (build digest differs)
+docker service update --with-registry-auth --force --image "$TAG" "$SERVICE" 2>&1 | tail -5
+
+echo "[deploy] done. service=$SERVICE tag=$TAG"


### PR DESCRIPTION
Follow-up to PR #51. First CI deploy (run 24689627134) failed because the VPS repo was still tracking the feature branch that got auto-deleted on merge; `git fetch origin` errored before reset could run.

Fix: fetch the target branch explicitly and reset to `FETCH_HEAD`. Also check in the canonical deploy script at `scripts/deploy-vps.sh` so future changes flow through Git.

Prod service was manually re-rolled via the patched on-VPS copy and is 1/1 healthy. Public smoke:
```
200  https://paragu-ai.com/api/health
200  https://paragu-ai.com/nexa-paraguay
200  https://paragu-ai.com/s/nl/nexa-paraguay
200  https://staging.paragu-ai.com/api/health
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)