### PR TITLE
feat(i18n): language switcher + Nexa network strip

### DIFF
--- a/web/components/sections/footer-section.tsx
+++ b/web/components/sections/footer-section.tsx
@@ -1,5 +1,6 @@
 import { Container } from '@/components/ui/container'
 import { Heading } from '@/components/ui/heading'
+import type { Locale } from '@/lib/i18n/config'
 
 export interface FooterSectionProps {
   businessName: string
@@ -11,6 +12,27 @@ export interface FooterSectionProps {
   facebook?: string
   whatsapp?: string
   navLinks?: Array<{ label: string; href: string }>
+  __siteSlug?: string
+  __locale?: Locale
+}
+
+const NEXA_GROUP: Array<{
+  slug: string
+  label: string
+  defaultLocale: Locale
+  locales: Locale[]
+}> = [
+  { slug: 'nexa-paraguay', label: 'Nexa Paraguay', defaultLocale: 'nl', locales: ['nl', 'en', 'de', 'es'] },
+  { slug: 'nexa-uruguay', label: 'Nexa Uruguay', defaultLocale: 'en', locales: ['en', 'es'] },
+  { slug: 'nexa-propiedades', label: 'Nexa Propiedades', defaultLocale: 'es', locales: ['es', 'en', 'pt'] },
+]
+
+const NETWORK_LABEL: Record<string, string> = {
+  nl: 'Nexa-netwerk',
+  en: 'Nexa network',
+  de: 'Nexa-Netzwerk',
+  es: 'Red Nexa',
+  pt: 'Rede Nexa',
 }
 
 export function FooterSection({
@@ -23,8 +45,13 @@ export function FooterSection({
   facebook,
   whatsapp,
   navLinks = [],
+  __siteSlug,
+  __locale,
 }: FooterSectionProps) {
   const year = new Date().getFullYear()
+
+  const isNexa = __siteSlug?.startsWith('nexa-') || __siteSlug === 'nexaparaguay'
+  const networkHeading = (__locale && NETWORK_LABEL[__locale]) || NETWORK_LABEL.en
 
   return (
     <footer className="bg-[var(--primary)] py-12 text-[var(--primary-foreground)]">
@@ -128,6 +155,27 @@ export function FooterSection({
             </div>
           )}
         </div>
+
+        {isNexa && (
+          <div className="mt-10 border-t border-white/20 pt-6">
+            <h4 className="mb-3 text-xs font-semibold uppercase tracking-wider opacity-60">
+              {networkHeading}
+            </h4>
+            <ul className="flex flex-wrap gap-x-5 gap-y-2 text-sm">
+              {NEXA_GROUP.filter((g) => g.slug !== __siteSlug).map((g) => {
+                const loc = __locale && g.locales.includes(__locale) ? __locale : g.defaultLocale
+                const href = `/s/${loc}/${g.slug}`
+                return (
+                  <li key={g.slug}>
+                    <a href={href} className="opacity-80 transition-opacity hover:opacity-100">
+                      {g.label}
+                    </a>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        )}
 
         <div className="mt-10 border-t border-white/20 pt-6 text-center text-sm opacity-60">
           {year} {businessName}. Todos los derechos reservados.

--- a/web/components/sections/header-section.tsx
+++ b/web/components/sections/header-section.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Container } from '@/components/ui/container'
+import { LOCALE_LABELS, type Locale } from '@/lib/i18n/config'
+import { buildLocaleUrl } from '@/lib/i18n/routing'
 
 export interface NavItem {
   label: string
@@ -14,6 +16,10 @@ export interface HeaderSectionProps {
   navItems: NavItem[]
   ctaText?: string
   ctaHref?: string
+  __siteSlug?: string
+  __locale?: Locale
+  __availableLocales?: Locale[]
+  __currentPath?: string
 }
 
 export function HeaderSection({
@@ -21,8 +27,47 @@ export function HeaderSection({
   navItems,
   ctaText,
   ctaHref = '#contacto',
+  __siteSlug,
+  __locale,
+  __availableLocales,
+  __currentPath = '',
 }: HeaderSectionProps) {
   const [mobileOpen, setMobileOpen] = useState(false)
+
+  const showLocaleSwitch =
+    !!__siteSlug && !!__locale && !!__availableLocales && __availableLocales.length > 1
+
+  const renderLocaleSwitch = (variant: 'desktop' | 'mobile') => {
+    if (!showLocaleSwitch) return null
+    const wrapperClass =
+      variant === 'desktop'
+        ? 'ml-2 hidden items-center gap-2 border-l border-[var(--surface-light)] pl-4 md:flex'
+        : 'mt-3 flex items-center gap-3 border-t border-[var(--surface-light)] pt-3'
+    return (
+      <nav aria-label="Language" className={wrapperClass}>
+        {__availableLocales!.map((loc) => {
+          const href = buildLocaleUrl(loc, __siteSlug!, __currentPath)
+          const active = loc === __locale
+          return (
+            <a
+              key={loc}
+              href={href}
+              hrefLang={loc}
+              aria-current={active ? 'true' : undefined}
+              title={LOCALE_LABELS[loc]}
+              className={
+                active
+                  ? 'text-xs font-semibold uppercase tracking-wider text-[var(--secondary)]'
+                  : 'text-xs uppercase tracking-wider text-[var(--text-muted)] transition-colors hover:text-[var(--text)]'
+              }
+            >
+              {loc}
+            </a>
+          )
+        })}
+      </nav>
+    )
+  }
 
   return (
     <header className="sticky top-0 z-50 bg-[var(--surface)] shadow-nav">
@@ -53,6 +98,7 @@ export function HeaderSection({
                 {ctaText}
               </Button>
             )}
+            {renderLocaleSwitch('desktop')}
           </nav>
 
           {/* Mobile toggle */}
@@ -83,6 +129,7 @@ export function HeaderSection({
                 {ctaText}
               </Button>
             )}
+            {renderLocaleSwitch('mobile')}
           </nav>
         )}
       </Container>

--- a/web/lib/engine/compose-site.ts
+++ b/web/lib/engine/compose-site.ts
@@ -108,6 +108,8 @@ export function composeSitePage(input: ComposeInput): ResolvedPage {
           __siteSlug: site.slug,
           __locale: locale,
           __country: site.country,
+          __availableLocales: site.locales,
+          __currentPath: pageSlug === DEFAULT_PAGE_SLUG ? '' : pageSlug,
         }
         return { id: s.id, variant, props }
       } catch (err) {


### PR DESCRIPTION
## Summary

Addresses two usability gaps across the three Nexa tenants (paragu-ai.com/s/[locale]/nexa-paraguay|uruguay|propiedades):

- **Language switcher** — visitors had hreflang metadata but no on-page way to switch. The `LanguageSwitcher` component existed but wasn't imported anywhere.
  - Now rendered in `HeaderSection` (desktop + mobile), uppercase two-letter codes, preserves current path, `aria-current` on active locale.
  - Driven by `__availableLocales` + `__currentPath` that `compose-site.ts` now injects alongside the existing `__locale` / `__siteSlug` / `__country` props.
  - Auto-appears on any tenant with >1 locale — no per-site configuration.

- **Cross-Nexa network strip** — each Nexa site was siloed; a visitor on nexa-paraguay couldn't discover nexa-uruguay or nexa-propiedades.
  - Footer renders a localized "Nexa network" / "Red Nexa" / "Nexa-netwerk" strip on `nexa-*` slugs only.
  - Each cross-link respects the target site's supported locales (e.g. if you're on `/nl/nexa-paraguay`, the link to nexa-uruguay falls back to its default `en` since `nl` isn't enabled there).

## Test plan

- [x] `tsc --noEmit` — clean after clearing stale `.next/{dev,types}/validator.ts` codegen artifacts
- [x] `npm test` — 361 passing / 11 skipped (unchanged)
- [x] Lint on touched files — clean
- [x] Local dev smoke — verified switcher renders with all 4 locales on `/s/en/nexa-paraguay`, with `aria-current="true"` on the active one and `hreflang` on all four. Network strip renders cross-links on all three Nexa tenants with locale-appropriate heading.
- [ ] Post-merge: confirm live URLs on `paragu-ai.com/s/*/nexa-paraguay|uruguay|propiedades` show the switcher + network strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)