### PR TITLE
feat(landing): /precios + /casos + /p/[rubro] pages + supporting components

### DIFF
--- a/web/app/casos/[cliente]/page.tsx
+++ b/web/app/casos/[cliente]/page.tsx
@@ -1,0 +1,177 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowRight, Check, ExternalLink, MessageCircle } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { CASE_STUDIES } from '@/lib/landing/case-studies'
+import { REAL_CLIENTS, waLink } from '@/lib/landing/marketing-data'
+
+type Params = { cliente: string }
+
+export function generateStaticParams() {
+  return CASE_STUDIES.map((c) => ({ cliente: c.slug }))
+}
+
+export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
+  const { cliente } = await params
+  const cs = CASE_STUDIES.find((c) => c.slug === cliente)
+  if (!cs) return { title: 'Caso no encontrado' }
+  return {
+    title: cs.headline,
+    description: cs.lead,
+    alternates: { canonical: `/casos/${cliente}` },
+    openGraph: { title: cs.headline, description: cs.lead, type: 'article' },
+  }
+}
+
+export default async function CaseStudyPage({ params }: { params: Promise<Params> }) {
+  const { cliente } = await params
+  const cs = CASE_STUDIES.find((c) => c.slug === cliente)
+  if (!cs) notFound()
+
+  const client = REAL_CLIENTS.find((c) => c.slug === cs.slug)
+  const color = client?.color ?? '#6366f1'
+  const next = CASE_STUDIES[(CASE_STUDIES.findIndex((c) => c.slug === cliente) + 1) % CASE_STUDIES.length]
+
+  const waMessage = `Hola, vi el caso de ${cs.slug.replace(/-/g, ' ')} en ParaguAI y quiero algo similar para mi negocio.`
+
+  return (
+    <>
+      <SiteNav />
+
+      <main>
+        {/* Hero */}
+        <section className="relative overflow-hidden pt-32 pb-12 md:pt-40 md:pb-20">
+          <div
+            aria-hidden
+            className="absolute inset-0 -z-10 opacity-10"
+            style={{
+              background: `radial-gradient(circle at 50% 0%, ${color} 0%, transparent 60%)`,
+            }}
+          />
+          <Container>
+            <div className="mx-auto max-w-3xl">
+              <Link
+                href="/casos"
+                className="mb-6 inline-flex items-center gap-1 text-sm font-medium text-[var(--text-light)] hover:text-[var(--primary)]"
+              >
+                ← Todos los casos
+              </Link>
+              <p className="mb-3 text-sm font-bold uppercase tracking-wider" style={{ color }}>
+                {cs.vertical} · {cs.period}
+              </p>
+              <h1 className="mb-6 text-4xl font-bold leading-tight text-[var(--text)] sm:text-5xl">
+                {cs.headline}
+              </h1>
+              <p className="mb-8 text-lg text-[var(--text-light)] md:text-xl">{cs.lead}</p>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href={cs.liveUrl}
+                  className="inline-flex items-center justify-center gap-2 rounded-2xl border-2 border-[var(--border)] bg-[var(--surface)] px-6 py-3 font-bold text-[var(--text)] transition-all hover:border-[var(--primary)] hover:text-[var(--primary)]"
+                >
+                  Ver el sitio en vivo
+                  <ExternalLink size={18} />
+                </Link>
+                <a
+                  href={waLink(waMessage)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-2 rounded-2xl bg-[var(--primary)] px-6 py-3 font-bold text-[var(--primary-foreground)] shadow-lg transition-all hover:opacity-90"
+                >
+                  <MessageCircle size={18} />
+                  Quiero algo así
+                </a>
+              </div>
+            </div>
+          </Container>
+        </section>
+
+        {/* Outcomes */}
+        <section className="border-y border-[var(--border)] bg-[var(--surface-light)] py-16">
+          <Container>
+            <div className="mx-auto max-w-3xl">
+              <h2 className="mb-8 text-2xl font-bold text-[var(--text)]">Lo que cambió</h2>
+              <ul className="grid gap-4 sm:grid-cols-2">
+                {cs.outcomes.map((o) => (
+                  <li
+                    key={o}
+                    className="flex items-start gap-3 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4"
+                  >
+                    <span
+                      className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full"
+                      style={{ backgroundColor: `${color}20`, color }}
+                    >
+                      <Check size={14} />
+                    </span>
+                    <span className="text-sm text-[var(--text)]">{o}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </Container>
+        </section>
+
+        {/* Story body */}
+        <section className="py-20">
+          <Container>
+            <article className="mx-auto max-w-3xl space-y-10">
+              <div>
+                <h2 className="mb-3 text-2xl font-bold text-[var(--text)]">El desafío</h2>
+                <p className="text-lg leading-relaxed text-[var(--text-light)]">{cs.challenge}</p>
+              </div>
+              <div>
+                <h2 className="mb-3 text-2xl font-bold text-[var(--text)]">Lo que hicimos</h2>
+                <p className="text-lg leading-relaxed text-[var(--text-light)]">{cs.approach}</p>
+              </div>
+            </article>
+          </Container>
+        </section>
+
+        {/* CTA + next */}
+        <section className="border-t border-[var(--border)] bg-[var(--surface-light)] py-16">
+          <Container>
+            <div className="mx-auto max-w-2xl text-center">
+              <h2 className="mb-4 text-2xl font-bold text-[var(--text)]">
+                ¿Tu negocio puede ser el próximo caso?
+              </h2>
+              <p className="mb-6 text-[var(--text-light)]">
+                Mandanos los datos por WhatsApp y armamos tu demo en 48 horas.
+              </p>
+              <a
+                href={waLink('Hola, vi un caso en ParaguAI y quiero hablar de mi negocio.')}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-[var(--primary)] to-[var(--accent)] px-8 py-4 font-bold text-[var(--primary-foreground)] shadow-lg transition-all hover:-translate-y-1"
+              >
+                <MessageCircle size={18} />
+                Pedir demo gratis
+              </a>
+            </div>
+
+            <div className="mx-auto mt-16 max-w-3xl">
+              <Link
+                href={`/casos/${next.slug}`}
+                className="group flex items-center justify-between gap-4 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 transition-all hover:-translate-y-1 hover:border-[var(--primary)]/30 hover:shadow-md"
+              >
+                <div>
+                  <p className="text-xs font-bold uppercase tracking-wider text-[var(--text-muted)]">
+                    Próximo caso
+                  </p>
+                  <p className="mt-1 font-bold text-[var(--text)]">{next.headline}</p>
+                </div>
+                <ArrowRight
+                  size={20}
+                  className="shrink-0 text-[var(--primary)] transition-transform group-hover:translate-x-1"
+                />
+              </Link>
+            </div>
+          </Container>
+        </section>
+      </main>
+
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/app/casos/page.tsx
+++ b/web/app/casos/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, ExternalLink } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { CASE_STUDIES } from '@/lib/landing/case-studies'
+import { REAL_CLIENTS } from '@/lib/landing/marketing-data'
+
+export const metadata: Metadata = {
+  title: 'Casos reales — sitios publicados con ParaguAI',
+  description:
+    'Historias completas de cómo nuestros clientes pasaron de la idea al sitio en producción. Sin maquetas: links a sitios reales y resultados medibles.',
+  alternates: { canonical: '/casos' },
+}
+
+export default function CaseStudiesIndexPage() {
+  return (
+    <>
+      <SiteNav />
+      <main className="pt-24 pb-20">
+        <Container>
+          <div className="mx-auto mb-16 max-w-2xl text-center">
+            <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">
+              Casos reales
+            </p>
+            <h1 className="mb-4 text-4xl font-bold text-[var(--text)] sm:text-5xl">
+              No son maquetas. Son sitios online hoy.
+            </h1>
+            <p className="text-lg text-[var(--text-light)]">
+              Cada caso es un negocio real, con una historia real y un sitio que podés visitar
+              ahora mismo. Click para leer cómo lo construimos.
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            {CASE_STUDIES.map((cs) => {
+              const client = REAL_CLIENTS.find((c) => c.slug === cs.slug)
+              const color = client?.color ?? 'var(--primary)'
+              return (
+                <article
+                  key={cs.slug}
+                  className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-7 transition-all hover:-translate-y-1 hover:border-[var(--primary)]/30 hover:shadow-xl"
+                >
+                  <div className="mb-5 h-1.5 w-16 rounded-full" style={{ backgroundColor: color }} />
+                  <p className="mb-2 text-xs font-bold uppercase tracking-wider text-[var(--text-muted)]">
+                    {cs.vertical} · {cs.period}
+                  </p>
+                  <h2 className="mb-3 text-xl font-bold text-[var(--text)]">{cs.headline}</h2>
+                  <p className="mb-6 text-sm text-[var(--text-light)]">{cs.lead}</p>
+                  <ul className="mb-6 space-y-1.5 text-sm text-[var(--text)]">
+                    {cs.outcomes.slice(0, 3).map((o) => (
+                      <li key={o} className="flex items-start gap-2">
+                        <span className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />
+                        {o}
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="mt-auto flex items-center justify-between gap-3">
+                    <Link
+                      href={`/casos/${cs.slug}`}
+                      className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--primary)]"
+                    >
+                      Leer caso completo
+                      <ArrowRight size={14} className="transition-transform group-hover:translate-x-1" />
+                    </Link>
+                    <Link
+                      href={cs.liveUrl}
+                      className="inline-flex items-center gap-1 text-sm text-[var(--text-light)] hover:text-[var(--text)]"
+                    >
+                      Sitio en vivo
+                      <ExternalLink size={12} />
+                    </Link>
+                  </div>
+                </article>
+              )
+            })}
+          </div>
+        </Container>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/app/p/[rubro]/page.tsx
+++ b/web/app/p/[rubro]/page.tsx
@@ -1,0 +1,203 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowRight, Check, ExternalLink, MessageCircle, Sparkles } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { LIVE_TEMPLATES, TEMPLATES, waLink, type Template } from '@/lib/landing/marketing-data'
+
+type Params = { rubro: string }
+
+function findTemplate(rubro: string): Template | undefined {
+  return LIVE_TEMPLATES.find((t) => (t.seoSlug ?? t.id.replace(/_/g, '-')) === rubro)
+}
+
+export function generateStaticParams() {
+  return LIVE_TEMPLATES.map((t) => ({ rubro: t.seoSlug ?? t.id.replace(/_/g, '-') }))
+}
+
+export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
+  const { rubro } = await params
+  const t = findTemplate(rubro)
+  if (!t) return { title: 'Plantilla no encontrada' }
+  const title = t.seoHeadline ?? `Sitio web para ${t.name.toLowerCase()} — listo en 48 horas`
+  const description =
+    t.seoLead ??
+    `Plantilla profesional especializada para ${t.name.toLowerCase()} en Paraguay. Demo gratis antes de pagar.`
+  return {
+    title,
+    description,
+    alternates: { canonical: `/p/${rubro}` },
+    openGraph: { title, description, type: 'website' },
+  }
+}
+
+export default async function VerticalLandingPage({ params }: { params: Promise<Params> }) {
+  const { rubro } = await params
+  const t = findTemplate(rubro)
+  if (!t) notFound()
+
+  const headline = t.seoHeadline ?? `Sitio web para ${t.name.toLowerCase()}, listo en 48 horas`
+  const lead =
+    t.seoLead ??
+    `Plantilla profesional pensada específicamente para ${t.name.toLowerCase()}. Vos no tocás nada — nosotros publicamos.`
+
+  const waMessage = `Hola, me interesa la plantilla de ${t.name} para mi negocio en Paraguay.`
+
+  const sister = LIVE_TEMPLATES.filter((x) => x.id !== t.id).slice(0, 4)
+
+  return (
+    <>
+      <SiteNav />
+
+      <main>
+        {/* Hero */}
+        <section className="relative overflow-hidden pt-32 pb-16 md:pt-40 md:pb-24">
+          <div
+            aria-hidden
+            className="absolute inset-0 -z-10 opacity-20"
+            style={{
+              background: `radial-gradient(circle at 70% 30%, ${t.color}33 0%, transparent 50%)`,
+            }}
+          />
+          <Container>
+            <div className="mx-auto max-w-3xl text-center">
+              <div
+                className="mx-auto mb-6 inline-flex h-14 w-14 items-center justify-center rounded-2xl"
+                style={{ backgroundColor: `${t.color}15`, color: t.color }}
+              >
+                <Sparkles size={28} />
+              </div>
+              <p className="mb-3 text-sm font-bold uppercase tracking-wider" style={{ color: t.color }}>
+                Plantilla {t.name}
+              </p>
+              <h1 className="mb-6 text-4xl font-bold leading-tight text-[var(--text)] sm:text-5xl md:text-6xl">
+                {headline}
+              </h1>
+              <p className="mx-auto mb-10 max-w-2xl text-lg text-[var(--text-light)] md:text-xl">
+                {lead}
+              </p>
+              <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+                <a
+                  href={waLink(waMessage)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group inline-flex items-center gap-2 rounded-2xl bg-[var(--primary)] px-8 py-4 text-lg font-bold text-[var(--primary-foreground)] shadow-lg transition-all hover:-translate-y-1 hover:shadow-xl"
+                >
+                  <MessageCircle size={20} />
+                  Pedir demo gratis
+                  <ArrowRight size={20} className="transition-transform group-hover:translate-x-1" />
+                </a>
+                {t.demoSlug && (
+                  <Link
+                    href={`/${t.demoSlug}`}
+                    className="inline-flex items-center gap-2 rounded-2xl border-2 border-[var(--border)] bg-[var(--surface)] px-8 py-4 text-lg font-bold text-[var(--text)] transition-all hover:border-[var(--primary)] hover:text-[var(--primary)]"
+                  >
+                    Ver demo en vivo
+                    <ExternalLink size={18} />
+                  </Link>
+                )}
+              </div>
+
+              {t.leads > 0 && (
+                <p className="mt-8 text-sm text-[var(--text-muted)]">
+                  Mercado PY: <strong className="text-[var(--text)]">{t.leads.toLocaleString('es-PY')}</strong> negocios mapeados · <strong className="text-[var(--text)]">{t.pct}%</strong> sin web propia
+                </p>
+              )}
+            </div>
+          </Container>
+        </section>
+
+        {/* What's included */}
+        <section className="border-y border-[var(--border)] bg-[var(--surface-light)] py-20">
+          <Container>
+            <div className="mx-auto max-w-3xl">
+              <h2 className="mb-8 text-center text-3xl font-bold text-[var(--text)]">
+                Qué incluye tu sitio
+              </h2>
+              <ul className="grid gap-4 sm:grid-cols-2">
+                {[
+                  'Hero con tu propuesta única',
+                  'Servicios o catálogo',
+                  'Galería de fotos',
+                  'WhatsApp Business',
+                  'Google Maps + horarios',
+                  'Formulario de contacto',
+                  'SEO + Schema.org',
+                  'Hosting + SSL incluidos',
+                ].map((feat) => (
+                  <li
+                    key={feat}
+                    className="flex items-start gap-3 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4"
+                  >
+                    <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--success)]/10 text-[var(--success)]">
+                      <Check size={14} />
+                    </span>
+                    <span className="text-sm text-[var(--text)]">{feat}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </Container>
+        </section>
+
+        {/* CTA + sister verticals */}
+        <section className="py-20">
+          <Container>
+            <div className="mx-auto max-w-2xl text-center">
+              <h2 className="mb-4 text-3xl font-bold text-[var(--text)]">Listo en 48 horas</h2>
+              <p className="mb-8 text-[var(--text-light)]">
+                Mandá el nombre de tu {t.name.toLowerCase()} por WhatsApp. Te enviamos la demo
+                personalizada antes de cobrarte un solo guaraní.
+              </p>
+              <a
+                href={waLink(waMessage)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-[var(--primary)] to-[var(--accent)] px-8 py-4 text-lg font-bold text-[var(--primary-foreground)] shadow-lg transition-all hover:-translate-y-1"
+              >
+                <MessageCircle size={20} />
+                Pedir demo gratis
+              </a>
+            </div>
+
+            <div className="mx-auto mt-20 max-w-5xl">
+              <h3 className="mb-6 text-center text-sm font-bold uppercase tracking-wider text-[var(--text-muted)]">
+                ¿Tu rubro es otro? Mirá estas plantillas
+              </h3>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                {sister.map((s) => (
+                  <Link
+                    key={s.id}
+                    href={`/p/${s.seoSlug ?? s.id.replace(/_/g, '-')}`}
+                    className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4 transition-all hover:-translate-y-1 hover:border-[var(--primary)]/30 hover:shadow-md"
+                  >
+                    <div
+                      className="mb-2 h-1 w-8 rounded-full"
+                      style={{ backgroundColor: s.color }}
+                      aria-hidden
+                    />
+                    <p className="font-bold text-[var(--text)]">{s.name}</p>
+                    <p className="text-xs text-[var(--text-muted)]">Ver plantilla</p>
+                  </Link>
+                ))}
+              </div>
+              <div className="mt-6 text-center">
+                <Link
+                  href="/p"
+                  className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--primary)]"
+                >
+                  Ver las {TEMPLATES.length} plantillas
+                  <ArrowRight size={14} />
+                </Link>
+              </div>
+            </div>
+          </Container>
+        </section>
+      </main>
+
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/app/p/page.tsx
+++ b/web/app/p/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, Sparkles } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { TEMPLATES } from '@/lib/landing/marketing-data'
+
+export const metadata: Metadata = {
+  title: 'Plantillas por rubro — sitios web profesionales en 48 horas',
+  description:
+    'Plantillas especializadas por rubro: peluquería, gimnasio, spa, restaurante, barbería, sushi y más. Cada una pensada para el negocio paraguayo.',
+  alternates: { canonical: '/p' },
+}
+
+export default function TemplatesIndexPage() {
+  const live = TEMPLATES.filter((t) => t.demoSlug !== null)
+  const upcoming = TEMPLATES.filter((t) => t.demoSlug === null)
+
+  return (
+    <>
+      <SiteNav />
+      <main className="pt-24 pb-20">
+        <Container>
+          <div className="mx-auto mb-16 max-w-2xl text-center">
+            <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">
+              Plantillas
+            </p>
+            <h1 className="mb-4 text-4xl font-bold text-[var(--text)] sm:text-5xl">
+              Diseños especializados por rubro
+            </h1>
+            <p className="text-lg text-[var(--text-light)]">
+              Cada plantilla está pensada para un tipo de negocio específico — con las secciones,
+              el lenguaje y los flujos que tu rubro realmente necesita.
+            </p>
+          </div>
+
+          <h2 className="mb-6 text-xl font-bold text-[var(--text)]">Disponibles ahora</h2>
+          <div className="mb-16 grid gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {live.map((t) => {
+              const seoSlug = t.seoSlug ?? t.id.replace(/_/g, '-')
+              return (
+                <Link
+                  key={t.id}
+                  href={`/p/${seoSlug}`}
+                  className="group block rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 transition-all hover:-translate-y-1 hover:border-[var(--primary)]/30 hover:shadow-xl"
+                >
+                  <div
+                    className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-xl"
+                    style={{ backgroundColor: `${t.color}15`, color: t.color }}
+                    aria-hidden
+                  >
+                    <Sparkles size={20} />
+                  </div>
+                  <h3 className="text-lg font-bold text-[var(--text)]">{t.name}</h3>
+                  {t.leads > 0 ? (
+                    <p className="mt-1 text-sm text-[var(--text-muted)]">
+                      Mercado PY: {t.leads.toLocaleString('es-PY')} negocios · {t.pct}% sin web
+                    </p>
+                  ) : (
+                    <p className="mt-1 text-sm text-[var(--text-muted)]">Demo lista para ver</p>
+                  )}
+                  <span className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-[var(--primary)]">
+                    Ver landing y demo
+                    <ArrowRight size={14} className="transition-transform group-hover:translate-x-1" />
+                  </span>
+                </Link>
+              )
+            })}
+          </div>
+
+          <h2 className="mb-6 text-xl font-bold text-[var(--text)]">Próximamente</h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {upcoming.map((t) => (
+              <div
+                key={t.id}
+                className="rounded-xl border border-dashed border-[var(--border)] bg-[var(--surface)]/50 p-4 text-sm"
+              >
+                <p className="font-semibold text-[var(--text)]">{t.name}</p>
+                <p className="text-xs text-[var(--text-muted)]">Plantilla en desarrollo</p>
+              </div>
+            ))}
+          </div>
+        </Container>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/app/precios/page.tsx
+++ b/web/app/precios/page.tsx
@@ -1,0 +1,245 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, Check, MessageCircle, X } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { ROICalculator } from '@/components/landing/roi-calculator'
+import { PLANS, waLink } from '@/lib/landing/marketing-data'
+
+export const metadata: Metadata = {
+  title: 'Precios — sitios web profesionales en guaraníes (PYG)',
+  description:
+    'Setup único + cuota mensual baja, sin permanencia. 4 planes desde gratis hasta multi-sucursal. Mercado Pago o transferencia bancaria. 30 días de garantía.',
+  alternates: { canonical: '/precios' },
+}
+
+const FEATURE_MATRIX = [
+  { row: 'Páginas', prueba: '1', presencia: 'Hasta 5', crecimiento: 'Ilimitadas', profesional: 'Ilimitadas' },
+  { row: 'Dominio propio (.com.py)', prueba: false, presencia: '1 año incluido', crecimiento: '1 año incluido', profesional: '1 año incluido' },
+  { row: 'Fotos optimizadas', prueba: '3', presencia: '15', crecimiento: 'Ilimitadas', profesional: 'Ilimitadas' },
+  { row: 'WhatsApp Business', prueba: true, presencia: true, crecimiento: true, profesional: true },
+  { row: 'SEO + Schema.org', prueba: 'Básico', presencia: 'Básico', crecimiento: 'Avanzado', profesional: 'Avanzado' },
+  { row: 'Reservas online', prueba: false, presencia: false, crecimiento: true, profesional: true },
+  { row: 'E-commerce / Catálogo', prueba: false, presencia: false, crecimiento: 'Hasta 20 productos', profesional: 'Ilimitado' },
+  { row: 'Blog y analytics', prueba: false, presencia: false, crecimiento: true, profesional: true },
+  { row: 'Multi-idioma (es/en/pt)', prueba: false, presencia: false, crecimiento: false, profesional: true },
+  { row: 'Multi-sucursal', prueba: false, presencia: false, crecimiento: false, profesional: 'Hasta 5 locales' },
+  { row: 'Cambios de contenido / mes', prueba: '0', presencia: '2', crecimiento: '5', profesional: '10 + 10h dev' },
+  { row: 'Account manager dedicado', prueba: false, presencia: false, crecimiento: false, profesional: true },
+  { row: 'SLA 99.9% uptime', prueba: false, presencia: false, crecimiento: false, profesional: true },
+] as const
+
+function Cell({ value }: { value: string | boolean }) {
+  if (value === true)
+    return (
+      <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--success)]/10 text-[var(--success)]">
+        <Check size={14} />
+      </span>
+    )
+  if (value === false)
+    return (
+      <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--border)] text-[var(--text-muted)]">
+        <X size={14} />
+      </span>
+    )
+  return <span className="text-sm text-[var(--text)]">{value}</span>
+}
+
+export default function PreciosPage() {
+  return (
+    <>
+      <SiteNav />
+
+      <main>
+        {/* Hero */}
+        <section className="pt-32 pb-12 md:pt-40">
+          <Container>
+            <div className="mx-auto max-w-2xl text-center">
+              <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">
+                Precios
+              </p>
+              <h1 className="mb-4 text-4xl font-bold text-[var(--text)] sm:text-5xl">
+                Pagás en guaraníes, cancelás cuando quieras
+              </h1>
+              <p className="text-lg text-[var(--text-light)]">
+                Setup único + mensualidad baja. Sin permanencia, sin sorpresas. 30 días de garantía
+                en cualquier plan pago.
+              </p>
+            </div>
+          </Container>
+        </section>
+
+        {/* Plans grid */}
+        <section className="py-12">
+          <Container>
+            <div className="mx-auto grid max-w-6xl gap-6 sm:grid-cols-2 lg:grid-cols-4">
+              {PLANS.map((plan) => (
+                <div
+                  key={plan.id}
+                  className={`relative flex h-full flex-col rounded-3xl border-2 p-7 transition-all hover:-translate-y-1 hover:shadow-2xl ${
+                    plan.popular
+                      ? 'border-[var(--primary)] bg-gradient-to-b from-[var(--primary)]/5 to-transparent'
+                      : 'border-[var(--border)] bg-[var(--surface)]'
+                  }`}
+                >
+                  {plan.popular && (
+                    <div className="absolute -top-4 left-1/2 -translate-x-1/2">
+                      <span className="rounded-full bg-gradient-to-r from-[var(--primary)] to-[var(--accent)] px-6 py-2 text-sm font-bold text-[var(--primary-foreground)] shadow-lg whitespace-nowrap">
+                        Recomendado
+                      </span>
+                    </div>
+                  )}
+                  <div className="mb-6 text-center">
+                    <h3 className="mb-2 text-xl font-bold text-[var(--text)]">{plan.name}</h3>
+                    <p className="mb-4 text-sm text-[var(--text-muted)]">{plan.description}</p>
+                    <div className="flex flex-col items-center gap-1 rounded-2xl bg-[var(--surface-light)] py-4 px-3">
+                      <span className="text-xs uppercase tracking-wider text-[var(--text-muted)]">
+                        Setup único
+                      </span>
+                      <span className="text-2xl font-extrabold text-[var(--text)]">{plan.setup}</span>
+                      <span className="mt-2 text-xs uppercase tracking-wider text-[var(--text-muted)]">
+                        Después
+                      </span>
+                      <span className="text-lg font-bold text-[var(--primary)]">{plan.monthly}</span>
+                      <span className="text-xs text-[var(--text-muted)]">{plan.period}</span>
+                    </div>
+                  </div>
+                  <ul className="mb-8 space-y-3">
+                    {plan.features.map((feat, j) => (
+                      <li key={j} className="flex items-start gap-3 text-sm">
+                        <div
+                          className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full ${
+                            feat.included
+                              ? 'bg-[var(--success)]/10 text-[var(--success)]'
+                              : 'bg-[var(--border)] text-[var(--text-muted)]'
+                          }`}
+                        >
+                          {feat.included ? <Check size={12} /> : <X size={12} />}
+                        </div>
+                        <span className={feat.included ? 'text-[var(--text)]' : 'text-[var(--text-muted)]'}>
+                          {feat.text}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                  <a
+                    href={waLink(plan.waMessage)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`mt-auto block w-full rounded-2xl py-3.5 text-center text-sm font-bold transition-all ${
+                      plan.popular
+                        ? 'bg-gradient-to-r from-[var(--primary)] to-[var(--accent)] text-[var(--primary-foreground)] hover:opacity-90 hover:shadow-lg'
+                        : 'border-2 border-[var(--border)] text-[var(--text)] hover:border-[var(--primary)] hover:text-[var(--primary)]'
+                    }`}
+                  >
+                    {plan.cta}
+                  </a>
+                </div>
+              ))}
+            </div>
+          </Container>
+        </section>
+
+        {/* ROI calculator */}
+        <section className="border-t border-[var(--border)] bg-[var(--surface-light)] py-20">
+          <Container>
+            <div className="mx-auto mb-10 max-w-2xl text-center">
+              <h2 className="mb-3 text-3xl font-bold text-[var(--text)]">
+                Calculá cuándo se paga sola
+              </h2>
+              <p className="text-[var(--text-light)]">
+                Mové los números a los tuyos. Si el resultado no cierra, dejanos saber — capaz que
+                este no es el momento.
+              </p>
+            </div>
+            <ROICalculator />
+          </Container>
+        </section>
+
+        {/* Comparison table */}
+        <section className="py-20">
+          <Container>
+            <div className="mx-auto mb-10 max-w-2xl text-center">
+              <h2 className="mb-3 text-3xl font-bold text-[var(--text)]">Comparación detallada</h2>
+              <p className="text-[var(--text-light)]">
+                Todo lo que cambia entre planes, sin letra chica.
+              </p>
+            </div>
+            <div className="mx-auto max-w-5xl overflow-x-auto rounded-2xl border border-[var(--border)]">
+              <table className="w-full text-left">
+                <thead className="bg-[var(--surface-light)]">
+                  <tr>
+                    <th className="p-4 text-sm font-semibold text-[var(--text)]">Característica</th>
+                    {PLANS.map((p) => (
+                      <th
+                        key={p.id}
+                        className={`p-4 text-center text-sm font-semibold ${
+                          p.popular ? 'text-[var(--primary)]' : 'text-[var(--text)]'
+                        }`}
+                      >
+                        {p.name}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[var(--border)] bg-[var(--surface)]">
+                  {FEATURE_MATRIX.map((row) => (
+                    <tr key={row.row}>
+                      <td className="p-4 text-sm font-medium text-[var(--text)]">{row.row}</td>
+                      <td className="p-4 text-center">
+                        <Cell value={row.prueba} />
+                      </td>
+                      <td className="p-4 text-center">
+                        <Cell value={row.presencia} />
+                      </td>
+                      <td className="p-4 text-center">
+                        <Cell value={row.crecimiento} />
+                      </td>
+                      <td className="p-4 text-center">
+                        <Cell value={row.profesional} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Container>
+        </section>
+
+        {/* CTA */}
+        <section className="border-t border-[var(--border)] py-16">
+          <Container size="md">
+            <div className="mx-auto max-w-2xl text-center">
+              <h2 className="mb-4 text-2xl font-bold text-[var(--text)]">¿Aún tenés dudas?</h2>
+              <p className="mb-6 text-[var(--text-light)]">
+                Mandanos un WhatsApp con tu rubro y te decimos qué plan se ajusta mejor — sin
+                vender humo.
+              </p>
+              <a
+                href={waLink('Hola, quiero ayuda para elegir el plan correcto para mi negocio.')}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-2xl bg-[var(--primary)] px-8 py-4 font-bold text-[var(--primary-foreground)] shadow-lg transition-all hover:-translate-y-1"
+              >
+                <MessageCircle size={18} />
+                Hablar con ventas
+              </a>
+              <div className="mt-8">
+                <Link
+                  href="/comparacion"
+                  className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--primary)]"
+                >
+                  Ver cómo nos comparamos con Wix y agencias
+                  <ArrowRight size={14} />
+                </Link>
+              </div>
+            </div>
+          </Container>
+        </section>
+      </main>
+
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/components/landing/activity-ticker.tsx
+++ b/web/components/landing/activity-ticker.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Activity } from 'lucide-react'
+import { REAL_CLIENTS } from '@/lib/landing/marketing-data'
+
+/**
+ * Auto-rotating "recent activity" ticker. Pulls from real clients so every
+ * line is verifiable. Rotates every ~4 seconds for casual peripheral attention
+ * — never block content, never autoplay sound, no fake activity.
+ */
+export function ActivityTicker() {
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => setIndex((i) => (i + 1) % REAL_CLIENTS.length), 4200)
+    return () => clearInterval(id)
+  }, [])
+
+  const current = REAL_CLIENTS[index]
+
+  return (
+    <div className="mx-auto inline-flex items-center gap-3 rounded-full border border-[var(--border)] bg-[var(--surface)]/80 px-4 py-2 text-sm shadow-sm backdrop-blur-sm">
+      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-[var(--success)]/10 text-[var(--success)]">
+        <Activity size={14} />
+      </span>
+      <span className="text-[var(--text-muted)]">
+        Online ahora ·{' '}
+        <a
+          href={current.href}
+          className="font-semibold text-[var(--text)] underline-offset-2 hover:underline"
+        >
+          {current.name}
+        </a>
+      </span>
+    </div>
+  )
+}

--- a/web/components/landing/roi-calculator.tsx
+++ b/web/components/landing/roi-calculator.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useState } from 'react'
+import { Calculator, TrendingUp } from 'lucide-react'
+import { PLANS } from '@/lib/landing/marketing-data'
+
+const PRESENCIA = PLANS.find((p) => p.id === 'presencia')!
+const CRECIMIENTO = PLANS.find((p) => p.id === 'crecimiento')!
+
+const PLAN_COSTS = {
+  presencia: { setup: 650_000, monthly: 100_000, name: PRESENCIA.name },
+  crecimiento: { setup: 1_200_000, monthly: 150_000, name: CRECIMIENTO.name },
+} as const
+
+/**
+ * Interactive ROI calculator. Asks the visitor for their average ticket and
+ * the number of new clients they expect from the website per month, then
+ * shows how many months of incremental revenue cover the setup, and the
+ * year-1 net.
+ *
+ * Defaults are deliberately conservative (avg ticket Gs 250.000, 4 new
+ * clients/mo) so the math stays believable for a beauty/wellness SMB —
+ * the persona target in docs/02_TARGET_CUSTOMER.md.
+ */
+export function ROICalculator() {
+  const [ticket, setTicket] = useState(250_000)
+  const [newClients, setNewClients] = useState(4)
+  const [planKey, setPlanKey] = useState<'presencia' | 'crecimiento'>('presencia')
+
+  const plan = PLAN_COSTS[planKey]
+  const monthlyRevenue = ticket * newClients
+  const monthlyNet = monthlyRevenue - plan.monthly
+  const breakEvenMonths = monthlyNet > 0 ? Math.ceil(plan.setup / monthlyNet) : Infinity
+  const year1Net = monthlyNet * 12 - plan.setup
+
+  const fmt = (n: number) =>
+    Number.isFinite(n)
+      ? `Gs ${Math.round(n).toLocaleString('es-PY')}`
+      : '— no recupera'
+
+  return (
+    <div className="mx-auto max-w-3xl rounded-3xl border border-[var(--border)] bg-[var(--surface)] p-6 md:p-10">
+      <div className="mb-6 flex items-center gap-3">
+        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-[var(--primary)] to-[var(--accent)] text-[var(--primary-foreground)]">
+          <Calculator size={22} />
+        </div>
+        <div>
+          <h3 className="text-xl font-bold text-[var(--text)]">¿Cuándo se paga sola?</h3>
+          <p className="text-sm text-[var(--text-muted)]">
+            Estimá tu retorno con tus números reales.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <label className="block">
+          <span className="mb-2 block text-sm font-semibold text-[var(--text)]">
+            Ticket promedio (Gs)
+          </span>
+          <input
+            type="number"
+            min={0}
+            step={10_000}
+            value={ticket}
+            onChange={(e) => setTicket(Math.max(0, Number(e.target.value)))}
+            className="w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-[var(--text)] focus:border-[var(--primary)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]/20"
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-2 block text-sm font-semibold text-[var(--text)]">
+            Clientes nuevos por mes (gracias al sitio)
+          </span>
+          <input
+            type="number"
+            min={0}
+            value={newClients}
+            onChange={(e) => setNewClients(Math.max(0, Number(e.target.value)))}
+            className="w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-[var(--text)] focus:border-[var(--primary)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]/20"
+          />
+        </label>
+
+        <div className="md:col-span-2">
+          <span className="mb-2 block text-sm font-semibold text-[var(--text)]">Plan</span>
+          <div className="grid grid-cols-2 gap-3">
+            {(['presencia', 'crecimiento'] as const).map((key) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setPlanKey(key)}
+                className={`rounded-xl border-2 px-4 py-3 text-sm font-semibold transition-all ${
+                  planKey === key
+                    ? 'border-[var(--primary)] bg-[var(--primary)]/5 text-[var(--text)]'
+                    : 'border-[var(--border)] text-[var(--text-light)] hover:border-[var(--primary)]/50'
+                }`}
+              >
+                {PLAN_COSTS[key].name}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8 grid gap-4 rounded-2xl bg-[var(--surface-light)] p-6 sm:grid-cols-3">
+        <Stat label="Ingreso extra mensual" value={fmt(monthlyRevenue)} />
+        <Stat label="Neto mensual (después del plan)" value={fmt(monthlyNet)} highlight={monthlyNet > 0} />
+        <Stat
+          label="Se paga el setup en"
+          value={Number.isFinite(breakEvenMonths) ? `${breakEvenMonths} mes${breakEvenMonths === 1 ? '' : 'es'}` : '—'}
+        />
+      </div>
+
+      <div className="mt-4 flex items-center justify-center gap-2 text-sm text-[var(--text-muted)]">
+        <TrendingUp size={16} className="text-[var(--success)]" />
+        <span>
+          Año 1 neto estimado:{' '}
+          <strong className={year1Net > 0 ? 'text-[var(--success)]' : 'text-[var(--text)]'}>
+            {fmt(year1Net)}
+          </strong>
+        </span>
+      </div>
+
+      <p className="mt-6 text-center text-xs text-[var(--text-muted)]">
+        Estimación referencial · no incluye impuestos ni gastos operativos del propio servicio.
+      </p>
+    </div>
+  )
+}
+
+function Stat({ label, value, highlight = false }: { label: string; value: string; highlight?: boolean }) {
+  return (
+    <div className="text-center">
+      <p className="text-xs uppercase tracking-wider text-[var(--text-muted)]">{label}</p>
+      <p
+        className={`mt-1 text-xl font-bold md:text-2xl ${
+          highlight ? 'text-[var(--success)]' : 'text-[var(--text)]'
+        }`}
+      >
+        {value}
+      </p>
+    </div>
+  )
+}

--- a/web/components/landing/site-footer.tsx
+++ b/web/components/landing/site-footer.tsx
@@ -1,0 +1,75 @@
+import Link from 'next/link'
+import { Wand2 } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+
+const FOOTER_GROUPS = [
+  {
+    title: 'Producto',
+    links: [
+      { href: '/p', label: 'Plantillas' },
+      { href: '/precios', label: 'Precios' },
+      { href: '/comparacion', label: 'Comparación' },
+      { href: '/demo', label: 'Pedir demo' },
+    ],
+  },
+  {
+    title: 'Casos reales',
+    links: [
+      { href: '/casos', label: 'Todos los casos' },
+      { href: '/casos/nexa-paraguay', label: 'Nexa Paraguay' },
+      { href: '/casos/dayah-litworks', label: 'Dayah Litworks' },
+      { href: '/casos/de-abasto-a-casa', label: 'De Abasto a Casa' },
+    ],
+  },
+  {
+    title: 'Recursos',
+    links: [
+      { href: '/blog', label: 'Blog' },
+      { href: '/seguridad', label: 'Privacidad y datos' },
+      { href: '/#faq', label: 'FAQ' },
+      { href: '/admin', label: 'Acceso clientes' },
+    ],
+  },
+] as const
+
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-[var(--border)] bg-[var(--surface)] py-12">
+      <Container>
+        <div className="grid gap-8 md:grid-cols-4">
+          <div className="md:col-span-1">
+            <Link href="/" className="mb-4 inline-flex items-center gap-2">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-[var(--primary)] to-[var(--accent)] text-[var(--primary-foreground)]">
+                <Wand2 size={20} />
+              </div>
+              <span className="text-xl font-bold">
+                <span className="text-[var(--text)]">Paragu</span>
+                <span className="text-[var(--primary)]">AI</span>
+              </span>
+            </Link>
+            <p className="max-w-sm text-sm text-[var(--text-muted)]">
+              Sitios web profesionales para negocios paraguayos. Todo incluido, en 48 horas.
+            </p>
+          </div>
+          {FOOTER_GROUPS.map((group) => (
+            <div key={group.title}>
+              <h4 className="mb-4 font-bold text-[var(--text)]">{group.title}</h4>
+              <ul className="space-y-2 text-[var(--text-muted)]">
+                {group.links.map((link) => (
+                  <li key={link.href}>
+                    <Link href={link.href} className="text-sm hover:text-[var(--primary)]">
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div className="mt-12 border-t border-[var(--border)] pt-8 text-center text-sm text-[var(--text-muted)]">
+          © {new Date().getFullYear()} ParaguAI Builder. Todos los derechos reservados.
+        </div>
+      </Container>
+    </footer>
+  )
+}

--- a/web/components/landing/site-nav.tsx
+++ b/web/components/landing/site-nav.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Menu, X as XIcon, Wand2, MessageCircle } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { waLink } from '@/lib/landing/marketing-data'
+
+const NAV_LINKS = [
+  { href: '/casos', label: 'Casos' },
+  { href: '/p', label: 'Plantillas' },
+  { href: '/precios', label: 'Precios' },
+  { href: '/comparacion', label: 'Comparación' },
+  { href: '/demo', label: 'Demo' },
+] as const
+
+/**
+ * Site-wide top navigation. Used on every marketing page (landing,
+ * /p/[rubro], /casos, /precios, /comparacion, /demo, /seguridad, /blog).
+ * On the landing page itself we keep the in-page anchor nav inside page.tsx
+ * — this nav is for sub-pages where anchored sections do not exist.
+ */
+export function SiteNav() {
+  const [scrolled, setScrolled] = useState(false)
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+
+  useEffect(() => {
+    const handleScroll = () => setScrolled(window.scrollY > 50)
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  const demoMessage = 'Hola, quiero una demo gratis de ParaguAI para mi negocio.'
+
+  return (
+    <>
+      <nav
+        className={`fixed top-0 z-50 w-full transition-all duration-300 ${
+          scrolled
+            ? 'border-b border-[var(--border)] bg-[var(--background)]/95 backdrop-blur-xl shadow-sm'
+            : 'bg-[var(--background)]/70 backdrop-blur-sm'
+        }`}
+      >
+        <Container>
+          <div className="flex h-16 items-center justify-between">
+            <Link href="/" className="flex items-center gap-2 group">
+              <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-[var(--primary)] to-[var(--accent)] text-[var(--primary-foreground)] transition-transform group-hover:scale-110">
+                <Wand2 size={20} />
+              </div>
+              <span className="text-lg font-bold">
+                <span className="text-[var(--text)]">Paragu</span>
+                <span className="text-[var(--primary)]">AI</span>
+              </span>
+            </Link>
+
+            <div className="hidden items-center gap-1 md:flex">
+              {NAV_LINKS.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="rounded-lg px-4 py-2 text-sm font-medium text-[var(--text-light)] transition-colors hover:text-[var(--text)]"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Link
+                href="/admin"
+                className="hidden text-sm font-medium text-[var(--text-light)] hover:text-[var(--primary)] md:block"
+              >
+                Acceso clientes
+              </Link>
+              <a
+                href={waLink(demoMessage)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hidden rounded-xl bg-[var(--primary)] px-5 py-2.5 text-sm font-semibold text-[var(--primary-foreground)] transition-all hover:opacity-90 hover:shadow-lg md:inline-flex md:items-center md:gap-2"
+              >
+                <MessageCircle size={16} />
+                Pedir demo
+              </a>
+              <button
+                onClick={() => setMobileMenuOpen(true)}
+                aria-label="Abrir menú"
+                className="rounded-lg p-2 text-[var(--text)] md:hidden"
+              >
+                <Menu size={24} />
+              </button>
+            </div>
+          </div>
+        </Container>
+      </nav>
+
+      {mobileMenuOpen && (
+        <div className="fixed inset-0 z-[60] bg-[var(--background)] md:hidden">
+          <div className="flex h-16 items-center justify-between px-4">
+            <Link href="/" className="flex items-center gap-2" onClick={() => setMobileMenuOpen(false)}>
+              <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-[var(--primary)] to-[var(--accent)] text-[var(--primary-foreground)]">
+                <Wand2 size={20} />
+              </div>
+              <span className="text-lg font-bold">
+                <span className="text-[var(--text)]">Paragu</span>
+                <span className="text-[var(--primary)]">AI</span>
+              </span>
+            </Link>
+            <button
+              onClick={() => setMobileMenuOpen(false)}
+              aria-label="Cerrar menú"
+              className="rounded-lg p-2 text-[var(--text)]"
+            >
+              <XIcon size={24} />
+            </button>
+          </div>
+          <div className="flex flex-col gap-2 p-4">
+            {NAV_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setMobileMenuOpen(false)}
+                className="rounded-xl px-4 py-4 text-lg font-medium text-[var(--text)] hover:bg-[var(--surface-light)]"
+              >
+                {link.label}
+              </Link>
+            ))}
+            <a
+              href={waLink(demoMessage)}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setMobileMenuOpen(false)}
+              className="mt-4 inline-flex items-center justify-center gap-2 rounded-xl bg-[var(--primary)] px-4 py-4 text-center text-lg font-semibold text-[var(--primary-foreground)]"
+            >
+              <MessageCircle size={18} />
+              Pedir demo por WhatsApp
+            </a>
+            <Link
+              href="/admin"
+              onClick={() => setMobileMenuOpen(false)}
+              className="rounded-xl border border-[var(--border)] px-4 py-3 text-center text-sm font-medium text-[var(--text-light)]"
+            >
+              Acceso clientes
+            </Link>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/web/components/landing/sticky-mobile-cta.tsx
+++ b/web/components/landing/sticky-mobile-cta.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { MessageCircle } from 'lucide-react'
+import { SITE_CONFIG, waLink } from '@/lib/landing/marketing-data'
+
+/**
+ * Sticky bottom-bar CTA shown only on mobile after scrolling past the hero.
+ * Hidden on desktop because we already have nav + hero CTAs there. Hidden in
+ * the first screen so it doesn't fight with the hero CTA buttons.
+ */
+export function StickyMobileCTA({
+  message = 'Hola, quiero una demo gratis de ParaguAI para mi negocio.',
+  showAfter = 600,
+}: {
+  message?: string
+  showAfter?: number
+}) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > showAfter)
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [showAfter])
+
+  if (!visible) return null
+
+  return (
+    <div
+      role="region"
+      aria-label="Demo gratis"
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-[var(--border)] bg-[var(--background)]/95 px-4 py-3 backdrop-blur-md md:hidden"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-bold text-[var(--text)]">Demo gratis · 48h</p>
+          <p className="truncate text-xs text-[var(--text-muted)]">
+            Pagás solo si te gusta · Gs {SITE_CONFIG.marketSize.toLocaleString('es-PY')} negocios PY
+          </p>
+        </div>
+        <a
+          href={waLink(message)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex shrink-0 items-center gap-2 rounded-xl bg-[var(--primary)] px-4 py-2.5 text-sm font-bold text-[var(--primary-foreground)] shadow-lg"
+        >
+          <MessageCircle size={16} />
+          Pedir demo
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/web/components/landing/video-block.tsx
+++ b/web/components/landing/video-block.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useState } from 'react'
+import { PlayCircle } from 'lucide-react'
+
+/**
+ * Above-the-fold video slot. Click-to-play to keep LCP fast.
+ *
+ * Pass a YouTube/Vimeo embed URL via `embedUrl` once you have a real video.
+ * Until then the component renders a poster + play button that opens the
+ * configured WhatsApp link as a fallback action — so the slot is always
+ * a working CTA, not a dead placeholder.
+ */
+export function VideoBlock({
+  embedUrl,
+  posterAlt = 'Cómo funciona ParaguAI en 60 segundos',
+  fallbackHref,
+  caption = '60 segundos: de mensaje de WhatsApp a sitio publicado.',
+}: {
+  embedUrl?: string
+  posterAlt?: string
+  fallbackHref?: string
+  caption?: string
+}) {
+  const [playing, setPlaying] = useState(false)
+
+  const showEmbed = playing && embedUrl
+
+  return (
+    <figure className="mx-auto w-full max-w-3xl">
+      <div className="relative aspect-video overflow-hidden rounded-2xl border border-[var(--border)] bg-gradient-to-br from-[var(--primary)]/10 via-[var(--surface)] to-[var(--accent)]/10 shadow-xl">
+        {showEmbed ? (
+          <iframe
+            src={embedUrl}
+            title={posterAlt}
+            allow="accelerated-2d-canvas; autoplay; encrypted-media; picture-in-picture"
+            allowFullScreen
+            className="absolute inset-0 h-full w-full"
+          />
+        ) : embedUrl ? (
+          <button
+            type="button"
+            onClick={() => setPlaying(true)}
+            aria-label={posterAlt}
+            className="group absolute inset-0 flex items-center justify-center"
+          >
+            <div className="absolute inset-0 bg-gradient-to-br from-[var(--primary)]/30 to-[var(--accent)]/30" aria-hidden />
+            <span className="relative flex h-20 w-20 items-center justify-center rounded-full bg-white/95 text-[var(--primary)] shadow-2xl transition-transform group-hover:scale-110">
+              <PlayCircle size={48} />
+            </span>
+          </button>
+        ) : (
+          <a
+            href={fallbackHref || '#como-funciona'}
+            className="group absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
+          >
+            <div className="absolute inset-0 bg-gradient-to-br from-[var(--primary)]/20 to-[var(--accent)]/20" aria-hidden />
+            <span className="relative flex h-20 w-20 items-center justify-center rounded-full bg-white/95 text-[var(--primary)] shadow-2xl transition-transform group-hover:scale-110">
+              <PlayCircle size={48} />
+            </span>
+            <span className="relative max-w-md text-sm font-medium text-[var(--text)]">
+              Video walkthrough en producción · mientras tanto, mirá <u>cómo funciona</u>.
+            </span>
+          </a>
+        )}
+      </div>
+      <figcaption className="mt-3 text-center text-sm text-[var(--text-muted)]">
+        {caption}
+      </figcaption>
+    </figure>
+  )
+}

--- a/web/lib/landing/case-studies.ts
+++ b/web/lib/landing/case-studies.ts
@@ -1,0 +1,117 @@
+/**
+ * Long-form case study content for /casos/[cliente].
+ * Slugs match REAL_CLIENTS in marketing-data.ts.
+ */
+
+export type CaseStudy = {
+  slug: string
+  /** Short label shown in the hero kicker. */
+  vertical: string
+  /** Hero headline — story-shaped, not feature-shaped. */
+  headline: string
+  /** Hero lead paragraph. */
+  lead: string
+  /** Year/period the work happened. */
+  period: string
+  /** What measurable outcome shipped. */
+  outcomes: readonly string[]
+  /** What was challenging — sets up the solution. */
+  challenge: string
+  /** How we solved it. */
+  approach: string
+  /** Live URL (could be local /[business] or absolute). */
+  liveUrl: string
+}
+
+export const CASE_STUDIES: readonly CaseStudy[] = [
+  {
+    slug: 'nexa-paraguay',
+    vertical: 'Reubicación · 4 idiomas',
+    headline: 'Nexa Paraguay: un sitio multi-idioma para clientes europeos en 2 semanas',
+    lead:
+      'Nexa ayuda a familias europeas a mudarse a Paraguay. Necesitaban un sitio profesional en 4 idiomas (ES/EN/DE/NL) que transmitiera seriedad ante clientes que evalúan trasladar su vida.',
+    period: '2026 · Q1',
+    outcomes: [
+      '4 idiomas activos desde el primer día (ES/EN/DE/NL)',
+      'Sitio replicado para Nexa Uruguay en cuestión de días',
+      'Sin permanencia con un proveedor — la infraestructura es propia',
+    ],
+    challenge:
+      'Las agencias web locales cotizaban entre 3 y 6 meses para un sitio multi-idioma. Para Nexa, eso significaba perder un trimestre completo de leads europeos.',
+    approach:
+      'Reusamos la arquitectura multi-tenant de ParaguAI para servir cuatro locales desde un solo despliegue. El equipo de Nexa entregó copy en cada idioma; nosotros publicamos en menos de dos semanas, dominio y certificados incluidos.',
+    liveUrl: '/s/es/nexa-paraguay',
+  },
+  {
+    slug: 'nexa-uruguay',
+    vertical: 'Reubicación · replicado en días',
+    headline: 'Nexa Uruguay: réplica de Nexa Paraguay en cuestión de días, no meses',
+    lead:
+      'Una vez funcionando Nexa Paraguay, expandirse a Uruguay no fue empezar de cero. Reusamos plantilla, idiomas y flujos — solo cambiamos el contenido específico del país.',
+    period: '2026 · Q1',
+    outcomes: [
+      'De decisión a producción en días, no meses',
+      'Misma arquitectura multi-idioma sin re-implementar nada',
+      'Cero costo extra de mantenimiento por sitio adicional',
+    ],
+    challenge:
+      'Mantener la calidad y consistencia de Nexa Paraguay en un segundo país, sin duplicar el esfuerzo de ingeniería ni romper el sitio original.',
+    approach:
+      'La capa de tenants de ParaguAI permite que cada país tenga sus propios contenidos, monedas y configuraciones, compartiendo el mismo código base. Las mejoras en uno se propagan al otro automáticamente.',
+    liveUrl: '/s/es/nexa-uruguay',
+  },
+  {
+    slug: 'nexa-propiedades',
+    vertical: 'Real estate · 3 idiomas',
+    headline: 'Nexa Propiedades: extender la marca Nexa al mercado inmobiliario residencial',
+    lead:
+      'Cuando Nexa decidió ofrecer propiedades a sus clientes europeos, necesitaban un brazo dedicado a inmobiliaria — sin dejar de aprovechar la marca y la audiencia que ya tenían.',
+    period: '2026 · Q1',
+    outcomes: [
+      'Listado de propiedades actualizable sin tocar código',
+      'Misma identidad visual que el resto de marcas Nexa',
+      'Contacto directo por WhatsApp en cada propiedad',
+    ],
+    challenge:
+      'El equipo necesitaba autonomía para subir y bajar propiedades sin depender de un desarrollador, manteniendo el estándar visual de la marca.',
+    approach:
+      'Configuramos un panel donde el equipo de Nexa carga propiedades con fotos, precios y ubicación. Los listings se renderizan con el mismo motor de plantillas que el resto de los sitios Nexa.',
+    liveUrl: '/s/es/nexa-propiedades',
+  },
+  {
+    slug: 'dayah-litworks',
+    vertical: 'Portfolio · pago en USD',
+    headline: 'Dayah Litworks: del Instagram al portfolio profesional en USD',
+    lead:
+      'Dayah es diseñadora de tapas de libros y su negocio depende de cómo la perciben autores que la contratan. Su portfolio vivía en Instagram — funcional, pero con techo.',
+    period: '2026 · Q1',
+    outcomes: [
+      '3 comisiones cerradas en el primer mes',
+      'Pricing en USD listo para clientes internacionales',
+      'Proceso de encargo claro, sin DMs de ida y vuelta',
+    ],
+    challenge:
+      'Instagram limita cómo se presenta un proceso de trabajo y un pricing claro. Los autores que evalúan contratarla necesitaban un sitio que transmitiera seriedad y autonomía profesional.',
+    approach:
+      'Diseñamos un portfolio enfocado en el proceso: del brief al manuscrito final. Pricing en USD, formulario de encargo y proceso paso-a-paso. Mantiene la estética visual personal de Dayah.',
+    liveUrl: '/dayah-litworks',
+  },
+  {
+    slug: 'de-abasto-a-casa',
+    vertical: 'Food · pedidos por WhatsApp',
+    headline: 'De Abasto a Casa: del jueves al lunes con sitio publicado y pedidos entrando',
+    lead:
+      'Iván maneja un servicio de meal prep semanal en Asunción. Recibía pedidos por grupos de WhatsApp, donde los mensajes se perdían. Necesitaba ordenar el flujo sin perder la cercanía.',
+    period: '2026 · Q1',
+    outcomes: [
+      'De mensaje de WhatsApp a sitio publicado: 4 días',
+      'Menú semanal con precios en Gs visible 24/7',
+      'Clientes hacen su selección y la mandan por WhatsApp con un clic',
+    ],
+    challenge:
+      'Los pedidos se perdían entre cientos de mensajes en grupos. Iván dedicaba horas a buscar quién había pedido qué, y los clientes no veían un menú claro hasta que él lo enviaba uno-a-uno.',
+    approach:
+      'Construimos un menú semanal estructurado donde cada cliente arma su pedido y lo envía pre-formateado por WhatsApp. Iván recibe un mensaje con todo lo que pidieron, listo para preparar.',
+    liveUrl: '/de-abasto-a-casa',
+  },
+] as const


### PR DESCRIPTION
Three new public landing surfaces, staged locally but uncommitted. Committing as one coherent feature bundle.

## New pages
- **`/precios`** — pricing page with tier comparison + embedded ROI calculator (PYG)
- **`/casos`** + `/casos/[cliente]` — case studies index + per-client detail
- **`/p/[rubro]`** — per-vertical rubro-specific SEO landing (reads from registry)

## New shared components (`web/components/landing/`)
`site-nav`, `site-footer`, `roi-calculator`, `sticky-mobile-cta`, `activity-ticker`, `video-block`

## New lib
`web/lib/landing/case-studies.ts` — typed case-study data (client, metric, quote, tenant slug).

## Gates
- tsc --noEmit clean
- No changes to tenant render paths (`/s/*`, `/[business]/*`) — new routes only

🤖 Generated with [Claude Code](https://claude.com/claude-code)