### PR TITLE
feat(landing): /comparacion, /demo, /seguridad, /blog + sitemap + dynamic OG

### DIFF
--- a/web/app/blog/[slug]/page.tsx
+++ b/web/app/blog/[slug]/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowLeft, Clock, MessageCircle } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { BLOG_POSTS, getPost } from '@/lib/landing/blog-posts'
+import { waLink } from '@/lib/landing/marketing-data'
+
+type Params = { slug: string }
+
+export function generateStaticParams() {
+  return BLOG_POSTS.map((p) => ({ slug: p.slug }))
+}
+
+export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
+  const { slug } = await params
+  const post = getPost(slug)
+  if (!post) return { title: 'Artículo no encontrado' }
+  return {
+    title: post.title,
+    description: post.excerpt,
+    alternates: { canonical: `/blog/${slug}` },
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      type: 'article',
+      publishedTime: post.date,
+      authors: [post.author],
+    },
+  }
+}
+
+/** Render a paragraph that may contain **bold** markdown spans. */
+function renderParagraph(text: string, key: number) {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g)
+  return (
+    <p key={key} className="mb-5 leading-relaxed text-[var(--text-light)]">
+      {parts.map((part, i) => {
+        if (part.startsWith('**') && part.endsWith('**')) {
+          return (
+            <strong key={i} className="text-[var(--text)]">
+              {part.slice(2, -2)}
+            </strong>
+          )
+        }
+        return <span key={i}>{part}</span>
+      })}
+    </p>
+  )
+}
+
+export default async function BlogPostPage({ params }: { params: Promise<Params> }) {
+  const { slug } = await params
+  const post = getPost(slug)
+  if (!post) notFound()
+
+  return (
+    <>
+      <SiteNav />
+      <main className="pt-24 pb-20">
+        <Container size="md">
+          <article className="mx-auto max-w-3xl">
+            <Link
+              href="/blog"
+              className="mb-6 inline-flex items-center gap-1 text-sm font-medium text-[var(--text-light)] hover:text-[var(--primary)]"
+            >
+              <ArrowLeft size={14} />
+              Todos los artículos
+            </Link>
+            <p className="mb-3 flex items-center gap-3 text-xs uppercase tracking-wider text-[var(--text-muted)]">
+              <span>{post.tag.split(':')[1] ?? post.tag}</span>
+              <span className="inline-flex items-center gap-1">
+                <Clock size={12} />
+                {post.readingTime}
+              </span>
+              <span>
+                {new Date(post.date).toLocaleDateString('es-PY', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </span>
+            </p>
+            <h1 className="mb-6 text-4xl font-bold leading-tight text-[var(--text)] sm:text-5xl">
+              {post.title}
+            </h1>
+            <p className="mb-10 text-xl leading-relaxed text-[var(--text-light)]">{post.excerpt}</p>
+
+            <div className="prose prose-lg max-w-none text-lg">
+              {post.body.map((p, i) => renderParagraph(p, i))}
+            </div>
+
+            <footer className="mt-12 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 text-center">
+              <p className="mb-4 text-sm text-[var(--text-muted)]">
+                Por <strong className="text-[var(--text)]">{post.author}</strong>
+              </p>
+              <a
+                href={waLink('Hola, leí un artículo en el blog y quiero hablar de mi negocio.')}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-[var(--primary)] to-[var(--accent)] px-6 py-3 font-bold text-[var(--primary-foreground)] shadow-lg transition-all hover:-translate-y-1"
+              >
+                <MessageCircle size={16} />
+                Pedir mi demo gratis
+              </a>
+            </footer>
+          </article>
+        </Container>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/app/blog/page.tsx
+++ b/web/app/blog/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, Clock } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { BLOG_POSTS } from '@/lib/landing/blog-posts'
+
+export const metadata: Metadata = {
+  title: 'Blog — guías y casos para negocios paraguayos',
+  description:
+    'Cómo mejorar la presencia digital de tu negocio: SEO local, conversión por WhatsApp, casos de éxito y errores comunes en sitios para PyMEs en Paraguay.',
+  alternates: { canonical: '/blog' },
+}
+
+export default function BlogIndexPage() {
+  const sorted = [...BLOG_POSTS].sort((a, b) => b.date.localeCompare(a.date))
+
+  return (
+    <>
+      <SiteNav />
+      <main className="pt-24 pb-20">
+        <Container>
+          <div className="mx-auto mb-16 max-w-2xl text-center">
+            <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">
+              Blog
+            </p>
+            <h1 className="mb-4 text-4xl font-bold text-[var(--text)] sm:text-5xl">
+              Guías para negocios paraguayos
+            </h1>
+            <p className="text-lg text-[var(--text-light)]">
+              Sin fluff. Lo que aprendimos publicando sitios reales para peluquerías, gimnasios,
+              meal prep y más.
+            </p>
+          </div>
+
+          <div className="mx-auto grid max-w-4xl gap-6">
+            {sorted.map((post) => (
+              <article
+                key={post.slug}
+                className="group rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 transition-all hover:-translate-y-1 hover:border-[var(--primary)]/30 hover:shadow-md md:p-8"
+              >
+                <p className="mb-2 flex items-center gap-3 text-xs uppercase tracking-wider text-[var(--text-muted)]">
+                  <span>{post.tag.split(':')[1] ?? post.tag}</span>
+                  <span className="inline-flex items-center gap-1">
+                    <Clock size={12} />
+                    {post.readingTime}
+                  </span>
+                  <span>{new Date(post.date).toLocaleDateString('es-PY', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
+                </p>
+                <h2 className="mb-3 text-2xl font-bold text-[var(--text)]">
+                  <Link href={`/blog/${post.slug}`} className="hover:text-[var(--primary)]">
+                    {post.title}
+                  </Link>
+                </h2>
+                <p className="mb-4 text-[var(--text-light)]">{post.excerpt}</p>
+                <Link
+                  href={`/blog/${post.slug}`}
+                  className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--primary)]"
+                >
+                  Leer artículo
+                  <ArrowRight size={14} className="transition-transform group-hover:translate-x-1" />
+                </Link>
+              </article>
+            ))}
+          </div>
+
+          <div className="mx-auto mt-12 max-w-2xl rounded-2xl border border-dashed border-[var(--border)] bg-[var(--surface-light)] p-6 text-center">
+            <p className="text-sm text-[var(--text-light)]">
+              Más artículos en preparación. ¿Querés que escribamos sobre algún tema?{' '}
+              <a
+                href={`https://wa.me/595981234567?text=${encodeURIComponent('Hola, me interesaría leer un post sobre...')}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-[var(--primary)]"
+              >
+                Sugerinos por WhatsApp
+              </a>
+              .
+            </p>
+          </div>
+        </Container>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/app/comparacion/page.tsx
+++ b/web/app/comparacion/page.tsx
@@ -1,0 +1,160 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, Check, MessageCircle, Minus, X } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { waLink } from '@/lib/landing/marketing-data'
+
+export const metadata: Metadata = {
+  title: 'ParaguAI vs Wix vs Agencia local — comparación honesta',
+  description:
+    'Cómo se compara ParaguAI con Wix/WordPress y con una agencia web local en Paraguay: precio, tiempo, soporte, soporte WhatsApp y dominio .com.py.',
+  alternates: { canonical: '/comparacion' },
+}
+
+type Cell = 'yes' | 'no' | 'partial' | string
+
+const ROWS: { label: string; paraguai: Cell; wix: Cell; agencia: Cell }[] = [
+  { label: 'Tiempo de entrega', paraguai: '48 horas', wix: 'Tu tiempo (DIY)', agencia: '2-4 meses' },
+  { label: 'Setup inicial', paraguai: 'Desde Gs 0', wix: 'Gratis', agencia: 'Gs 3-5M' },
+  { label: 'Mensualidad', paraguai: 'Desde Gs 100K', wix: 'Desde USD 16', agencia: 'Hosting aparte' },
+  { label: 'Demo antes de pagar', paraguai: 'yes', wix: 'no', agencia: 'partial' },
+  { label: 'Vos no tocás nada', paraguai: 'yes', wix: 'no', agencia: 'yes' },
+  { label: 'Dominio .com.py incluido', paraguai: 'yes', wix: 'no', agencia: 'partial' },
+  { label: 'Soporte por WhatsApp', paraguai: 'yes', wix: 'no', agencia: 'partial' },
+  { label: 'Cambios mensuales incluidos', paraguai: '2-10 / mes', wix: 'Tu tiempo', agencia: 'Cobran aparte' },
+  { label: 'SEO + Schema.org listo', paraguai: 'yes', wix: 'partial', agencia: 'partial' },
+  { label: 'Sin permanencia', paraguai: 'yes', wix: 'yes', agencia: 'no' },
+  { label: 'Te llevás el dominio si te vas', paraguai: 'yes', wix: 'yes', agencia: 'partial' },
+  { label: 'Pago en guaraníes (Mercado Pago)', paraguai: 'yes', wix: 'no', agencia: 'yes' },
+  { label: 'Garantía de 30 días', paraguai: 'yes', wix: 'partial', agencia: 'no' },
+]
+
+function Marker({ value }: { value: Cell }) {
+  if (value === 'yes')
+    return (
+      <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[var(--success)]/10 text-[var(--success)]">
+        <Check size={16} />
+      </span>
+    )
+  if (value === 'no')
+    return (
+      <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[var(--border)] text-[var(--text-muted)]">
+        <X size={16} />
+      </span>
+    )
+  if (value === 'partial')
+    return (
+      <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[var(--warning)]/10 text-[var(--warning)]">
+        <Minus size={16} />
+      </span>
+    )
+  return <span className="text-sm font-medium text-[var(--text)]">{value}</span>
+}
+
+export default function ComparacionPage() {
+  return (
+    <>
+      <SiteNav />
+      <main className="pt-24 pb-20">
+        <Container>
+          <div className="mx-auto mb-12 max-w-2xl text-center">
+            <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">
+              Comparación honesta
+            </p>
+            <h1 className="mb-4 text-4xl font-bold text-[var(--text)] sm:text-5xl">
+              ParaguAI vs Wix vs Agencia local
+            </h1>
+            <p className="text-lg text-[var(--text-light)]">
+              Las tres opciones funcionan. Pero cada una tiene un perfil diferente. Mirá la
+              comparación con datos reales del mercado paraguayo y elegí la que mejor te calza.
+            </p>
+          </div>
+
+          <div className="mx-auto max-w-5xl overflow-x-auto rounded-2xl border border-[var(--border)] shadow-sm">
+            <table className="w-full text-left">
+              <thead className="bg-[var(--surface-light)]">
+                <tr>
+                  <th className="p-4 text-sm font-semibold text-[var(--text)]">Característica</th>
+                  <th className="p-4 text-center text-sm font-bold text-[var(--primary)]">ParaguAI</th>
+                  <th className="p-4 text-center text-sm font-semibold text-[var(--text)]">Wix / WordPress</th>
+                  <th className="p-4 text-center text-sm font-semibold text-[var(--text)]">Agencia local</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--border)] bg-[var(--surface)]">
+                {ROWS.map((row) => (
+                  <tr key={row.label}>
+                    <td className="p-4 text-sm font-medium text-[var(--text)]">{row.label}</td>
+                    <td className="p-4 text-center">
+                      <Marker value={row.paraguai} />
+                    </td>
+                    <td className="p-4 text-center">
+                      <Marker value={row.wix} />
+                    </td>
+                    <td className="p-4 text-center">
+                      <Marker value={row.agencia} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="mx-auto mt-16 grid max-w-5xl gap-6 md:grid-cols-3">
+            <Card
+              title="Elegí Wix si..."
+              body="Tenés tiempo y ganas de aprender. Te gusta diseñar y experimentar. No necesitás dominio .com.py ni soporte en español rioplatense."
+            />
+            <Card
+              title="Elegí una agencia local si..."
+              body="Tenés un presupuesto de Gs 5M+ y un proyecto muy a medida. Necesitás integraciones complejas con sistemas existentes."
+            />
+            <Card
+              title="Elegí ParaguAI si..."
+              body="Querés un sitio profesional sin dolor, en 48 horas, pagando en guaraníes, con soporte por WhatsApp y la libertad de irte cuando quieras."
+              highlighted
+            />
+          </div>
+
+          <div className="mx-auto mt-16 max-w-2xl text-center">
+            <a
+              href={waLink('Hola, vi la comparación y quiero una demo de ParaguAI para mi negocio.')}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-[var(--primary)] to-[var(--accent)] px-8 py-4 font-bold text-[var(--primary-foreground)] shadow-lg transition-all hover:-translate-y-1"
+            >
+              <MessageCircle size={18} />
+              Pedir demo gratis
+            </a>
+            <div className="mt-6">
+              <Link
+                href="/precios"
+                className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--primary)]"
+              >
+                Ver precios y planes en detalle
+                <ArrowRight size={14} />
+              </Link>
+            </div>
+          </div>
+        </Container>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}
+
+function Card({ title, body, highlighted }: { title: string; body: string; highlighted?: boolean }) {
+  return (
+    <div
+      className={`rounded-2xl border p-6 ${
+        highlighted
+          ? 'border-[var(--primary)] bg-gradient-to-b from-[var(--primary)]/5 to-transparent'
+          : 'border-[var(--border)] bg-[var(--surface)]'
+      }`}
+    >
+      <h3 className="mb-3 text-lg font-bold text-[var(--text)]">{title}</h3>
+      <p className="text-sm text-[var(--text-light)]">{body}</p>
+    </div>
+  )
+}

--- a/web/app/demo/page.tsx
+++ b/web/app/demo/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from 'next'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { DemoQualifier } from '@/components/landing/demo-qualifier'
+
+export const metadata: Metadata = {
+  title: 'Pedir demo gratis — sitio web profesional en 48 horas',
+  description:
+    'Decinos tu rubro y tu situación actual. Te mandamos una demo personalizada por WhatsApp en 24-48 horas. Sin compromiso.',
+  alternates: { canonical: '/demo' },
+}
+
+export default function DemoPage() {
+  return (
+    <>
+      <SiteNav />
+      <main className="pt-24 pb-20">
+        <Container>
+          <div className="mx-auto mb-10 max-w-2xl text-center">
+            <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">
+              Demo gratis
+            </p>
+            <h1 className="mb-4 text-4xl font-bold text-[var(--text)] sm:text-5xl">
+              Tres preguntas y armamos tu demo
+            </h1>
+            <p className="text-lg text-[var(--text-light)]">
+              Cuanto más sepamos, mejor te llega la primera versión. Igual podés saltarte esto y
+              escribirnos por WhatsApp directamente — pero esto nos ahorra ida y vuelta.
+            </p>
+          </div>
+          <DemoQualifier />
+        </Container>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -18,20 +18,12 @@ export const metadata: Metadata = {
     siteName: 'ParaguAI Builder',
     title: 'ParaguAI Builder — Sitios Web con IA para Negocios',
     description: 'Motor de generación con IA que crea sitios web profesionales, rápidos y optimizados para cualquier tipo de negocio en Paraguay.',
-    images: [
-      {
-        url: '/og-image.png',
-        width: 1200,
-        height: 630,
-        alt: 'ParaguAI Builder - Sitios Web con IA',
-      },
-    ],
+    // Image is provided by app/opengraph-image.tsx (dynamic via next/og).
   },
   twitter: {
     card: 'summary_large_image',
     title: 'ParaguAI Builder',
     description: 'Sitios web profesionales con IA para negocios en Paraguay',
-    images: ['/og-image.png'],
   },
   robots: {
     index: true,

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -1,0 +1,100 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'nodejs'
+
+export const alt = 'ParaguAI Builder — Sitios web profesionales en 48 horas'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          background: 'linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)',
+          padding: 80,
+          color: 'white',
+          fontFamily: 'system-ui, sans-serif',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 16,
+            fontSize: 32,
+            fontWeight: 700,
+          }}
+        >
+          <div
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: 16,
+              background: 'linear-gradient(135deg, #6366f1 0%, #ec4899 100%)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 36,
+            }}
+          >
+            ✨
+          </div>
+          <div>
+            <span style={{ color: 'white' }}>Paragu</span>
+            <span style={{ color: '#a78bfa' }}>AI</span>
+          </div>
+        </div>
+
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+          <div
+            style={{
+              fontSize: 76,
+              fontWeight: 800,
+              lineHeight: 1.05,
+              letterSpacing: -2,
+              marginBottom: 24,
+            }}
+          >
+            Tu sitio web{' '}
+            <span
+              style={{
+                background: 'linear-gradient(90deg, #a78bfa 0%, #f472b6 100%)',
+                backgroundClip: 'text',
+                color: 'transparent',
+              }}
+            >
+              profesional
+            </span>{' '}
+            en 48 horas
+          </div>
+          <div style={{ fontSize: 30, color: '#cbd5e1', lineHeight: 1.4 }}>
+            Todo incluido: diseño, dominio .com.py, SEO y WhatsApp. Demo gratis antes de pagar.
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            fontSize: 24,
+            color: '#94a3b8',
+          }}
+        >
+          <div style={{ display: 'flex', gap: 32 }}>
+            <span>🇵🇾 Paraguay</span>
+            <span>· 16 plantillas listas</span>
+            <span>· 7.4K negocios mapeados</span>
+          </div>
+          <div>paragu-ai.com</div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  )
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -17,6 +17,10 @@ import { FadeIn } from '@/components/landing/fade-in'
 import { FAQItem } from '@/components/landing/faq-item'
 import { TestimonialCarousel } from '@/components/landing/testimonial-carousel'
 import { NewsletterForm } from '@/components/landing/newsletter-form'
+import { LogoStrip } from '@/components/landing/logo-strip'
+import { VideoBlock } from '@/components/landing/video-block'
+import { StickyMobileCTA } from '@/components/landing/sticky-mobile-cta'
+import { ActivityTicker } from '@/components/landing/activity-ticker'
 import {
   FloatingShape,
   ScrollProgress,
@@ -244,11 +248,11 @@ function Navigation() {
   }, [])
 
   const navLinks = [
-    { href: '#clientes', label: 'Clientes' },
-    { href: '#plantillas', label: 'Plantillas' },
-    { href: '#como-funciona', label: 'Cómo funciona' },
-    { href: '#precios', label: 'Precios' },
-    { href: '#faq', label: 'FAQ' },
+    { href: '/casos', label: 'Casos' },
+    { href: '/p', label: 'Plantillas' },
+    { href: '/precios', label: 'Precios' },
+    { href: '/comparacion', label: 'Comparación' },
+    { href: '/demo', label: 'Demo' },
   ]
 
   return (
@@ -402,11 +406,14 @@ export default function HomePage() {
           <Container>
             <div className="mx-auto max-w-5xl text-center">
               <FadeIn delay={0}>
-                <div className="mb-8 inline-flex items-center gap-3 rounded-full border border-[var(--border)] bg-[var(--surface)]/80 px-5 py-2.5 backdrop-blur-sm">
-                  <span className="inline-block h-2.5 w-2.5 animate-pulse rounded-full bg-[var(--success)]" />
-                  <span className="text-sm font-medium text-[var(--text-light)]">
-                    {heroCount1.toLocaleString()} negocios identificados en Paraguay
-                  </span>
+                <div className="mb-4 flex flex-col items-center gap-3">
+                  <div className="inline-flex items-center gap-3 rounded-full border border-[var(--border)] bg-[var(--surface)]/80 px-5 py-2.5 backdrop-blur-sm">
+                    <span className="inline-block h-2.5 w-2.5 animate-pulse rounded-full bg-[var(--success)]" />
+                    <span className="text-sm font-medium text-[var(--text-light)]">
+                      {heroCount1.toLocaleString()} negocios identificados en Paraguay
+                    </span>
+                  </div>
+                  <ActivityTicker />
                 </div>
               </FadeIn>
 
@@ -463,6 +470,17 @@ export default function HomePage() {
                       <p className="mt-1 text-sm text-[var(--text-muted)]">{stat.label}</p>
                     </div>
                   ))}
+                </div>
+              </FadeIn>
+
+              {/* Real-client logo strip + video walkthrough */}
+              <FadeIn delay={700}>
+                <LogoStrip />
+              </FadeIn>
+
+              <FadeIn delay={750}>
+                <div className="mt-16">
+                  <VideoBlock fallbackHref="#como-funciona" />
                 </div>
               </FadeIn>
 
@@ -939,16 +957,20 @@ export default function HomePage() {
               </p>
             </div>
             <div>
-              <h4 className="mb-4 font-bold text-[var(--text)]">Plataforma</h4>
+              <h4 className="mb-4 font-bold text-[var(--text)]">Producto</h4>
               <ul className="space-y-2 text-[var(--text-muted)]">
-                <li><a href="#plantillas" className="hover:text-[var(--primary)]">Plantillas</a></li>
-                <li><a href="#funcionalidades" className="hover:text-[var(--primary)]">Funcionalidades</a></li>
-                <li><a href="#precios" className="hover:text-[var(--primary)]">Precios</a></li>
+                <li><Link href="/p" className="hover:text-[var(--primary)]">Plantillas</Link></li>
+                <li><Link href="/precios" className="hover:text-[var(--primary)]">Precios</Link></li>
+                <li><Link href="/comparacion" className="hover:text-[var(--primary)]">Comparación</Link></li>
+                <li><Link href="/demo" className="hover:text-[var(--primary)]">Pedir demo</Link></li>
               </ul>
             </div>
             <div>
-              <h4 className="mb-4 font-bold text-[var(--text)]">Soporte</h4>
+              <h4 className="mb-4 font-bold text-[var(--text)]">Recursos</h4>
               <ul className="space-y-2 text-[var(--text-muted)]">
+                <li><Link href="/casos" className="hover:text-[var(--primary)]">Casos reales</Link></li>
+                <li><Link href="/blog" className="hover:text-[var(--primary)]">Blog</Link></li>
+                <li><Link href="/seguridad" className="hover:text-[var(--primary)]">Privacidad</Link></li>
                 <li><a href="#faq" className="hover:text-[var(--primary)]">FAQ</a></li>
                 <li><Link href="/admin" className="hover:text-[var(--primary)]">Panel Admin</Link></li>
               </ul>
@@ -962,6 +984,7 @@ export default function HomePage() {
 
       <FloatingWhatsApp />
       <BackToTop />
+      <StickyMobileCTA />
     </>
   )
 }

--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/admin', '/api', '/login'],
+      },
+    ],
+    sitemap: 'https://paragu-ai.com/sitemap.xml',
+    host: 'https://paragu-ai.com',
+  }
+}

--- a/web/app/seguridad/page.tsx
+++ b/web/app/seguridad/page.tsx
@@ -1,0 +1,117 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Lock, Shield, Server, FileText, Mail } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+
+export const metadata: Metadata = {
+  title: 'Privacidad y manejo de datos — ParaguAI',
+  description:
+    'Cómo guardamos los datos de tu negocio, dónde se aloja tu sitio, qué hacemos si te vas y cómo cumplimos con la Ley 6534 de Paraguay.',
+  alternates: { canonical: '/seguridad' },
+}
+
+const POINTS = [
+  {
+    icon: Server,
+    title: 'Dónde vive tu sitio',
+    body:
+      'Hosting en Cloudflare (CDN global) + Supabase (datos). Backups automáticos diarios. Si nuestro proveedor cae, tu sitio sigue sirviendo desde la caché.',
+  },
+  {
+    icon: Lock,
+    title: 'Quién accede a tu información',
+    body:
+      'Solo el equipo de ParaguAI involucrado en tu proyecto. No vendemos ni compartimos los datos de tu negocio con terceros para publicidad.',
+  },
+  {
+    icon: Shield,
+    title: 'Datos de tus visitantes',
+    body:
+      'Si activás analytics, registramos tráfico anónimo (visitas, fuentes, clicks). Si activás formularios, guardamos los envíos para que vos los veas. Nunca trackeamos a tus visitantes para revenderlos.',
+  },
+  {
+    icon: FileText,
+    title: 'Si decidís irte',
+    body:
+      'Te llevás tu dominio. Te exportamos tu contenido (textos y fotos) en formato estándar. Borramos tus datos de nuestros sistemas en 30 días.',
+  },
+] as const
+
+export default function SeguridadPage() {
+  return (
+    <>
+      <SiteNav />
+      <main className="pt-24 pb-20">
+        <Container>
+          <div className="mx-auto max-w-3xl">
+            <div className="mb-12 text-center">
+              <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">
+                Privacidad y datos
+              </p>
+              <h1 className="mb-4 text-4xl font-bold text-[var(--text)] sm:text-5xl">
+                Lo que hacemos con tu información
+              </h1>
+              <p className="text-lg text-[var(--text-light)]">
+                Sin letra chica. Lo que necesitás saber para confiar en dejarnos los datos de tu
+                negocio.
+              </p>
+            </div>
+
+            <div className="space-y-5">
+              {POINTS.map((p) => {
+                const Icon = p.icon
+                return (
+                  <div
+                    key={p.title}
+                    className="flex gap-5 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6"
+                  >
+                    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-[var(--primary)]/10 text-[var(--primary)]">
+                      <Icon size={22} />
+                    </div>
+                    <div>
+                      <h2 className="mb-2 text-lg font-bold text-[var(--text)]">{p.title}</h2>
+                      <p className="text-[var(--text-light)]">{p.body}</p>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+
+            <div className="mt-12 rounded-2xl border border-[var(--border)] bg-[var(--surface-light)] p-6">
+              <h2 className="mb-3 text-lg font-bold text-[var(--text)]">Marco legal</h2>
+              <p className="mb-4 text-[var(--text-light)]">
+                Operamos bajo la <strong>Ley N° 6534/2020 de Protección de Datos Personales</strong> de
+                Paraguay. Para usuarios europeos relacionados con clientes nuestros (ej. Nexa Paraguay
+                en sus mercados europeos), aplicamos los principios de minimización de datos del GDPR.
+              </p>
+              <p className="text-[var(--text-light)]">
+                Si querés ejercer tu derecho de acceso, rectificación o eliminación, escribinos por
+                WhatsApp o al correo del equipo.
+              </p>
+            </div>
+
+            <div className="mt-10 flex flex-wrap items-center justify-center gap-4 text-sm">
+              <Link
+                href="/"
+                className="inline-flex items-center gap-1 text-[var(--text-light)] hover:text-[var(--primary)]"
+              >
+                ← Volver al inicio
+              </Link>
+              <span className="text-[var(--text-muted)]">·</span>
+              <a
+                href="mailto:contacto@paragu-ai.com"
+                className="inline-flex items-center gap-1 text-[var(--text-light)] hover:text-[var(--primary)]"
+              >
+                <Mail size={14} />
+                contacto@paragu-ai.com
+              </a>
+            </div>
+          </div>
+        </Container>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -1,0 +1,44 @@
+import type { MetadataRoute } from 'next'
+import { LIVE_TEMPLATES } from '@/lib/landing/marketing-data'
+import { CASE_STUDIES } from '@/lib/landing/case-studies'
+import { BLOG_POSTS } from '@/lib/landing/blog-posts'
+
+const BASE = 'https://paragu-ai.com'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date()
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: `${BASE}/`, lastModified: now, changeFrequency: 'weekly', priority: 1 },
+    { url: `${BASE}/precios`, lastModified: now, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${BASE}/casos`, lastModified: now, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${BASE}/p`, lastModified: now, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${BASE}/comparacion`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${BASE}/demo`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${BASE}/seguridad`, lastModified: now, changeFrequency: 'yearly', priority: 0.4 },
+    { url: `${BASE}/blog`, lastModified: now, changeFrequency: 'weekly', priority: 0.7 },
+  ]
+
+  const verticalRoutes: MetadataRoute.Sitemap = LIVE_TEMPLATES.map((t) => ({
+    url: `${BASE}/p/${t.seoSlug ?? t.id.replace(/_/g, '-')}`,
+    lastModified: now,
+    changeFrequency: 'monthly',
+    priority: 0.8,
+  }))
+
+  const caseRoutes: MetadataRoute.Sitemap = CASE_STUDIES.map((c) => ({
+    url: `${BASE}/casos/${c.slug}`,
+    lastModified: now,
+    changeFrequency: 'monthly',
+    priority: 0.7,
+  }))
+
+  const blogRoutes: MetadataRoute.Sitemap = BLOG_POSTS.map((p) => ({
+    url: `${BASE}/blog/${p.slug}`,
+    lastModified: new Date(p.date),
+    changeFrequency: 'monthly',
+    priority: 0.6,
+  }))
+
+  return [...staticRoutes, ...verticalRoutes, ...caseRoutes, ...blogRoutes]
+}

--- a/web/components/landing/demo-qualifier.tsx
+++ b/web/components/landing/demo-qualifier.tsx
@@ -1,0 +1,219 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, ArrowRight, Check, MessageCircle } from 'lucide-react'
+import { Heading } from '@/components/ui/heading'
+import { LIVE_TEMPLATES, TEMPLATES, waLink } from '@/lib/landing/marketing-data'
+
+const SIZES = [
+  { id: 'solo', label: 'Solo yo' },
+  { id: 'small', label: '2-5 personas' },
+  { id: 'medium', label: '6-15 personas' },
+  { id: 'large', label: '15+ personas' },
+] as const
+
+const PRESENCE = [
+  { id: 'none', label: 'Solo Instagram / WhatsApp' },
+  { id: 'facebook', label: 'Tengo Facebook' },
+  { id: 'old-site', label: 'Tengo un sitio viejo' },
+  { id: 'new-site', label: 'Quiero rediseñar mi sitio' },
+] as const
+
+type Step = 0 | 1 | 2 | 3
+
+export function DemoQualifier() {
+  const [step, setStep] = useState<Step>(0)
+  const [rubro, setRubro] = useState<string>('')
+  const [size, setSize] = useState<string>('')
+  const [presence, setPresence] = useState<string>('')
+
+  const liveSlugs = useMemo(() => new Set(LIVE_TEMPLATES.map((t) => t.id)), [])
+  const orderedTemplates = useMemo(
+    () => [...TEMPLATES].sort((a, b) => Number(liveSlugs.has(b.id)) - Number(liveSlugs.has(a.id))),
+    [liveSlugs],
+  )
+
+  function next() {
+    setStep((s) => Math.min(3, s + 1) as Step)
+  }
+  function back() {
+    setStep((s) => Math.max(0, s - 1) as Step)
+  }
+
+  const summary = useMemo(() => {
+    const t = TEMPLATES.find((x) => x.id === rubro)
+    const sz = SIZES.find((s) => s.id === size)
+    const pr = PRESENCE.find((p) => p.id === presence)
+    return {
+      rubroLabel: t?.name ?? '',
+      sizeLabel: sz?.label ?? '',
+      presenceLabel: pr?.label ?? '',
+    }
+  }, [rubro, size, presence])
+
+  const waMessage = `Hola, quiero una demo gratis de ParaguAI.
+- Rubro: ${summary.rubroLabel}
+- Equipo: ${summary.sizeLabel}
+- Presencia actual: ${summary.presenceLabel}`
+
+  const canNext = (step === 0 && rubro) || (step === 1 && size) || (step === 2 && presence)
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      {/* Progress */}
+      <div className="mb-8 flex items-center justify-center gap-2">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className={`h-1.5 flex-1 rounded-full transition-colors ${
+              step >= i ? 'bg-[var(--primary)]' : 'bg-[var(--border)]'
+            }`}
+          />
+        ))}
+      </div>
+
+      <div className="rounded-3xl border border-[var(--border)] bg-[var(--surface)] p-6 md:p-10">
+        {step === 0 && (
+          <div>
+            <Heading level={2} className="mb-2 text-2xl">¿Cuál es tu rubro?</Heading>
+            <p className="mb-6 text-sm text-[var(--text-muted)]">
+              Esto nos ayuda a armar la demo más cercana a lo que necesitás.
+            </p>
+            <div className="grid max-h-96 gap-2 overflow-y-auto pr-2 sm:grid-cols-2">
+              {orderedTemplates.map((t) => {
+                const isLive = liveSlugs.has(t.id)
+                const selected = rubro === t.id
+                return (
+                  <button
+                    key={t.id}
+                    type="button"
+                    onClick={() => setRubro(t.id)}
+                    className={`flex items-center justify-between rounded-xl border-2 px-4 py-3 text-left text-sm font-medium transition-all ${
+                      selected
+                        ? 'border-[var(--primary)] bg-[var(--primary)]/5 text-[var(--text)]'
+                        : 'border-[var(--border)] text-[var(--text-light)] hover:border-[var(--primary)]/50'
+                    }`}
+                  >
+                    <span>{t.name}</span>
+                    {isLive ? (
+                      <span className="text-xs text-[var(--success)]">Demo lista</span>
+                    ) : (
+                      <span className="text-xs text-[var(--text-muted)]">Próx.</span>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {step === 1 && (
+          <div>
+            <Heading level={2} className="mb-2 text-2xl">¿Cuántos son en tu equipo?</Heading>
+            <p className="mb-6 text-sm text-[var(--text-muted)]">
+              Para sugerirte el plan más realista — no para ofrecerte el más caro.
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {SIZES.map((s) => (
+                <button
+                  key={s.id}
+                  type="button"
+                  onClick={() => setSize(s.id)}
+                  className={`rounded-xl border-2 px-4 py-4 text-left font-medium transition-all ${
+                    size === s.id
+                      ? 'border-[var(--primary)] bg-[var(--primary)]/5 text-[var(--text)]'
+                      : 'border-[var(--border)] text-[var(--text-light)] hover:border-[var(--primary)]/50'
+                  }`}
+                >
+                  {s.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {step === 2 && (
+          <div>
+            <Heading level={2} className="mb-2 text-2xl">¿Qué presencia digital tenés hoy?</Heading>
+            <p className="mb-6 text-sm text-[var(--text-muted)]">
+              Si ya tenés Wix o WordPress, te ayudamos a migrar sin perder dominio ni SEO.
+            </p>
+            <div className="grid gap-3">
+              {PRESENCE.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => setPresence(p.id)}
+                  className={`rounded-xl border-2 px-4 py-4 text-left font-medium transition-all ${
+                    presence === p.id
+                      ? 'border-[var(--primary)] bg-[var(--primary)]/5 text-[var(--text)]'
+                      : 'border-[var(--border)] text-[var(--text-light)] hover:border-[var(--primary)]/50'
+                  }`}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="text-center">
+            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-[var(--success)]/10 text-[var(--success)]">
+              <Check size={28} />
+            </div>
+            <Heading level={2} className="mb-3 text-2xl">Listo. Mandanos el WhatsApp.</Heading>
+            <p className="mb-6 text-[var(--text-light)]">
+              Ya armamos el mensaje con la info que nos diste. Hacé clic abajo, revisalo si querés
+              y mandalo. Te respondemos en horario hábil.
+            </p>
+            <pre className="mb-6 whitespace-pre-wrap rounded-xl bg-[var(--surface-light)] p-4 text-left text-sm text-[var(--text)]">
+              {waMessage}
+            </pre>
+            <a
+              href={waLink(waMessage)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-[var(--primary)] to-[var(--accent)] px-8 py-4 font-bold text-[var(--primary-foreground)] shadow-lg transition-all hover:-translate-y-1"
+            >
+              <MessageCircle size={20} />
+              Enviar por WhatsApp
+            </a>
+            <div className="mt-6">
+              <Link
+                href={`/p/${rubro.replace(/_/g, '-')}`}
+                className="text-sm font-semibold text-[var(--primary)]"
+              >
+                Mientras tanto, mirá la plantilla de tu rubro →
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {step !== 3 && (
+          <div className="mt-8 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={back}
+              disabled={step === 0}
+              className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--text-muted)] disabled:opacity-40"
+            >
+              <ArrowLeft size={14} />
+              Atrás
+            </button>
+            <button
+              type="button"
+              onClick={next}
+              disabled={!canNext}
+              className="inline-flex items-center gap-2 rounded-xl bg-[var(--primary)] px-5 py-2.5 text-sm font-bold text-[var(--primary-foreground)] transition-all hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Siguiente
+              <ArrowRight size={14} />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/components/landing/roi-calculator.tsx
+++ b/web/components/landing/roi-calculator.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { Calculator, TrendingUp } from 'lucide-react'
+import { Heading } from '@/components/ui/heading'
 import { PLANS } from '@/lib/landing/marketing-data'
 
 const PRESENCIA = PLANS.find((p) => p.id === 'presencia')!
@@ -45,7 +46,7 @@ export function ROICalculator() {
           <Calculator size={22} />
         </div>
         <div>
-          <h3 className="text-xl font-bold text-[var(--text)]">¿Cuándo se paga sola?</h3>
+          <Heading level={3} className="text-xl">¿Cuándo se paga sola?</Heading>
           <p className="text-sm text-[var(--text-muted)]">
             Estimá tu retorno con tus números reales.
           </p>

--- a/web/lib/landing/blog-posts.ts
+++ b/web/lib/landing/blog-posts.ts
@@ -1,0 +1,49 @@
+/**
+ * Blog post registry. Add new posts as objects in this array.
+ * Body is plain Markdown-ish strings — rendered as paragraphs.
+ *
+ * NOT a CMS — intentionally keeps content close to code so the team can
+ * publish via PR. When the volume justifies it, switch to MDX or a headless CMS.
+ */
+
+export type BlogPost = {
+  slug: string
+  title: string
+  excerpt: string
+  /** ISO date string (YYYY-MM-DD). */
+  date: string
+  /** Author display name. */
+  author: string
+  /** Reading-time estimate, e.g. "4 min". */
+  readingTime: string
+  /** Tag like "vertical:peluqueria" or "topic:seo". */
+  tag: string
+  /** Body as an array of paragraphs (kept simple — no MDX runtime). */
+  body: readonly string[]
+}
+
+export const BLOG_POSTS: readonly BlogPost[] = [
+  {
+    slug: 'por-que-tu-peluqueria-necesita-web',
+    title: 'Por qué tu peluquería necesita un sitio web (y no solo Instagram)',
+    excerpt:
+      'Instagram es genial para mostrar trabajos. Pero si tus clientes no pueden encontrarte en Google, ver tus precios o reservar sin escribirte, estás dejando dinero en la mesa.',
+    date: '2026-04-20',
+    author: 'Equipo ParaguAI',
+    readingTime: '4 min',
+    tag: 'vertical:peluqueria',
+    body: [
+      'En Paraguay hay 2.393 peluquerías mapeadas. El 81% no tiene sitio web propio. Eso significa que cuando alguien busca "peluquería cerca" en Google, casi nadie aparece — y los pocos que sí, se llevan toda la clientela nueva.',
+      'Instagram es excelente para mostrar trabajos terminados. Pero tiene tres techos que no podés romper desde la app:',
+      '1) **No salís en Google.** Las búsquedas locales ("peluquería en Asunción", "corte de pelo cerca") las gana quien tiene un sitio bien optimizado. Instagram no compite ahí.',
+      '2) **Los precios viven en DMs.** Cada cliente nuevo te escribe "¿cuánto sale el corte?" y vos contestás lo mismo veinte veces al día. Un sitio con precios visibles 24/7 te ahorra horas y filtra a quien no es tu cliente.',
+      '3) **No podés hacer reservas.** Las clientas tienen que coordinar por mensaje. Pierden interés a mitad de conversación. Un botón de "reservar turno por WhatsApp" con tu agenda lista cierra muchas más reservas que ir y volver.',
+      'No tenés que elegir entre Instagram y un sitio. Lo ideal es que se potencien: Instagram trae el descubrimiento visual, el sitio web cierra la venta y aparece en Google.',
+      'En ParaguAI armamos sitios para peluquerías paraguayas en 48 horas, con WhatsApp Business, Google Maps y galería sincronizada. Si querés ver cómo se vería, mandanos un WhatsApp y armamos tu demo gratis.',
+    ],
+  },
+] as const
+
+export function getPost(slug: string): BlogPost | undefined {
+  return BLOG_POSTS.find((p) => p.slug === slug)
+}


### PR DESCRIPTION
## Summary

Second wave of marketing pages extending PR #59. Adds the four sub-pages that were missing, plus the SEO-routing essentials (sitemap, robots, dynamic OG image).

### New sub-pages

| Route | Purpose |
|---|---|
| \`/comparacion\` | Honest comparison: ParaguAI vs Wix/WordPress vs agencia local. 13-row table + a "what to choose if..." card per option. |
| \`/demo\` | 3-step qualifier (rubro / team size / current presence) that pre-fills a structured WhatsApp message. Reduces back-and-forth on first contact. |
| \`/seguridad\` | Privacy + data-handling page. Cites Ley 6534 (PY) and GDPR principles. |
| \`/blog\` + \`/blog/[slug]\` | Blog index + dynamic post route. Seeded with one real article ("Por qué tu peluquería necesita un sitio web"). New posts ship as PRs to \`web/lib/landing/blog-posts.ts\`. |

### SEO-routing essentials

- \`app/sitemap.ts\` — auto-generates from \`LIVE_TEMPLATES\`, \`CASE_STUDIES\`, \`BLOG_POSTS\` + static routes (no manual maintenance).
- \`app/robots.ts\` — allow-all with explicit \`/admin\`, \`/api\`, \`/login\` disallow.
- \`app/opengraph-image.tsx\` — dynamic OG via \`next/og\` (replaces missing static \`og-image.png\` references in layout).

### Landing wiring

- Nav and footer now link to the real sub-routes (\`/casos\`, \`/p\`, \`/precios\`, \`/comparacion\`, \`/demo\`, \`/blog\`, \`/seguridad\`) instead of in-page anchors only.
- Hero gets \`ActivityTicker\` + \`LogoStrip\` + \`VideoBlock\` mounted above the fold (components already existed from #59 but weren't wired in).
- \`StickyMobileCTA\` mounted globally so the demo CTA persists on mobile scroll.

### Lint + cleanup

- \`roi-calculator.tsx\`: replace raw \`<h3>\` with \`<Heading level={3}>\` per the no-restricted-syntax rule from PR #58.
- \`layout.tsx\`: remove broken \`/og-image.png\` references — file-based OG now provides the image automatically.

## Test plan

- [ ] Typecheck + lint clean (verified locally)
- [ ] Visit \`/comparacion\`, \`/demo\`, \`/seguridad\`, \`/blog\`, \`/blog/por-que-tu-peluqueria-necesita-web\` on staging
- [ ] Demo qualifier: complete the 3 steps → opens WhatsApp with structured message
- [ ] \`/sitemap.xml\` contains \`/comparacion\`, \`/demo\`, \`/seguridad\`, \`/blog\` + per-vertical and per-case URLs
- [ ] \`/robots.txt\` references \`/sitemap.xml\` and disallows \`/admin\`
- [ ] OG preview check: paste \`https://paragu-ai.com/\` into a WhatsApp chat → image renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)