### PR TITLE
docs(dayah-litworks): pre-filled onboarding questionnaire

### DIFF
--- a/sites/dayah-litworks/docs/onboarding-questionnaire.md
+++ b/sites/dayah-litworks/docs/onboarding-questionnaire.md
@@ -1,0 +1,482 @@
+# Cuestionario de onboarding — Dayah LitWorks
+
+**Para:** Dayah · **De:** equipo ParaguAI · **Fecha:** 21 abr 2026
+
+Hola Dayah 👋. Ya tenés tu sitio en vivo en **[paragu-ai.com/dayah-litworks](https://paragu-ai.com/dayah-litworks)** con los datos que migramos del demo. Pero hay mucho que **precargamos con valores por defecto** y varias cosas que necesitamos que **confirmes, corrijas o completes** para que el sitio refleje realmente tu marca y convierta bien.
+
+Este cuestionario está dividido en 4 partes:
+
+1. **[Parte A](#parte-a--confirmar-lo-que-ya-tenemos)** — lo que ya precargamos (confirmalo o corregilo)
+2. **[Parte B](#parte-b--datos-que-faltan-necesitamos-tu-aporte)** — datos que faltan
+3. **[Parte C](#parte-c--estrategia-y-posicionamiento)** — preguntas de negocio (actúo acá como tu director/socio estratégico, no sólo como el que te hace el sitio)
+4. **[Parte D](#parte-d--feedback-sobre-paraguai-como-servicio)** — cómo te está yendo con nosotros
+
+No te preocupés por ser breve — cuanto más detallada la respuesta, menos idas y vueltas. **Tiempo estimado: 60–90 minutos si lo hacés con cuidado.**
+
+Podés responder en este mismo Markdown editando debajo de cada campo, o en un Google Doc, o agendamos un llamado y lo vamos completando juntas.
+
+---
+
+## Parte A — Confirmar lo que ya tenemos
+
+> Abajo están los datos que ya están en tu tenant (y en el sitio en vivo). Marcá **✓** si está bien, **✗** si hay que corregir, y poné el valor correcto abajo. Lo que dejes sin marcar se va como está.
+
+### A.1 Identidad de la marca
+
+| Campo | Valor actual | ✓/✗ | Corrección |
+|---|---|---|---|
+| Nombre comercial | **Dayah LitWorks** | | |
+| Tagline / frase corta | **"Donde la fantasía se convierte en realidad"** | | |
+| Slug en la URL | **dayah-litworks** (paragu-ai.com/dayah-litworks) | | |
+| Dominio propio (futuro) | **dayah-litworks.com** — ¿tenés este dominio registrado? | | |
+| Ciudad | **Asunción** | | |
+| País | **Paraguay** | | |
+| Año de fundación | (no lo tenemos — falta) | | |
+| CUIT / RUC / identificador fiscal | (falta) | | |
+| Razón social formal | (falta) | | |
+| Idioma principal | **Español** solamente. ¿Querés inglés también para clientes internacionales? | | |
+
+### A.2 Contacto
+
+| Campo | Valor actual | ✓/✗ | Corrección |
+|---|---|---|---|
+| Email | **dayah@litworks.com** | | |
+| WhatsApp | **+595 981 000 000** _(⚠️ esto parece un placeholder — ¿cuál es el número real?)_ | | |
+| Instagram | **@dayah.litworks** | | |
+| TikTok | (no registrado) — ¿tenés? | | |
+| Pinterest | (no registrado) — **muy relevante para book cover design** — ¿tenés? | | |
+| Facebook | (no registrado) — ¿tenés? | | |
+| Behance / Dribbble | (no registrado) — ¿tenés portafolio en alguno? | | |
+| LinkedIn personal | (no registrado) — ¿tenés? | | |
+
+### A.3 Servicios actualmente listados
+
+Tenemos estos 4 servicios publicados, todos con precio **"Consultar"**. Necesito que me confirmés precios reales (o rangos) para que la gente tenga una idea y no abandone la página:
+
+| # | Servicio | Precio actual | Precio real / rango | Duración / entrega | Incluye |
+|---|---|---|---|---|---|
+| 1 | **Portada Personalizada — Ebook** | Consultar | **$___ USD** o **Gs ____** | | | 
+| 2 | **Portada Personalizada — Tapa Blanda** (frente + lomo + contra) | Consultar | | | |
+| 3 | **Mockup 3D Estático** | Consultar | | | |
+| 4 | **Video Mockup 3D** (animación) | Consultar | | | |
+
+**Preguntas sobre servicios:**
+- ¿Faltan servicios que sí ofrecés y no están listados? (ej: typography-only, formateo interior del libro, branding completo de autor, packaging de serie)
+- ¿Alguno de estos lo estás dejando de ofrecer?
+- ¿Hacés paquetes (ej: "Kit autor indie" = portada + ebook + 3 mockups)?
+
+### A.4 Portadas pre-hechas (premades) actualmente publicadas
+
+Son las **6** que están en el sitio. Todas sin imagen (`imageUrl` vacío), todas marcadas disponibles:
+
+| # | Nombre | Precio | Género | Imagen subida | Vendida ya (quitar) |
+|---|---|---|---|---|---|
+| 1 | Susurros del Bosque | $35 | Fantasía | ✗ falta | |
+| 2 | Corazón de Cenizas | $35 | Romance | ✗ falta | |
+| 3 | El Último Código | $30 | Thriller | ✗ falta | |
+| 4 | Galaxia Interior | $35 | Ciencia Ficción | ✗ falta | |
+| 5 | Sombras en el Espejo | $30 | Terror | ✗ falta | |
+| 6 | Alas de Cristal | $35 | Fantasía | ✗ falta | |
+
+**⚠️ Esto es el bug más grande del sitio ahora**: los nombres parecen **placeholders/dummy** que puse en el seed. Necesito:
+
+- [ ] **¿Son nombres reales de premades tuyos o son placeholders?**
+- [ ] Si son reales: **subir las imágenes** (1200×1800 px mínimo, JPG o PNG). Carpeta para subir: (te paso un Drive)
+- [ ] Si son placeholders: mandame la lista real de tus premades con imágenes.
+- [ ] ¿Los precios están en **USD** (porque $ sin moneda ambigüedad)? ¿Querés también mostrar precio equivalente en PYG?
+- [ ] ¿Tenés más premades que no están en el sitio? Mandame tu catálogo completo (Google Drive / link a tu tienda).
+- [ ] Licencia de premades: ¿**exclusiva** (una persona la compra y el diseño sale de venta) o **no exclusiva** (se puede vender varias veces)?
+
+### A.5 Testimonios actuales
+
+Tenemos 2 publicados:
+
+| # | Testimonio | Autor | ★ | ¿Real? | Permiso para usar nombre + foto? |
+|---|---|---|---|---|---|
+| 1 | "Mi portada quedó increíble! Dayah entendió perfectamente la esencia de mi libro." | **María G.** | 5 | | |
+| 2 | "Profesional, creativa y super rápida. Mi portada premade fue amor a primera vista." | **Carlos R.** | 5 | | |
+
+**Preguntas:**
+- ¿María G. y Carlos R. son **clientes reales** o los puse como placeholder?
+- Si son reales: ¿tenés su nombre completo + permiso para usarlo + foto opcional?
+- **Necesitamos mínimo 6 testimonios** idealmente (3 de serviço custom, 3 de premades). ¿Podés reunirlos?
+- ¿Algún cliente te mandó testimonio en video / audio? Eso convierte 3× más que texto.
+
+### A.6 Diseño visual (colores, tipografías)
+
+Actualmente heredás los colores/tipografías del **vertical `portfolio-professional`** genérico — no tenés branding custom.
+
+| Elemento | Actual | Tu preferencia |
+|---|---|---|
+| Color primario | (default genérico portfolio) | **#______ (hex)** o "usá el color de mi logo" |
+| Color secundario / acento | | |
+| Tipografía para títulos | Default | Sugerencia: Playfair Display (elegante, coincide con libros fantasy) o tu preferencia |
+| Tipografía para texto | Default | Sugerencia: Inter |
+| Tema | claro | claro / oscuro / dual |
+
+**Preguntas:**
+- ¿Tenés **logo** en SVG o PNG transparente alta resolución? Necesito uno para el header y el footer.
+- ¿Tenés **manual de marca** o paleta definida? Si sí, mandámelo.
+- ¿Tenés alguna **referencia visual** de sitios que te gusten? (mandame 3–5 links, no importa si son competencia)
+
+---
+
+## Parte B — Datos que faltan (necesitamos tu aporte)
+
+> Esto son cosas que hoy no tiene el sitio y que **sí o sí** necesitamos para que convierta bien.
+
+### B.1 Portafolio / trabajos pasados
+
+**Esto es crítico para book cover design** — la decisión de compra es 80% visual.
+
+- [ ] **Cantidad de portadas terminadas** que querés mostrar: ___
+- [ ] **Carpeta compartida** (Google Drive / Dropbox / link público): ___
+- [ ] **Por cada portada**, incluir:
+  - [ ] Imagen en alta resolución (mínimo 1200×1800 px)
+  - [ ] Título del libro
+  - [ ] Autor/a (si tenés permiso para nombrar)
+  - [ ] Año
+  - [ ] Género
+  - [ ] Mención corta (1–2 frases): brief del cliente + tu solución
+  - [ ] ¿Mockup 3D disponible también? (queda buenísimo en sitio)
+  - [ ] ¿Link a Amazon / Wattpad / plataforma donde se vende?
+- [ ] ¿Querés categorizar por **género** (Fantasía / Romance / Thriller / SciFi / Terror / Juvenil / No-ficción)?
+
+### B.2 Antes/Después (before/after)
+
+Si en algún caso hiciste un **rediseño** de una portada anterior o mostrás progreso de bocetos → imagen final:
+
+- [ ] ¿Tenés 2–4 ejemplos de antes/después con permiso del cliente?
+- [ ] (Opcional pero fuerte): mostrar **proceso creativo** — del moodboard al sketch al final.
+
+### B.3 Tu proceso de trabajo
+
+La gente que va a contratar un custom quiere entender **cómo vas a trabajar con ella**. Armá un proceso de 4–6 pasos. Si no tenés claro qué contar, usá esto como plantilla y editá:
+
+| Paso | Qué pasa | Duración |
+|---|---|---|
+| 1. Briefing | Llamado de 30 min donde me contás tu libro, tu público, referencias visuales. Gratis. | 30 min |
+| 2. Propuesta + anticipo | Te mando cotización. Con el 50% de anticipo, arrancamos. | 2 días |
+| 3. Moodboard + 2 rutas creativas | Te presento 2 direcciones visuales distintas, elegís una. | 5 días |
+| 4. Diseño final + 2 revisiones | Refino la ruta elegida, con hasta 2 rondas de ajustes. | 7 días |
+| 5. Entrega | Archivos en alta resolución, mockup 3D incluido, listos para subir a tu plataforma. | 1 día |
+
+**Adaptá esto a cómo realmente trabajás** y contame cómo sería. Si ya lo tenés escrito en algún lado, mandámelo.
+
+### B.4 Preguntas frecuentes (FAQ)
+
+Armemos **12–15 preguntas** que te hacen seguido. Empiezo yo con algunas típicas para tu rubro; completá las que te hagan a vos + agregá otras:
+
+1. **¿Cuánto tarda una portada personalizada?** → ___
+2. **¿Cuántas revisiones incluye?** → ___
+3. **¿Cómo es el proceso de pago?** → ¿50/50? ¿Por MercadoPago / transferencia / PayPal?
+4. **¿Cobro en guaraníes o en USD?** → ___
+5. **¿Hago lomos para tapa dura / tapa blanda / ebook por separado?** → ___
+6. **¿Puedo usar la portada en Amazon KDP / Wattpad / editorial tradicional?** → cesión de derechos, tema licensing
+7. **¿Qué es un mockup 3D? ¿Sirve para qué?** → ___
+8. **¿Qué pasa si no me gusta nada después de los bocetos?** → política de no-gusto, reembolso, etc.
+9. **¿Hacés rediseños sobre portadas viejas?** → ___
+10. **¿Trabajás con editoriales o solo con autores indie?** → ___
+11. **¿Necesito mandarte los textos finales del libro o solo el título?** → ___
+12. **¿Cuánto cuesta una portada vs un mockup vs un video animado?** → ___
+13. **¿En qué idioma diseñás la tipografía?** — si escriben en inglés, ¿te manejás?
+14. **¿Puedo contratar urgente (entrega en 48–72h)?** → recargo por rush?
+15. **¿Cómo se entregan los archivos finales?** → formatos (PSD, AI, PNG, PDF), resoluciones, DPI.
+
+Respondé cada una en 2–3 oraciones directas. Estas son las preguntas que tus clientes **no se atreven a escribir por WhatsApp** pero les pesan para decidir.
+
+### B.5 Sobre vos (página "Sobre")
+
+Aún no hay página "Sobre". Armemos una para que los clientes sepan con quién están trabajando:
+
+- [ ] **Foto profesional tuya** (1 foto cuadrada 800×800 px mínimo, fondo neutro)
+- [ ] **Bio corta** (2–3 oraciones, para mostrar en la home): ___
+- [ ] **Bio larga** (3–4 párrafos, para la página "Sobre"): ___
+- [ ] **Tu historia** — ¿cómo empezaste con el diseño de portadas? ¿Qué te enamoró del rubro?
+- [ ] **Formación / estudios** (si relevante) — ¿autodidacta? ¿carrera formal de diseño? ¿cursos específicos de book cover design?
+- [ ] **Software / herramientas** que usás (Photoshop, Illustrator, Procreate, Blender para 3D, etc.)
+- [ ] **Idiomas** que hablás / en los que podés trabajar: ___
+- [ ] **Géneros que preferís / en los que tenés más experiencia**: ___
+- [ ] **Libros que leés** (para hablarle al cliente en su lenguaje): ___
+
+### B.6 Imágenes
+
+| Imagen | Tamaño mínimo | ¿Tenés? | Link / notas |
+|---|---|---|---|
+| **Logo** (SVG preferido) | 512×512 cuadrado | | |
+| **Favicon** | 512×512 | | |
+| **Hero image** (fondo arriba de la página) | 1920×1080, horizontal | ⚠️ ahora mismo no hay, texto sobre color plano | |
+| **Foto tuya** | 800×800 | | |
+| **Premades** (1 por portada) | 1200×1800 | | |
+| **Mockups 3D** (1 por trabajo en portafolio) | 1920×1080 | | |
+| **Foto de escritorio/espacio de trabajo** (opcional, para "Sobre") | 1200×800 | | |
+| **Moodboards / behind the scenes** (opcional) | varía | | |
+
+**Si no tenés fotos profesionales tuyas**, podemos:
+- Usar foto informal que mejoremos con IA (gratis, sale OK)
+- Agendar sesión con fotógrafo paraguayo (~Gs 800k–1.5M, resultado mejor)
+- Usar un avatar/ilustración tuya (bastante in para freelancers creativos — ~Gs 300k con ilustrador)
+
+¿Qué preferís?
+
+### B.7 Blog
+
+- [ ] ¿Querés blog? **Sí / no**
+- [ ] Si sí: **¿cuántos artículos iniciales podés tener listos** para el lanzamiento? (idealmente 3–5, sino arrancamos con 0)
+- [ ] Ideas de artículos (marcá los que te gustan + agregá los tuyos):
+  - [ ] "5 errores que cometen los autores indie al elegir portada"
+  - [ ] "¿Qué es más importante: el título o la portada?"
+  - [ ] "Cómo leer un reporte de ventas de Amazon KDP (y qué dice de tu portada)"
+  - [ ] "Behind the scenes: diseñando [nombre-libro]"
+  - [ ] "Tendencias de portadas 2026 por género"
+  - [ ] "Portada ebook vs tapa blanda: qué cambia"
+  - [ ] Case study de un cliente exitoso
+- [ ] ¿Quién los escribe? **Vos / yo (extra) / intercambio**
+
+---
+
+## Parte C — Estrategia y posicionamiento
+
+> Ahora me pongo el sombrero de **director de producto / socio estratégico**. Estas preguntas son para decidir cómo posicionamos tu marca, qué features priorizamos, y hacia dónde va el negocio.
+
+### C.1 Perfil del cliente ideal (ICP)
+
+- **Cliente ideal típico**: _(rellená el arquetipo — ej: "Autora de 30-45 años, escribiendo fantasía romántica en español, publicando en Amazon KDP, con 1-3 libros publicados, presupuesto 300-600 USD por portada")_
+- **Ticket promedio por proyecto**: $___
+- **Tiempo desde primer contacto hasta cierre**: ___ días
+- **% de leads que convierten**: ___ %
+- **¿De qué país son la mayoría de tus clientes?** Paraguay / Argentina / Latam / España / USA / otro
+- **¿Cliente custom o cliente premade — cuál te deja más margen?** ___
+- **¿Quién es un cliente que NO querés atender?** (importante definir — ejemplos: "gente sin presupuesto claro", "libros que no me interesan éticamente", "autores que piden infinitas revisiones gratis", etc.)
+
+### C.2 Canales de adquisición
+
+¿De dónde vienen tus clientes hoy?
+
+| Canal | % actual | ¿Querés crecer? |
+|---|---|---|
+| Instagram (@dayah.litworks) | __% | |
+| Recomendaciones / boca en boca | __% | |
+| Grupos de Facebook de autores indie | __% | |
+| Pinterest | __% | |
+| Reddit (r/selfpublish, r/fantasywriters) | __% | |
+| Wattpad (poner tu portafolio ahí) | __% | |
+| Fiverr / 99designs / Reedsy / Upwork | __% | |
+| Búsqueda Google (SEO) | __% | |
+| Referidos de escritores a escritores | __% | |
+| Otros: ___ | | |
+
+**Preguntas:**
+- ¿Qué canal tiene más potencial pero no estás explotando?
+- ¿Hacés ads pagos? Meta / Google / Pinterest. Si sí, ¿presupuesto actual?
+- ¿Cuánto ganaste los últimos 3 meses? (es para calibrarnos — si quiere compartir)
+- ¿Cuánto querrías ganar en 6 meses?
+
+### C.3 Competencia
+
+- **3 competidores directos** (diseñadores de portadas en español / internacionales):
+  - 1: _______________
+  - 2: _______________
+  - 3: _______________
+- **Qué hacen mejor que vos**: ___
+- **Qué hacés mejor que ellos**: ___
+- **En qué precio se mueven**: ___
+
+### C.4 Posicionamiento
+
+Pick 1 (o proponé tuyo):
+
+- ☐ **"Portadas premium para autoras de fantasía"** — nicho súper específico, premium
+- ☐ **"Portadas profesionales a precio accesible"** — volumen, mid-market
+- ☐ **"Portadas + mockups + packaging completo"** — full service para autores serios
+- ☐ **"Portadas paraguayas para Latam"** — cultural, mercado regional
+- ☐ **"Book design integral: portada + interior + marketing visual"** — escalar hacia branding de autor
+- ☐ Otro: ___
+
+### C.5 Productos / monetización
+
+¿Querés solo hacer portadas custom + premades, o escalar con productos digitales?
+
+- ☐ **Solo lo actual** (custom + premades)
+- ☐ **Kits / templates descargables** (Photoshop templates para autores que quieren hacerlo solos) → $15-30, volumen
+- ☐ **Curso online** "Diseñá tu propia portada" → $50-300, una vez
+- ☐ **Membresía mensual** con premades ilimitados → recurring revenue
+- ☐ **Affiliates** con plataformas (KDP, Canva, etc.)
+- ☐ **Servicios adicionales** (formateo interior, marketing visual, branding de autor)
+
+### C.6 Objetivos a 6 meses
+
+- [ ] **# de clientes custom cerrados / mes**: ___ (hoy) → ___ (objetivo)
+- [ ] **# de premades vendidos / mes**: ___ (hoy) → ___ (objetivo)
+- [ ] **Ticket promedio**: $___ (hoy) → $___ (objetivo)
+- [ ] **Revenue mensual**: $___ (hoy) → $___ (objetivo)
+- [ ] **¿Querés mantener solo / contratar asistente / armar equipo?**
+- [ ] **1 cosa específica** que querrías cambiar del negocio en 6 meses: ___
+
+### C.7 Bloqueos actuales
+
+¿Qué te frena ahora? (marcá todos los que apliquen)
+
+- ☐ No tengo suficientes leads
+- ☐ Me llegan leads pero no convierto (gente que pregunta y no contrata)
+- ☐ Precios muy bajos, margen chico
+- ☐ Mucho trabajo repetitivo, no puedo escalar
+- ☐ Clientes difíciles (muchas revisiones, quejas)
+- ☐ No tengo tiempo para marketing
+- ☐ No tengo portafolio fuerte todavía
+- ☐ No sé bien qué decir en redes
+- ☐ Competencia internacional más barata (diseñadores indios, filipinos)
+- ☐ Otro: ___
+
+### C.8 Credibilidad / trust signals
+
+- [ ] **Certificaciones / formación relevante** (escribir): ___
+- [ ] **Años diseñando portadas específicamente**: ___
+- [ ] **Cantidad total de portadas terminadas**: ___
+- [ ] **Cliente "más grande" o más reconocible** que hayas tenido: ___
+- [ ] **Premios / menciones / prensa** (si existe): ___
+- [ ] **Partnerships** con editoriales / plataformas: ___
+
+---
+
+## Parte D — Feedback sobre ParaguAI (como servicio)
+
+> Te pregunto como responsable del producto ParaguAI Builder — tu experiencia con nosotros define qué mejoramos.
+
+### D.1 Estado actual del sitio
+
+- **Qué te gusta del sitio actual**: ___
+- **Qué NO te gusta / cambiarías ya**: ___
+- **¿Lo mostraste a algún cliente o colega? ¿Qué dijeron?**: ___
+- **¿Ya mandaste tráfico al sitio? ¿De dónde?**: ___
+- **¿Te ayudó a cerrar alguna venta o consulta desde que está publicado?**: ___
+
+### D.2 Features que faltan (desde tu perspectiva)
+
+¿Qué le falta a tu sitio que nosotros deberíamos construir? Marcá prioridad:
+
+| Feature | 🔥 crítico | 👍 útil | 🤷 no urgente |
+|---|---|---|---|
+| Panel admin para vos editás contenido sin depender de nosotros | | | |
+| Página de portafolio con filtro por género | | | |
+| Tienda de premades con carrito + pago en línea (MercadoPago / PayPal) | | | |
+| Blog | | | |
+| Contact form con intake detallado (tipo "contame de tu libro") | | | |
+| Agenda online (Calendly) para briefings iniciales | | | |
+| Galería de antes/después | | | |
+| Embed de Instagram feed en home | | | |
+| Página "Sobre" dedicada | | | |
+| Página de cada portada individual con caso de estudio | | | |
+| Traducción automática a inglés (para captar clientes extranjeros) | | | |
+| Generador de mockups 3D automático (subís imagen y salen 5 mockups) | | | |
+| Sistema de reviews público tipo Google | | | |
+| Download de templates / recursos gratis (lead magnet) | | | |
+| Newsletter integrado | | | |
+| Otro: ___ | | | |
+
+### D.3 Precio y valor
+
+- **Si ParaguAI te cobrara hoy por este sitio, ¿cuánto te parecería justo?** — mensual / una sola vez
+- **¿Conocés competencia directa nuestra?** (Wix, Squarespace, Webflow con plantilla, freelancer local, etc.)
+- **¿Qué ventaja tenemos nosotros vs ellos según tu experiencia?** ___
+- **¿Qué desventaja?** ___
+
+### D.4 Dominio propio + email profesional
+
+- [ ] ¿Querés que te ayudemos a registrar **dayah-litworks.com** (si no lo tenés)?
+- [ ] ¿Querés email **dayah@dayah-litworks.com** (en vez del @litworks.com actual)?
+- [ ] Budget para dominio + email profesional: ~$15/año dominio + $6/mes Google Workspace.
+
+### D.5 Lanzamiento y marketing
+
+Una vez que completemos el sitio con tus datos reales:
+
+- [ ] **Fecha tentativa de "relanzamiento"** (cuando quieras empezar a promocionarlo): ___
+- [ ] **¿Querés que hagamos un announcement en tu Instagram?** Podemos armarte un carrusel con el proceso de tu propio sitio ("mirá cómo diseñé mi web con ParaguAI") — buen contenido para vos + nos ayudás marketeándonos.
+- [ ] **¿Podés ser caso de estudio público nuestro?** Esto sería una página en **paragu-ai.com/casos/dayah-litworks** contando tu historia. Beneficio para vos: backlink + exposición.
+
+### D.6 Referidos
+
+- **¿Conocés otros diseñadores / creativos / profesionales independientes que podrían necesitar un sitio?**
+- Si nos referís a alguien que contrata, te damos 3 meses **gratis** del plan actual + Gs 300k en cash.
+- Nombres que se te ocurren ahora: ___
+
+---
+
+## Parte E — Legal y operativa (lo obligatorio que aburre pero importa)
+
+### E.1 Política de privacidad
+
+Tu sitio capta datos (email + WhatsApp desde el form + IG messages). Necesitamos política de privacidad vigente.
+
+- [ ] **¿Tenés política de privacidad redactada?** Sí — mandala / No — usamos plantilla paraguaya (Ley 1.682/01) que te pasamos para revisión.
+- [ ] **Responsable del tratamiento de datos** (nombre legal tuyo): ___
+- [ ] **Email para solicitudes ARCO** (acceso / rectificación / cancelación / oposición): dayah@litworks.com ← ¿es correcto?
+
+### E.2 Términos de servicio
+
+- [ ] **¿Tenés T&C para proyectos custom?** (detalle cesión de derechos, revisiones, pagos, cancelación). Sí / No.
+- [ ] **Política de revisiones**: ___
+- [ ] **Política de reembolso** (si cancelan después del briefing): ___
+- [ ] **Cesión de derechos** — ¿el cliente se queda con todos los derechos comerciales o solo uso no-exclusivo?
+
+### E.3 Premades — licenciamiento
+
+- [ ] **¿Premades son exclusivos** (una vez vendido, sale de catálogo permanentemente)?
+- [ ] **¿O no exclusivos** (se pueden vender N veces)?
+- [ ] **Precio adicional si el cliente quiere upgrade a exclusivo después**: ___
+- [ ] **¿Cliente recibe los archivos .PSD/.AI o solo el render final**?
+
+### E.4 Métodos de cobro
+
+- ☐ Transferencia bancaria (Paraguay)
+- ☐ MercadoPago
+- ☐ PayPal (internacional)
+- ☐ Stripe
+- ☐ Wise / Revolut
+- ☐ USDT / cripto (algunos clientes indie prefieren)
+- ☐ Otro: ___
+
+¿Cuál preferís como default?
+
+### E.5 Facturación
+
+- [ ] ¿Emitís factura legal en Paraguay?
+- [ ] Si sí: RUC + sistema contable que usás (ContaBil, Siigo, Excel, contador externo): ___
+- [ ] ¿Necesitás que el sistema genere factura automática tras pago?
+
+---
+
+## ¿Cómo seguimos?
+
+1. **Respondé este cuestionario** (copiá en Google Doc si querés editar más cómoda, mandamelo completo)
+2. **Mandame los archivos** que pedí (logo, fotos, carpeta de Drive con portadas)
+3. **Agendamos una llamada de 30–45 min** para repasar tus respuestas y priorizar siguientes pasos
+4. **Implemento los cambios** en staging (staging.paragu-ai.com/dayah-litworks) en 2–4 días
+5. **Firmás el OK** y pasamos a producción
+
+**Contacto para responder**: whatsapp +595 975 550 123 · email hola@paragu-ai.com · DM en IG
+
+---
+
+## Apéndice — lo que hice yo de mi parte antes de mandarte esto
+
+- ✓ Analicé los 4 archivos que componen tu tenant: `site.json`, `tokens.json`, `pages/home.json`, `content/es.json`
+- ✓ Inspeccioné el sitio en vivo en paragu-ai.com/dayah-litworks (200 OK, renderiza)
+- ✓ Identifiqué 4 servicios publicados y 6 premades, flaggié los que parecen placeholder
+- ✓ Verifiqué los 2 testimonios — necesito que me confirmés si son reales
+- ✓ Confirmé que tu vertical es "portfolio-professional" (misma base que fotógrafos, arquitectos, freelancers creativos)
+- ✓ Listé los gaps del sitio actual vs lo que book cover design realmente necesita para convertir
+- ✓ Escribí este cuestionario con las preguntas priorizadas
+
+**Lo que aún no hice (te espero):**
+- Armar la página "Sobre" (necesito tu bio + foto)
+- Subir las imágenes del portafolio (necesito los archivos)
+- Cambiar el número de WhatsApp real (el actual `+595 981 000 000` es placeholder)
+- Ajustar colores/tipografías a tu marca real
+- Publicar precios reales (todos "Consultar" ahora)
+
+Nada urgente — tomate los días que necesites. Pero mientras antes, mejor: cada día que el sitio tenga placeholders es un lead menos que convierte.
+
+Abrazos,
+**— Equipo ParaguAI**

--- a/web/app/blog/[slug]/page.tsx
+++ b/web/app/blog/[slug]/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowLeft, Clock, MessageCircle } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { BLOG_POSTS, getPost } from '@/lib/landing/blog-posts'
+import { waLink } from '@/lib/landing/marketing-data'
+
+type Params = { slug: string }
+
+export function generateStaticParams() {
+  return BLOG_POSTS.map((p) => ({ slug: p.slug }))
+}
+
+export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
+  const { slug } = await params
+  const post = getPost(slug)
+  if (!post) return { title: 'Artículo no encontrado' }
+  return {
+    title: post.title,
+    description: post.excerpt,
+    alternates: { canonical: `/blog/${slug}` },
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      type: 'article',
+      publishedTime: post.date,
+      authors: [post.author],
+    },
+  }
+}
+
+/** Render a paragraph that may contain **bold** markdown spans. */
+function renderParagraph(text: string, key: number) {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g)
+  return (
+    <p key={key} className="mb-5 leading-relaxed text-[var(--text-light)]">
+      {parts.map((part, i) => {
+        if (part.startsWith('**') && part.endsWith('**')) {
+          return (
+            <strong key={i} className="text-[var(--text)]">
+              {part.slice(2, -2)}
+            </strong>
+          )
+        }
+        return <span key={i}>{part}</span>
+      })}
+    </p>
+  )
+}
+
+export default async function BlogPostPage({ params }: { params: Promise<Params> }) {
+  const { slug } = await params
+  const post = getPost(slug)
+  if (!post) notFound()
+
+  return (
+    <>
+      <SiteNav />
+      <main className="pt-24 pb-20">
+        <Container size="md">
+          <article className="mx-auto max-w-3xl">
+            <Link
+              href="/blog"
+              className="mb-6 inline-flex items-center gap-1 text-sm font-medium text-[var(--text-light)] hover:text-[var(--primary)]"
+            >
+              <ArrowLeft size={14} />
+              Todos los artículos
+            </Link>
+            <p className="mb-3 flex items-center gap-3 text-xs uppercase tracking-wider text-[var(--text-muted)]">
+              <span>{post.tag.split(':')[1] ?? post.tag}</span>
+              <span className="inline-flex items-center gap-1">
+                <Clock size={12} />
+                {post.readingTime}
+              </span>
+              <span>
+                {new Date(post.date).toLocaleDateString('es-PY', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </span>
+            </p>
+            <h1 className="mb-6 text-4xl font-bold leading-tight text-[var(--text)] sm:text-5xl">
+              {post.title}
+            </h1>
+            <p className="mb-10 text-xl leading-relaxed text-[var(--text-light)]">{post.excerpt}</p>
+
+            <div className="prose prose-lg max-w-none text-lg">
+              {post.body.map((p, i) => renderParagraph(p, i))}
+            </div>
+
+            <footer className="mt-12 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 text-center">
+              <p className="mb-4 text-sm text-[var(--text-muted)]">
+                Por <strong className="text-[var(--text)]">{post.author}</strong>
+              </p>
+              <a
+                href={waLink('Hola, leí un artículo en el blog y quiero hablar de mi negocio.')}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-[var(--primary)] to-[var(--accent)] px-6 py-3 font-bold text-[var(--primary-foreground)] shadow-lg transition-all hover:-translate-y-1"
+              >
+                <MessageCircle size={16} />
+                Pedir mi demo gratis
+              </a>
+            </footer>
+          </article>
+        </Container>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/app/blog/page.tsx
+++ b/web/app/blog/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, Clock } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { BLOG_POSTS } from '@/lib/landing/blog-posts'
+
+export const metadata: Metadata = {
+  title: 'Blog — guías y casos para negocios paraguayos',
+  description:
+    'Cómo mejorar la presencia digital de tu negocio: SEO local, conversión por WhatsApp, casos de éxito y errores comunes en sitios para PyMEs en Paraguay.',
+  alternates: { canonical: '/blog' },
+}
+
+export default function BlogIndexPage() {
+  const sorted = [...BLOG_POSTS].sort((a, b) => b.date.localeCompare(a.date))
+
+  return (
+    <>
+      <SiteNav />
+      <main className="pt-24 pb-20">
+        <Container>
+          <div className="mx-auto mb-16 max-w-2xl text-center">
+            <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">
+              Blog
+            </p>
+            <h1 className="mb-4 text-4xl font-bold text-[var(--text)] sm:text-5xl">
+              Guías para negocios paraguayos
+            </h1>
+            <p className="text-lg text-[var(--text-light)]">
+              Sin fluff. Lo que aprendimos publicando sitios reales para peluquerías, gimnasios,
+              meal prep y más.
+            </p>
+          </div>
+
+          <div className="mx-auto grid max-w-4xl gap-6">
+            {sorted.map((post) => (
+              <article
+                key={post.slug}
+                className="group rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 transition-all hover:-translate-y-1 hover:border-[var(--primary)]/30 hover:shadow-md md:p-8"
+              >
+                <p className="mb-2 flex items-center gap-3 text-xs uppercase tracking-wider text-[var(--text-muted)]">
+                  <span>{post.tag.split(':')[1] ?? post.tag}</span>
+                  <span className="inline-flex items-center gap-1">
+                    <Clock size={12} />
+                    {post.readingTime}
+                  </span>
+                  <span>{new Date(post.date).toLocaleDateString('es-PY', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
+                </p>
+                <h2 className="mb-3 text-2xl font-bold text-[var(--text)]">
+                  <Link href={`/blog/${post.slug}`} className="hover:text-[var(--primary)]">
+                    {post.title}
+                  </Link>
+                </h2>
+                <p className="mb-4 text-[var(--text-light)]">{post.excerpt}</p>
+                <Link
+                  href={`/blog/${post.slug}`}
+                  className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--primary)]"
+                >
+                  Leer artículo
+                  <ArrowRight size={14} className="transition-transform group-hover:translate-x-1" />
+                </Link>
+              </article>
+            ))}
+          </div>
+
+          <div className="mx-auto mt-12 max-w-2xl rounded-2xl border border-dashed border-[var(--border)] bg-[var(--surface-light)] p-6 text-center">
+            <p className="text-sm text-[var(--text-light)]">
+              Más artículos en preparación. ¿Querés que escribamos sobre algún tema?{' '}
+              <a
+                href={`https://wa.me/595981234567?text=${encodeURIComponent('Hola, me interesaría leer un post sobre...')}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-[var(--primary)]"
+              >
+                Sugerinos por WhatsApp
+              </a>
+              .
+            </p>
+          </div>
+        </Container>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/app/comparacion/page.tsx
+++ b/web/app/comparacion/page.tsx
@@ -1,0 +1,160 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, Check, MessageCircle, Minus, X } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { waLink } from '@/lib/landing/marketing-data'
+
+export const metadata: Metadata = {
+  title: 'ParaguAI vs Wix vs Agencia local — comparación honesta',
+  description:
+    'Cómo se compara ParaguAI con Wix/WordPress y con una agencia web local en Paraguay: precio, tiempo, soporte, soporte WhatsApp y dominio .com.py.',
+  alternates: { canonical: '/comparacion' },
+}
+
+type Cell = 'yes' | 'no' | 'partial' | string
+
+const ROWS: { label: string; paraguai: Cell; wix: Cell; agencia: Cell }[] = [
+  { label: 'Tiempo de entrega', paraguai: '48 horas', wix: 'Tu tiempo (DIY)', agencia: '2-4 meses' },
+  { label: 'Setup inicial', paraguai: 'Desde Gs 0', wix: 'Gratis', agencia: 'Gs 3-5M' },
+  { label: 'Mensualidad', paraguai: 'Desde Gs 100K', wix: 'Desde USD 16', agencia: 'Hosting aparte' },
+  { label: 'Demo antes de pagar', paraguai: 'yes', wix: 'no', agencia: 'partial' },
+  { label: 'Vos no tocás nada', paraguai: 'yes', wix: 'no', agencia: 'yes' },
+  { label: 'Dominio .com.py incluido', paraguai: 'yes', wix: 'no', agencia: 'partial' },
+  { label: 'Soporte por WhatsApp', paraguai: 'yes', wix: 'no', agencia: 'partial' },
+  { label: 'Cambios mensuales incluidos', paraguai: '2-10 / mes', wix: 'Tu tiempo', agencia: 'Cobran aparte' },
+  { label: 'SEO + Schema.org listo', paraguai: 'yes', wix: 'partial', agencia: 'partial' },
+  { label: 'Sin permanencia', paraguai: 'yes', wix: 'yes', agencia: 'no' },
+  { label: 'Te llevás el dominio si te vas', paraguai: 'yes', wix: 'yes', agencia: 'partial' },
+  { label: 'Pago en guaraníes (Mercado Pago)', paraguai: 'yes', wix: 'no', agencia: 'yes' },
+  { label: 'Garantía de 30 días', paraguai: 'yes', wix: 'partial', agencia: 'no' },
+]
+
+function Marker({ value }: { value: Cell }) {
+  if (value === 'yes')
+    return (
+      <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[var(--success)]/10 text-[var(--success)]">
+        <Check size={16} />
+      </span>
+    )
+  if (value === 'no')
+    return (
+      <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[var(--border)] text-[var(--text-muted)]">
+        <X size={16} />
+      </span>
+    )
+  if (value === 'partial')
+    return (
+      <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[var(--warning)]/10 text-[var(--warning)]">
+        <Minus size={16} />
+      </span>
+    )
+  return <span className="text-sm font-medium text-[var(--text)]">{value}</span>
+}
+
+export default function ComparacionPage() {
+  return (
+    <>
+      <SiteNav />
+      <main className="pt-24 pb-20">
+        <Container>
+          <div className="mx-auto mb-12 max-w-2xl text-center">
+            <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">
+              Comparación honesta
+            </p>
+            <h1 className="mb-4 text-4xl font-bold text-[var(--text)] sm:text-5xl">
+              ParaguAI vs Wix vs Agencia local
+            </h1>
+            <p className="text-lg text-[var(--text-light)]">
+              Las tres opciones funcionan. Pero cada una tiene un perfil diferente. Mirá la
+              comparación con datos reales del mercado paraguayo y elegí la que mejor te calza.
+            </p>
+          </div>
+
+          <div className="mx-auto max-w-5xl overflow-x-auto rounded-2xl border border-[var(--border)] shadow-sm">
+            <table className="w-full text-left">
+              <thead className="bg-[var(--surface-light)]">
+                <tr>
+                  <th className="p-4 text-sm font-semibold text-[var(--text)]">Característica</th>
+                  <th className="p-4 text-center text-sm font-bold text-[var(--primary)]">ParaguAI</th>
+                  <th className="p-4 text-center text-sm font-semibold text-[var(--text)]">Wix / WordPress</th>
+                  <th className="p-4 text-center text-sm font-semibold text-[var(--text)]">Agencia local</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--border)] bg-[var(--surface)]">
+                {ROWS.map((row) => (
+                  <tr key={row.label}>
+                    <td className="p-4 text-sm font-medium text-[var(--text)]">{row.label}</td>
+                    <td className="p-4 text-center">
+                      <Marker value={row.paraguai} />
+                    </td>
+                    <td className="p-4 text-center">
+                      <Marker value={row.wix} />
+                    </td>
+                    <td className="p-4 text-center">
+                      <Marker value={row.agencia} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="mx-auto mt-16 grid max-w-5xl gap-6 md:grid-cols-3">
+            <Card
+              title="Elegí Wix si..."
+              body="Tenés tiempo y ganas de aprender. Te gusta diseñar y experimentar. No necesitás dominio .com.py ni soporte en español rioplatense."
+            />
+            <Card
+              title="Elegí una agencia local si..."
+              body="Tenés un presupuesto de Gs 5M+ y un proyecto muy a medida. Necesitás integraciones complejas con sistemas existentes."
+            />
+            <Card
+              title="Elegí ParaguAI si..."
+              body="Querés un sitio profesional sin dolor, en 48 horas, pagando en guaraníes, con soporte por WhatsApp y la libertad de irte cuando quieras."
+              highlighted
+            />
+          </div>
+
+          <div className="mx-auto mt-16 max-w-2xl text-center">
+            <a
+              href={waLink('Hola, vi la comparación y quiero una demo de ParaguAI para mi negocio.')}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-[var(--primary)] to-[var(--accent)] px-8 py-4 font-bold text-[var(--primary-foreground)] shadow-lg transition-all hover:-translate-y-1"
+            >
+              <MessageCircle size={18} />
+              Pedir demo gratis
+            </a>
+            <div className="mt-6">
+              <Link
+                href="/precios"
+                className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--primary)]"
+              >
+                Ver precios y planes en detalle
+                <ArrowRight size={14} />
+              </Link>
+            </div>
+          </div>
+        </Container>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}
+
+function Card({ title, body, highlighted }: { title: string; body: string; highlighted?: boolean }) {
+  return (
+    <div
+      className={`rounded-2xl border p-6 ${
+        highlighted
+          ? 'border-[var(--primary)] bg-gradient-to-b from-[var(--primary)]/5 to-transparent'
+          : 'border-[var(--border)] bg-[var(--surface)]'
+      }`}
+    >
+      <h3 className="mb-3 text-lg font-bold text-[var(--text)]">{title}</h3>
+      <p className="text-sm text-[var(--text-light)]">{body}</p>
+    </div>
+  )
+}

--- a/web/app/demo/page.tsx
+++ b/web/app/demo/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from 'next'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+import { DemoQualifier } from '@/components/landing/demo-qualifier'
+
+export const metadata: Metadata = {
+  title: 'Pedir demo gratis — sitio web profesional en 48 horas',
+  description:
+    'Decinos tu rubro y tu situación actual. Te mandamos una demo personalizada por WhatsApp en 24-48 horas. Sin compromiso.',
+  alternates: { canonical: '/demo' },
+}
+
+export default function DemoPage() {
+  return (
+    <>
+      <SiteNav />
+      <main className="pt-24 pb-20">
+        <Container>
+          <div className="mx-auto mb-10 max-w-2xl text-center">
+            <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">
+              Demo gratis
+            </p>
+            <h1 className="mb-4 text-4xl font-bold text-[var(--text)] sm:text-5xl">
+              Tres preguntas y armamos tu demo
+            </h1>
+            <p className="text-lg text-[var(--text-light)]">
+              Cuanto más sepamos, mejor te llega la primera versión. Igual podés saltarte esto y
+              escribirnos por WhatsApp directamente — pero esto nos ahorra ida y vuelta.
+            </p>
+          </div>
+          <DemoQualifier />
+        </Container>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -18,20 +18,12 @@ export const metadata: Metadata = {
     siteName: 'ParaguAI Builder',
     title: 'ParaguAI Builder — Sitios Web con IA para Negocios',
     description: 'Motor de generación con IA que crea sitios web profesionales, rápidos y optimizados para cualquier tipo de negocio en Paraguay.',
-    images: [
-      {
-        url: '/og-image.png',
-        width: 1200,
-        height: 630,
-        alt: 'ParaguAI Builder - Sitios Web con IA',
-      },
-    ],
+    // Image is provided by app/opengraph-image.tsx (dynamic via next/og).
   },
   twitter: {
     card: 'summary_large_image',
     title: 'ParaguAI Builder',
     description: 'Sitios web profesionales con IA para negocios en Paraguay',
-    images: ['/og-image.png'],
   },
   robots: {
     index: true,

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -1,0 +1,100 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'nodejs'
+
+export const alt = 'ParaguAI Builder — Sitios web profesionales en 48 horas'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          background: 'linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)',
+          padding: 80,
+          color: 'white',
+          fontFamily: 'system-ui, sans-serif',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 16,
+            fontSize: 32,
+            fontWeight: 700,
+          }}
+        >
+          <div
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: 16,
+              background: 'linear-gradient(135deg, #6366f1 0%, #ec4899 100%)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 36,
+            }}
+          >
+            ✨
+          </div>
+          <div>
+            <span style={{ color: 'white' }}>Paragu</span>
+            <span style={{ color: '#a78bfa' }}>AI</span>
+          </div>
+        </div>
+
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+          <div
+            style={{
+              fontSize: 76,
+              fontWeight: 800,
+              lineHeight: 1.05,
+              letterSpacing: -2,
+              marginBottom: 24,
+            }}
+          >
+            Tu sitio web{' '}
+            <span
+              style={{
+                background: 'linear-gradient(90deg, #a78bfa 0%, #f472b6 100%)',
+                backgroundClip: 'text',
+                color: 'transparent',
+              }}
+            >
+              profesional
+            </span>{' '}
+            en 48 horas
+          </div>
+          <div style={{ fontSize: 30, color: '#cbd5e1', lineHeight: 1.4 }}>
+            Todo incluido: diseño, dominio .com.py, SEO y WhatsApp. Demo gratis antes de pagar.
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            fontSize: 24,
+            color: '#94a3b8',
+          }}
+        >
+          <div style={{ display: 'flex', gap: 32 }}>
+            <span>🇵🇾 Paraguay</span>
+            <span>· 16 plantillas listas</span>
+            <span>· 7.4K negocios mapeados</span>
+          </div>
+          <div>paragu-ai.com</div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  )
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -17,6 +17,10 @@ import { FadeIn } from '@/components/landing/fade-in'
 import { FAQItem } from '@/components/landing/faq-item'
 import { TestimonialCarousel } from '@/components/landing/testimonial-carousel'
 import { NewsletterForm } from '@/components/landing/newsletter-form'
+import { LogoStrip } from '@/components/landing/logo-strip'
+import { VideoBlock } from '@/components/landing/video-block'
+import { StickyMobileCTA } from '@/components/landing/sticky-mobile-cta'
+import { ActivityTicker } from '@/components/landing/activity-ticker'
 import {
   FloatingShape,
   ScrollProgress,
@@ -244,11 +248,11 @@ function Navigation() {
   }, [])
 
   const navLinks = [
-    { href: '#clientes', label: 'Clientes' },
-    { href: '#plantillas', label: 'Plantillas' },
-    { href: '#como-funciona', label: 'Cómo funciona' },
-    { href: '#precios', label: 'Precios' },
-    { href: '#faq', label: 'FAQ' },
+    { href: '/casos', label: 'Casos' },
+    { href: '/p', label: 'Plantillas' },
+    { href: '/precios', label: 'Precios' },
+    { href: '/comparacion', label: 'Comparación' },
+    { href: '/demo', label: 'Demo' },
   ]
 
   return (
@@ -402,11 +406,14 @@ export default function HomePage() {
           <Container>
             <div className="mx-auto max-w-5xl text-center">
               <FadeIn delay={0}>
-                <div className="mb-8 inline-flex items-center gap-3 rounded-full border border-[var(--border)] bg-[var(--surface)]/80 px-5 py-2.5 backdrop-blur-sm">
-                  <span className="inline-block h-2.5 w-2.5 animate-pulse rounded-full bg-[var(--success)]" />
-                  <span className="text-sm font-medium text-[var(--text-light)]">
-                    {heroCount1.toLocaleString()} negocios identificados en Paraguay
-                  </span>
+                <div className="mb-4 flex flex-col items-center gap-3">
+                  <div className="inline-flex items-center gap-3 rounded-full border border-[var(--border)] bg-[var(--surface)]/80 px-5 py-2.5 backdrop-blur-sm">
+                    <span className="inline-block h-2.5 w-2.5 animate-pulse rounded-full bg-[var(--success)]" />
+                    <span className="text-sm font-medium text-[var(--text-light)]">
+                      {heroCount1.toLocaleString()} negocios identificados en Paraguay
+                    </span>
+                  </div>
+                  <ActivityTicker />
                 </div>
               </FadeIn>
 
@@ -463,6 +470,17 @@ export default function HomePage() {
                       <p className="mt-1 text-sm text-[var(--text-muted)]">{stat.label}</p>
                     </div>
                   ))}
+                </div>
+              </FadeIn>
+
+              {/* Real-client logo strip + video walkthrough */}
+              <FadeIn delay={700}>
+                <LogoStrip />
+              </FadeIn>
+
+              <FadeIn delay={750}>
+                <div className="mt-16">
+                  <VideoBlock fallbackHref="#como-funciona" />
                 </div>
               </FadeIn>
 
@@ -939,16 +957,20 @@ export default function HomePage() {
               </p>
             </div>
             <div>
-              <h4 className="mb-4 font-bold text-[var(--text)]">Plataforma</h4>
+              <h4 className="mb-4 font-bold text-[var(--text)]">Producto</h4>
               <ul className="space-y-2 text-[var(--text-muted)]">
-                <li><a href="#plantillas" className="hover:text-[var(--primary)]">Plantillas</a></li>
-                <li><a href="#funcionalidades" className="hover:text-[var(--primary)]">Funcionalidades</a></li>
-                <li><a href="#precios" className="hover:text-[var(--primary)]">Precios</a></li>
+                <li><Link href="/p" className="hover:text-[var(--primary)]">Plantillas</Link></li>
+                <li><Link href="/precios" className="hover:text-[var(--primary)]">Precios</Link></li>
+                <li><Link href="/comparacion" className="hover:text-[var(--primary)]">Comparación</Link></li>
+                <li><Link href="/demo" className="hover:text-[var(--primary)]">Pedir demo</Link></li>
               </ul>
             </div>
             <div>
-              <h4 className="mb-4 font-bold text-[var(--text)]">Soporte</h4>
+              <h4 className="mb-4 font-bold text-[var(--text)]">Recursos</h4>
               <ul className="space-y-2 text-[var(--text-muted)]">
+                <li><Link href="/casos" className="hover:text-[var(--primary)]">Casos reales</Link></li>
+                <li><Link href="/blog" className="hover:text-[var(--primary)]">Blog</Link></li>
+                <li><Link href="/seguridad" className="hover:text-[var(--primary)]">Privacidad</Link></li>
                 <li><a href="#faq" className="hover:text-[var(--primary)]">FAQ</a></li>
                 <li><Link href="/admin" className="hover:text-[var(--primary)]">Panel Admin</Link></li>
               </ul>
@@ -962,6 +984,7 @@ export default function HomePage() {
 
       <FloatingWhatsApp />
       <BackToTop />
+      <StickyMobileCTA />
     </>
   )
 }

--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/admin', '/api', '/login'],
+      },
+    ],
+    sitemap: 'https://paragu-ai.com/sitemap.xml',
+    host: 'https://paragu-ai.com',
+  }
+}

--- a/web/app/seguridad/page.tsx
+++ b/web/app/seguridad/page.tsx
@@ -1,0 +1,117 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Lock, Shield, Server, FileText, Mail } from 'lucide-react'
+import { Container } from '@/components/ui/container'
+import { SiteNav } from '@/components/landing/site-nav'
+import { SiteFooter } from '@/components/landing/site-footer'
+
+export const metadata: Metadata = {
+  title: 'Privacidad y manejo de datos — ParaguAI',
+  description:
+    'Cómo guardamos los datos de tu negocio, dónde se aloja tu sitio, qué hacemos si te vas y cómo cumplimos con la Ley 6534 de Paraguay.',
+  alternates: { canonical: '/seguridad' },
+}
+
+const POINTS = [
+  {
+    icon: Server,
+    title: 'Dónde vive tu sitio',
+    body:
+      'Hosting en Cloudflare (CDN global) + Supabase (datos). Backups automáticos diarios. Si nuestro proveedor cae, tu sitio sigue sirviendo desde la caché.',
+  },
+  {
+    icon: Lock,
+    title: 'Quién accede a tu información',
+    body:
+      'Solo el equipo de ParaguAI involucrado en tu proyecto. No vendemos ni compartimos los datos de tu negocio con terceros para publicidad.',
+  },
+  {
+    icon: Shield,
+    title: 'Datos de tus visitantes',
+    body:
+      'Si activás analytics, registramos tráfico anónimo (visitas, fuentes, clicks). Si activás formularios, guardamos los envíos para que vos los veas. Nunca trackeamos a tus visitantes para revenderlos.',
+  },
+  {
+    icon: FileText,
+    title: 'Si decidís irte',
+    body:
+      'Te llevás tu dominio. Te exportamos tu contenido (textos y fotos) en formato estándar. Borramos tus datos de nuestros sistemas en 30 días.',
+  },
+] as const
+
+export default function SeguridadPage() {
+  return (
+    <>
+      <SiteNav />
+      <main className="pt-24 pb-20">
+        <Container>
+          <div className="mx-auto max-w-3xl">
+            <div className="mb-12 text-center">
+              <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">
+                Privacidad y datos
+              </p>
+              <h1 className="mb-4 text-4xl font-bold text-[var(--text)] sm:text-5xl">
+                Lo que hacemos con tu información
+              </h1>
+              <p className="text-lg text-[var(--text-light)]">
+                Sin letra chica. Lo que necesitás saber para confiar en dejarnos los datos de tu
+                negocio.
+              </p>
+            </div>
+
+            <div className="space-y-5">
+              {POINTS.map((p) => {
+                const Icon = p.icon
+                return (
+                  <div
+                    key={p.title}
+                    className="flex gap-5 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6"
+                  >
+                    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-[var(--primary)]/10 text-[var(--primary)]">
+                      <Icon size={22} />
+                    </div>
+                    <div>
+                      <h2 className="mb-2 text-lg font-bold text-[var(--text)]">{p.title}</h2>
+                      <p className="text-[var(--text-light)]">{p.body}</p>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+
+            <div className="mt-12 rounded-2xl border border-[var(--border)] bg-[var(--surface-light)] p-6">
+              <h2 className="mb-3 text-lg font-bold text-[var(--text)]">Marco legal</h2>
+              <p className="mb-4 text-[var(--text-light)]">
+                Operamos bajo la <strong>Ley N° 6534/2020 de Protección de Datos Personales</strong> de
+                Paraguay. Para usuarios europeos relacionados con clientes nuestros (ej. Nexa Paraguay
+                en sus mercados europeos), aplicamos los principios de minimización de datos del GDPR.
+              </p>
+              <p className="text-[var(--text-light)]">
+                Si querés ejercer tu derecho de acceso, rectificación o eliminación, escribinos por
+                WhatsApp o al correo del equipo.
+              </p>
+            </div>
+
+            <div className="mt-10 flex flex-wrap items-center justify-center gap-4 text-sm">
+              <Link
+                href="/"
+                className="inline-flex items-center gap-1 text-[var(--text-light)] hover:text-[var(--primary)]"
+              >
+                ← Volver al inicio
+              </Link>
+              <span className="text-[var(--text-muted)]">·</span>
+              <a
+                href="mailto:contacto@paragu-ai.com"
+                className="inline-flex items-center gap-1 text-[var(--text-light)] hover:text-[var(--primary)]"
+              >
+                <Mail size={14} />
+                contacto@paragu-ai.com
+              </a>
+            </div>
+          </div>
+        </Container>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -1,0 +1,44 @@
+import type { MetadataRoute } from 'next'
+import { LIVE_TEMPLATES } from '@/lib/landing/marketing-data'
+import { CASE_STUDIES } from '@/lib/landing/case-studies'
+import { BLOG_POSTS } from '@/lib/landing/blog-posts'
+
+const BASE = 'https://paragu-ai.com'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date()
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: `${BASE}/`, lastModified: now, changeFrequency: 'weekly', priority: 1 },
+    { url: `${BASE}/precios`, lastModified: now, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${BASE}/casos`, lastModified: now, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${BASE}/p`, lastModified: now, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${BASE}/comparacion`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${BASE}/demo`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${BASE}/seguridad`, lastModified: now, changeFrequency: 'yearly', priority: 0.4 },
+    { url: `${BASE}/blog`, lastModified: now, changeFrequency: 'weekly', priority: 0.7 },
+  ]
+
+  const verticalRoutes: MetadataRoute.Sitemap = LIVE_TEMPLATES.map((t) => ({
+    url: `${BASE}/p/${t.seoSlug ?? t.id.replace(/_/g, '-')}`,
+    lastModified: now,
+    changeFrequency: 'monthly',
+    priority: 0.8,
+  }))
+
+  const caseRoutes: MetadataRoute.Sitemap = CASE_STUDIES.map((c) => ({
+    url: `${BASE}/casos/${c.slug}`,
+    lastModified: now,
+    changeFrequency: 'monthly',
+    priority: 0.7,
+  }))
+
+  const blogRoutes: MetadataRoute.Sitemap = BLOG_POSTS.map((p) => ({
+    url: `${BASE}/blog/${p.slug}`,
+    lastModified: new Date(p.date),
+    changeFrequency: 'monthly',
+    priority: 0.6,
+  }))
+
+  return [...staticRoutes, ...verticalRoutes, ...caseRoutes, ...blogRoutes]
+}

--- a/web/components/landing/demo-qualifier.tsx
+++ b/web/components/landing/demo-qualifier.tsx
@@ -1,0 +1,219 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, ArrowRight, Check, MessageCircle } from 'lucide-react'
+import { Heading } from '@/components/ui/heading'
+import { LIVE_TEMPLATES, TEMPLATES, waLink } from '@/lib/landing/marketing-data'
+
+const SIZES = [
+  { id: 'solo', label: 'Solo yo' },
+  { id: 'small', label: '2-5 personas' },
+  { id: 'medium', label: '6-15 personas' },
+  { id: 'large', label: '15+ personas' },
+] as const
+
+const PRESENCE = [
+  { id: 'none', label: 'Solo Instagram / WhatsApp' },
+  { id: 'facebook', label: 'Tengo Facebook' },
+  { id: 'old-site', label: 'Tengo un sitio viejo' },
+  { id: 'new-site', label: 'Quiero rediseñar mi sitio' },
+] as const
+
+type Step = 0 | 1 | 2 | 3
+
+export function DemoQualifier() {
+  const [step, setStep] = useState<Step>(0)
+  const [rubro, setRubro] = useState<string>('')
+  const [size, setSize] = useState<string>('')
+  const [presence, setPresence] = useState<string>('')
+
+  const liveSlugs = useMemo(() => new Set(LIVE_TEMPLATES.map((t) => t.id)), [])
+  const orderedTemplates = useMemo(
+    () => [...TEMPLATES].sort((a, b) => Number(liveSlugs.has(b.id)) - Number(liveSlugs.has(a.id))),
+    [liveSlugs],
+  )
+
+  function next() {
+    setStep((s) => Math.min(3, s + 1) as Step)
+  }
+  function back() {
+    setStep((s) => Math.max(0, s - 1) as Step)
+  }
+
+  const summary = useMemo(() => {
+    const t = TEMPLATES.find((x) => x.id === rubro)
+    const sz = SIZES.find((s) => s.id === size)
+    const pr = PRESENCE.find((p) => p.id === presence)
+    return {
+      rubroLabel: t?.name ?? '',
+      sizeLabel: sz?.label ?? '',
+      presenceLabel: pr?.label ?? '',
+    }
+  }, [rubro, size, presence])
+
+  const waMessage = `Hola, quiero una demo gratis de ParaguAI.
+- Rubro: ${summary.rubroLabel}
+- Equipo: ${summary.sizeLabel}
+- Presencia actual: ${summary.presenceLabel}`
+
+  const canNext = (step === 0 && rubro) || (step === 1 && size) || (step === 2 && presence)
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      {/* Progress */}
+      <div className="mb-8 flex items-center justify-center gap-2">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className={`h-1.5 flex-1 rounded-full transition-colors ${
+              step >= i ? 'bg-[var(--primary)]' : 'bg-[var(--border)]'
+            }`}
+          />
+        ))}
+      </div>
+
+      <div className="rounded-3xl border border-[var(--border)] bg-[var(--surface)] p-6 md:p-10">
+        {step === 0 && (
+          <div>
+            <Heading level={2} className="mb-2 text-2xl">¿Cuál es tu rubro?</Heading>
+            <p className="mb-6 text-sm text-[var(--text-muted)]">
+              Esto nos ayuda a armar la demo más cercana a lo que necesitás.
+            </p>
+            <div className="grid max-h-96 gap-2 overflow-y-auto pr-2 sm:grid-cols-2">
+              {orderedTemplates.map((t) => {
+                const isLive = liveSlugs.has(t.id)
+                const selected = rubro === t.id
+                return (
+                  <button
+                    key={t.id}
+                    type="button"
+                    onClick={() => setRubro(t.id)}
+                    className={`flex items-center justify-between rounded-xl border-2 px-4 py-3 text-left text-sm font-medium transition-all ${
+                      selected
+                        ? 'border-[var(--primary)] bg-[var(--primary)]/5 text-[var(--text)]'
+                        : 'border-[var(--border)] text-[var(--text-light)] hover:border-[var(--primary)]/50'
+                    }`}
+                  >
+                    <span>{t.name}</span>
+                    {isLive ? (
+                      <span className="text-xs text-[var(--success)]">Demo lista</span>
+                    ) : (
+                      <span className="text-xs text-[var(--text-muted)]">Próx.</span>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {step === 1 && (
+          <div>
+            <Heading level={2} className="mb-2 text-2xl">¿Cuántos son en tu equipo?</Heading>
+            <p className="mb-6 text-sm text-[var(--text-muted)]">
+              Para sugerirte el plan más realista — no para ofrecerte el más caro.
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {SIZES.map((s) => (
+                <button
+                  key={s.id}
+                  type="button"
+                  onClick={() => setSize(s.id)}
+                  className={`rounded-xl border-2 px-4 py-4 text-left font-medium transition-all ${
+                    size === s.id
+                      ? 'border-[var(--primary)] bg-[var(--primary)]/5 text-[var(--text)]'
+                      : 'border-[var(--border)] text-[var(--text-light)] hover:border-[var(--primary)]/50'
+                  }`}
+                >
+                  {s.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {step === 2 && (
+          <div>
+            <Heading level={2} className="mb-2 text-2xl">¿Qué presencia digital tenés hoy?</Heading>
+            <p className="mb-6 text-sm text-[var(--text-muted)]">
+              Si ya tenés Wix o WordPress, te ayudamos a migrar sin perder dominio ni SEO.
+            </p>
+            <div className="grid gap-3">
+              {PRESENCE.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => setPresence(p.id)}
+                  className={`rounded-xl border-2 px-4 py-4 text-left font-medium transition-all ${
+                    presence === p.id
+                      ? 'border-[var(--primary)] bg-[var(--primary)]/5 text-[var(--text)]'
+                      : 'border-[var(--border)] text-[var(--text-light)] hover:border-[var(--primary)]/50'
+                  }`}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="text-center">
+            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-[var(--success)]/10 text-[var(--success)]">
+              <Check size={28} />
+            </div>
+            <Heading level={2} className="mb-3 text-2xl">Listo. Mandanos el WhatsApp.</Heading>
+            <p className="mb-6 text-[var(--text-light)]">
+              Ya armamos el mensaje con la info que nos diste. Hacé clic abajo, revisalo si querés
+              y mandalo. Te respondemos en horario hábil.
+            </p>
+            <pre className="mb-6 whitespace-pre-wrap rounded-xl bg-[var(--surface-light)] p-4 text-left text-sm text-[var(--text)]">
+              {waMessage}
+            </pre>
+            <a
+              href={waLink(waMessage)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-[var(--primary)] to-[var(--accent)] px-8 py-4 font-bold text-[var(--primary-foreground)] shadow-lg transition-all hover:-translate-y-1"
+            >
+              <MessageCircle size={20} />
+              Enviar por WhatsApp
+            </a>
+            <div className="mt-6">
+              <Link
+                href={`/p/${rubro.replace(/_/g, '-')}`}
+                className="text-sm font-semibold text-[var(--primary)]"
+              >
+                Mientras tanto, mirá la plantilla de tu rubro →
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {step !== 3 && (
+          <div className="mt-8 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={back}
+              disabled={step === 0}
+              className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--text-muted)] disabled:opacity-40"
+            >
+              <ArrowLeft size={14} />
+              Atrás
+            </button>
+            <button
+              type="button"
+              onClick={next}
+              disabled={!canNext}
+              className="inline-flex items-center gap-2 rounded-xl bg-[var(--primary)] px-5 py-2.5 text-sm font-bold text-[var(--primary-foreground)] transition-all hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Siguiente
+              <ArrowRight size={14} />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/components/landing/roi-calculator.tsx
+++ b/web/components/landing/roi-calculator.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { Calculator, TrendingUp } from 'lucide-react'
+import { Heading } from '@/components/ui/heading'
 import { PLANS } from '@/lib/landing/marketing-data'
 
 const PRESENCIA = PLANS.find((p) => p.id === 'presencia')!
@@ -45,7 +46,7 @@ export function ROICalculator() {
           <Calculator size={22} />
         </div>
         <div>
-          <h3 className="text-xl font-bold text-[var(--text)]">¿Cuándo se paga sola?</h3>
+          <Heading level={3} className="text-xl">¿Cuándo se paga sola?</Heading>
           <p className="text-sm text-[var(--text-muted)]">
             Estimá tu retorno con tus números reales.
           </p>

--- a/web/lib/landing/blog-posts.ts
+++ b/web/lib/landing/blog-posts.ts
@@ -1,0 +1,49 @@
+/**
+ * Blog post registry. Add new posts as objects in this array.
+ * Body is plain Markdown-ish strings — rendered as paragraphs.
+ *
+ * NOT a CMS — intentionally keeps content close to code so the team can
+ * publish via PR. When the volume justifies it, switch to MDX or a headless CMS.
+ */
+
+export type BlogPost = {
+  slug: string
+  title: string
+  excerpt: string
+  /** ISO date string (YYYY-MM-DD). */
+  date: string
+  /** Author display name. */
+  author: string
+  /** Reading-time estimate, e.g. "4 min". */
+  readingTime: string
+  /** Tag like "vertical:peluqueria" or "topic:seo". */
+  tag: string
+  /** Body as an array of paragraphs (kept simple — no MDX runtime). */
+  body: readonly string[]
+}
+
+export const BLOG_POSTS: readonly BlogPost[] = [
+  {
+    slug: 'por-que-tu-peluqueria-necesita-web',
+    title: 'Por qué tu peluquería necesita un sitio web (y no solo Instagram)',
+    excerpt:
+      'Instagram es genial para mostrar trabajos. Pero si tus clientes no pueden encontrarte en Google, ver tus precios o reservar sin escribirte, estás dejando dinero en la mesa.',
+    date: '2026-04-20',
+    author: 'Equipo ParaguAI',
+    readingTime: '4 min',
+    tag: 'vertical:peluqueria',
+    body: [
+      'En Paraguay hay 2.393 peluquerías mapeadas. El 81% no tiene sitio web propio. Eso significa que cuando alguien busca "peluquería cerca" en Google, casi nadie aparece — y los pocos que sí, se llevan toda la clientela nueva.',
+      'Instagram es excelente para mostrar trabajos terminados. Pero tiene tres techos que no podés romper desde la app:',
+      '1) **No salís en Google.** Las búsquedas locales ("peluquería en Asunción", "corte de pelo cerca") las gana quien tiene un sitio bien optimizado. Instagram no compite ahí.',
+      '2) **Los precios viven en DMs.** Cada cliente nuevo te escribe "¿cuánto sale el corte?" y vos contestás lo mismo veinte veces al día. Un sitio con precios visibles 24/7 te ahorra horas y filtra a quien no es tu cliente.',
+      '3) **No podés hacer reservas.** Las clientas tienen que coordinar por mensaje. Pierden interés a mitad de conversación. Un botón de "reservar turno por WhatsApp" con tu agenda lista cierra muchas más reservas que ir y volver.',
+      'No tenés que elegir entre Instagram y un sitio. Lo ideal es que se potencien: Instagram trae el descubrimiento visual, el sitio web cierra la venta y aparece en Google.',
+      'En ParaguAI armamos sitios para peluquerías paraguayas en 48 horas, con WhatsApp Business, Google Maps y galería sincronizada. Si querés ver cómo se vería, mandanos un WhatsApp y armamos tu demo gratis.',
+    ],
+  },
+] as const
+
+export function getPost(slug: string): BlogPost | undefined {
+  return BLOG_POSTS.find((p) => p.slug === slug)
+}


### PR DESCRIPTION
Comprehensive onboarding questionnaire for Dayah, pre-filled from her existing tenant config and organized in 5 parts.

## Structure
- **A** — confirm what we have (identity, contact, 4 services, 6 premades, 2 testimonials, design defaults) with ✓/✗ columns
- **B** — missing pieces (portfolio, before/after, process, FAQ, about, images, blog)
- **C** — strategy (ICP, channels, competitors, positioning, monetization, 6-mo goals, blockers)
- **D** — feedback to ParaguAI (what's working, features missing, pricing, case-study opt-in, referrals)
- **E** — legal (privacy, T&C, licensing, payments)

## Placeholders flagged for her attention
- WhatsApp `+595 981 000 000` is suspiciously round
- 6 premades all have empty `imageUrl`
- Product names (Susurros del Bosque, Corazón de Cenizas, …) may be seeds
- Only 2 testimonials (María G., Carlos R.), real?
- No custom branding — inherits `portfolio-professional` vertical defaults
- Missing: logo, hero image, about page, FAQ, blog, portfolio detail

## Delivery
Lives at `sites/dayah-litworks/docs/` so it travels with her tenant config and future re-onboarding has history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)