### PR TITLE
feat(payments): capability-matrix router + gateway-failover (PR 3/5)

### DIFF
--- a/web/app/api/storefront/[site]/checkout/route.ts
+++ b/web/app/api/storefront/[site]/checkout/route.ts
@@ -4,8 +4,10 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { withRequestLog } from '@/lib/api/with-request-log'
 import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { createOrder, getOrder, CheckoutError } from '@/lib/commerce/orders'
-import { getAdapter } from '@/lib/payments/registry'
+import { rankProvidersForOrder, NoEligibleProviderError } from '@/lib/payments/router'
+import { createCheckoutWithFailover, NoAvailableProviderError } from '@/lib/payments/failover'
 import { CheckoutInputSchema } from '@/lib/schemas/commerce/order'
+import type { PaymentProvider } from '@/lib/schemas/commerce/transaction'
 
 export const runtime = 'nodejs'
 
@@ -61,14 +63,35 @@ export const POST = withRequestLog<{ site: string }>(async (req, { log }, { site
   const order = await getOrder(business.id, orderId)
 
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000'
-  // PR 3 (feat/payment-router) replaces this hardcoded default with the
-  // capability-matrix router that picks per-order based on currency + country.
-  const provider = 'pagopar' as const
-  const adapter = getAdapter(provider)
-  const session = await adapter.createCheckoutSession(order, {
-    returnUrl: `${appUrl}/s/es/${site}/orden/${order.id}`,
-    webhookUrl: `${appUrl}/api/webhooks/${provider}`,
-  })
+
+  // Pick provider via capability matrix; failover on gateway 5xx/timeout.
+  // business.commerce.provider (from registry) is the preferred hint;
+  // PR 4 will read merchant-installed providers from
+  // business_payment_credentials and pass that as `available`.
+  let providers: PaymentProvider[]
+  try {
+    providers = rankProvidersForOrder(order, business.preferredProvider as PaymentProvider | undefined)
+  } catch (err) {
+    if (err instanceof NoEligibleProviderError) {
+      return NextResponse.json({ error: 'no_eligible_payment_provider' }, { status: 422 })
+    }
+    throw err
+  }
+
+  let routingResult
+  try {
+    routingResult = await createCheckoutWithFailover(order, providers, {
+      returnUrl: `${appUrl}/s/es/${site}/orden/${order.id}`,
+      webhookUrlFor: (p) => `${appUrl}/api/webhooks/${p}`,
+    })
+  } catch (err) {
+    if (err instanceof NoAvailableProviderError) {
+      return NextResponse.json({ error: 'all_providers_unavailable' }, { status: 502 })
+    }
+    throw err
+  }
+
+  const { session, provider, attempted } = routingResult
 
   await supabase.from('storefront_transactions').insert({
     business_id: business.id,
@@ -78,7 +101,7 @@ export const POST = withRequestLog<{ site: string }>(async (req, { log }, { site
     status: 'created',
     amount_cents: order.totalCents,
     currency: order.currency,
-    raw_payload: {},
+    raw_payload: { failover_attempts: attempted },
   })
 
   const responseBody = {

--- a/web/lib/commerce/resolve-business.ts
+++ b/web/lib/commerce/resolve-business.ts
@@ -7,6 +7,8 @@ export interface ResolvedBusiness {
   name: string
   type: string
   currency: string
+  /** Preferred payment provider hint, surfaced from registry/data_json. */
+  preferredProvider?: string
 }
 
 /**
@@ -34,7 +36,8 @@ export async function resolveBusinessBySlug(slug: string): Promise<ResolvedBusin
   }
   if (!data) return null
 
-  const currency = (data.data_json as { commerce?: { currency?: string } } | null)?.commerce?.currency ?? 'PYG'
+  const commerceCfg = (data.data_json as { commerce?: { currency?: string; provider?: string } } | null)?.commerce
+  const currency = commerceCfg?.currency ?? 'PYG'
 
   return {
     id: data.id,
@@ -42,5 +45,6 @@ export async function resolveBusinessBySlug(slug: string): Promise<ResolvedBusin
     name: data.name,
     type: data.type,
     currency,
+    preferredProvider: commerceCfg?.provider,
   }
 }

--- a/web/lib/payments/capabilities.ts
+++ b/web/lib/payments/capabilities.ts
@@ -1,0 +1,40 @@
+import type { PaymentCapability } from './types'
+
+/**
+ * Per-provider capability matrix. Source of truth for the router.
+ *
+ * Update this file when:
+ *   - Adding a new provider adapter (also add to registry.ts)
+ *   - A provider expands into a new country
+ *   - A provider's fee tier changes meaningfully
+ *
+ * basePriority lowers = more preferred. Pagopar wins for PY because it
+ * covers cash kiosks; dLocal wins for cross-border because it consolidates
+ * 20+ countries; Bancard wins on fees only when explicitly chosen.
+ */
+export const CAPABILITIES: PaymentCapability[] = [
+  {
+    provider: 'pagopar',
+    countries: ['PY'],
+    currencies: ['PYG'],
+    methods: ['credit_card', 'debit_card', 'wallet', 'cash_kiosk', 'bank_transfer', 'qr', 'pix'],
+    feeTier: 'medium',
+    basePriority: 1,
+  },
+  {
+    provider: 'bancard',
+    countries: ['PY'],
+    currencies: ['PYG'],
+    methods: ['credit_card', 'debit_card'],
+    feeTier: 'low',
+    basePriority: 5, // direct VPOS — only when explicitly chosen
+  },
+  {
+    provider: 'dlocal',
+    countries: ['AR', 'BR', 'CL', 'CO', 'MX', 'PE', 'UY', 'EC', 'BO'],
+    currencies: ['USD', 'ARS', 'BRL', 'CLP', 'COP', 'MXN', 'PEN', 'UYU'],
+    methods: ['credit_card', 'debit_card', 'bank_transfer', 'pix', 'cash_kiosk', 'wallet'],
+    feeTier: 'medium',
+    basePriority: 2,
+  },
+]

--- a/web/lib/payments/failover.ts
+++ b/web/lib/payments/failover.ts
@@ -1,0 +1,80 @@
+import { logger } from '@/lib/logger'
+import { getAdapter } from './registry'
+import type { Order } from '@/lib/schemas/commerce/order'
+import type { PaymentProvider } from '@/lib/schemas/commerce/transaction'
+import type { CheckoutSession } from './types'
+
+export class NoAvailableProviderError extends Error {
+  constructor(public attempted: PaymentProvider[]) {
+    super(`all_providers_failed:${attempted.join(',')}`)
+    this.name = 'NoAvailableProviderError'
+  }
+}
+
+/**
+ * Heuristic: a "gateway error" is a 5xx, fetch timeout, network failure,
+ * or "not_implemented" from a stub adapter — anything that says "this
+ * provider is sick, try another one." A 4xx (validation, unauthorized) is
+ * NOT a gateway error and bubbles up as a real failure.
+ */
+function isGatewayError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false
+  const m = err.message
+  if (m.includes('not_implemented')) return true
+  if (m.includes('fetch failed') || m.includes('ETIMEDOUT') || m.includes('ECONNRESET')) return true
+  // Provider-specific 5xx markers (mp_api_error:5xx:..., pagopar_api_error:5xx:..., etc.)
+  if (/_api_error:5\d\d:/.test(m)) return true
+  return false
+}
+
+export interface FailoverAttempt {
+  provider: PaymentProvider
+  error: string
+}
+
+export interface FailoverResult {
+  session: CheckoutSession
+  provider: PaymentProvider
+  attempted: FailoverAttempt[]
+}
+
+/**
+ * Walk providers best-first. Return on first success. Skip on gateway
+ * errors. Bubble on real validation errors.
+ */
+export async function createCheckoutWithFailover(
+  order: Order,
+  providers: PaymentProvider[],
+  opts: { returnUrl: string; webhookUrlFor: (provider: PaymentProvider) => string },
+): Promise<FailoverResult> {
+  const attempted: FailoverAttempt[] = []
+
+  for (const provider of providers) {
+    try {
+      const adapter = getAdapter(provider)
+      const session = await adapter.createCheckoutSession(order, {
+        returnUrl: opts.returnUrl,
+        webhookUrl: opts.webhookUrlFor(provider),
+      })
+      if (attempted.length > 0) {
+        logger.warn('commerce.payments.failover_recovered', {
+          orderId: order.id,
+          chosen: provider,
+          attemptedCount: attempted.length,
+        })
+      }
+      return { session, provider, attempted }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      attempted.push({ provider, error: message })
+      if (isGatewayError(err)) {
+        logger.warn('commerce.payments.failover_skip', { orderId: order.id, provider, error: message })
+        continue
+      }
+      // Real failure (validation, unauthorized, business rule) — stop.
+      throw err
+    }
+  }
+
+  throw new NoAvailableProviderError(providers)
+}

--- a/web/lib/payments/router.ts
+++ b/web/lib/payments/router.ts
@@ -1,0 +1,75 @@
+import type { Order } from '@/lib/schemas/commerce/order'
+import type { PaymentProvider } from '@/lib/schemas/commerce/transaction'
+import type { PaymentCapability } from './types'
+import { CAPABILITIES } from './capabilities'
+
+const FEE_TIER_RANK: Record<PaymentCapability['feeTier'], number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+}
+
+export interface RouteContext {
+  /** Country shipping to / shopper's billing country. ISO 3166-1 alpha-2. */
+  country: string
+  /** ISO 4217 currency. */
+  currency: string
+  /** Optional preferred provider (from business.commerce.provider). */
+  preferred?: PaymentProvider
+  /** Optional restriction — only consider these providers (merchant has creds). */
+  available?: PaymentProvider[]
+}
+
+export class NoEligibleProviderError extends Error {
+  constructor(public ctx: RouteContext) {
+    super(`no_provider_for_${ctx.country}_${ctx.currency}`)
+    this.name = 'NoEligibleProviderError'
+  }
+}
+
+/**
+ * Returns providers ranked best-first for the given context.
+ * Throws NoEligibleProviderError if none cover both country and currency.
+ *
+ * Ranking rule:
+ *   1. If `preferred` is in the eligible set → put it first.
+ *   2. Then sort remaining by (basePriority asc, feeTier asc).
+ *   3. Already-tried providers are NOT excluded here — that's failover's job.
+ */
+export function rankProviders(ctx: RouteContext): PaymentProvider[] {
+  const upperCountry = ctx.country.toUpperCase()
+  const upperCurrency = ctx.currency.toUpperCase()
+
+  const eligible = CAPABILITIES.filter((cap) => {
+    if (ctx.available && !ctx.available.includes(cap.provider)) return false
+    const countryOk = cap.countries.length === 0 || cap.countries.includes(upperCountry)
+    const currencyOk = cap.currencies.length === 0 || cap.currencies.includes(upperCurrency)
+    return countryOk && currencyOk
+  })
+
+  if (eligible.length === 0) throw new NoEligibleProviderError(ctx)
+
+  const sorted = [...eligible].sort((a, b) => {
+    if (a.basePriority !== b.basePriority) return a.basePriority - b.basePriority
+    return FEE_TIER_RANK[a.feeTier] - FEE_TIER_RANK[b.feeTier]
+  })
+
+  const ordered = sorted.map((cap) => cap.provider)
+  if (ctx.preferred && ordered.includes(ctx.preferred)) {
+    return [ctx.preferred, ...ordered.filter((p) => p !== ctx.preferred)]
+  }
+  return ordered
+}
+
+/** Convenience wrapper that derives ctx from an Order + business hint. */
+export function rankProvidersForOrder(
+  order: Order,
+  preferred?: PaymentProvider,
+  available?: PaymentProvider[],
+): PaymentProvider[] {
+  const country =
+    order.shippingAddress?.country?.toUpperCase()
+    ?? (order.metadata as { country?: string } | undefined)?.country
+    ?? 'PY'
+  return rankProviders({ country, currency: order.currency, preferred, available })
+}

--- a/web/lib/payments/types.ts
+++ b/web/lib/payments/types.ts
@@ -3,8 +3,30 @@ import type { TransactionStatus, PaymentProvider } from '@/lib/schemas/commerce/
 
 export interface CheckoutSession {
   redirectUrl: string
-  providerRef: string // preference_id for MP
+  providerRef: string // hash_pedido for Pagopar, preference_id for others
   sandbox: boolean
+}
+
+// Standardized payment-method tags surfaced to shopper UI + analytics.
+export type PaymentMethod =
+  | 'credit_card'
+  | 'debit_card'
+  | 'bank_transfer'
+  | 'wallet'
+  | 'cash_kiosk'
+  | 'pix'
+  | 'qr'
+  | 'crypto'
+
+export interface PaymentCapability {
+  provider: PaymentProvider
+  countries: string[]    // ISO 3166-1 alpha-2 — empty array means "everywhere"
+  currencies: string[]   // ISO 4217 — empty array means "everywhere"
+  methods: PaymentMethod[]
+  feeTier: 'low' | 'medium' | 'high'
+  // Lower = preferred when multiple providers cover the same country.
+  // Tie-breaker is feeTier (low → medium → high).
+  basePriority: number
 }
 
 export interface WebhookVerification {

--- a/web/tests/unit/commerce/failover.test.ts
+++ b/web/tests/unit/commerce/failover.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the registry so we can inject failing/succeeding adapters.
+const mockAdapters = new Map<string, { createCheckoutSession: ReturnType<typeof vi.fn> }>()
+
+vi.mock('@/lib/payments/registry', () => ({
+  getAdapter: (provider: string) => {
+    const adapter = mockAdapters.get(provider)
+    if (!adapter) throw new Error(`mock_not_set:${provider}`)
+    return adapter
+  },
+}))
+
+import { createCheckoutWithFailover, NoAvailableProviderError } from '@/lib/payments/failover'
+import type { Order } from '@/lib/schemas/commerce/order'
+
+const fakeOrder = { id: 'o-1', orderNumber: 'PRG-2026-0001', currency: 'PYG' } as unknown as Order
+
+beforeEach(() => {
+  mockAdapters.clear()
+})
+
+describe('createCheckoutWithFailover', () => {
+  it('returns the first successful provider', async () => {
+    const session = { redirectUrl: 'https://x', providerRef: 'r1', sandbox: true }
+    mockAdapters.set('pagopar', { createCheckoutSession: vi.fn().mockResolvedValue(session) })
+
+    const result = await createCheckoutWithFailover(fakeOrder, ['pagopar'], {
+      returnUrl: 'r',
+      webhookUrlFor: () => 'w',
+    })
+
+    expect(result.provider).toBe('pagopar')
+    expect(result.session).toBe(session)
+    expect(result.attempted).toEqual([])
+  })
+
+  it('skips a 5xx-throwing provider and falls back to the next', async () => {
+    const session = { redirectUrl: 'https://x', providerRef: 'r2', sandbox: true }
+    mockAdapters.set('pagopar', {
+      createCheckoutSession: vi.fn().mockRejectedValue(new Error('pagopar_api_error:503:upstream timeout')),
+    })
+    mockAdapters.set('dlocal', { createCheckoutSession: vi.fn().mockResolvedValue(session) })
+
+    const result = await createCheckoutWithFailover(fakeOrder, ['pagopar', 'dlocal'], {
+      returnUrl: 'r',
+      webhookUrlFor: () => 'w',
+    })
+
+    expect(result.provider).toBe('dlocal')
+    expect(result.attempted).toHaveLength(1)
+    expect(result.attempted[0]?.provider).toBe('pagopar')
+  })
+
+  it('skips a "not_implemented" stub and falls back', async () => {
+    const session = { redirectUrl: 'https://x', providerRef: 'r3', sandbox: true }
+    mockAdapters.set('bancard', {
+      createCheckoutSession: vi.fn().mockRejectedValue(new Error('bancard_adapter_not_implemented')),
+    })
+    mockAdapters.set('pagopar', { createCheckoutSession: vi.fn().mockResolvedValue(session) })
+
+    const result = await createCheckoutWithFailover(fakeOrder, ['bancard', 'pagopar'], {
+      returnUrl: 'r',
+      webhookUrlFor: () => 'w',
+    })
+    expect(result.provider).toBe('pagopar')
+  })
+
+  it('does NOT failover on 4xx / validation errors — bubbles up', async () => {
+    mockAdapters.set('pagopar', {
+      createCheckoutSession: vi.fn().mockRejectedValue(new Error('order_has_no_items')),
+    })
+    mockAdapters.set('dlocal', { createCheckoutSession: vi.fn() })
+
+    await expect(
+      createCheckoutWithFailover(fakeOrder, ['pagopar', 'dlocal'], {
+        returnUrl: 'r',
+        webhookUrlFor: () => 'w',
+      }),
+    ).rejects.toThrow('order_has_no_items')
+
+    // dlocal must NOT have been called
+    expect(mockAdapters.get('dlocal')!.createCheckoutSession).not.toHaveBeenCalled()
+  })
+
+  it('throws NoAvailableProviderError when all providers fail with 5xx', async () => {
+    mockAdapters.set('pagopar', {
+      createCheckoutSession: vi.fn().mockRejectedValue(new Error('pagopar_api_error:500:boom')),
+    })
+    mockAdapters.set('dlocal', {
+      createCheckoutSession: vi.fn().mockRejectedValue(new Error('dlocal_api_error:502:boom')),
+    })
+
+    await expect(
+      createCheckoutWithFailover(fakeOrder, ['pagopar', 'dlocal'], {
+        returnUrl: 'r',
+        webhookUrlFor: () => 'w',
+      }),
+    ).rejects.toBeInstanceOf(NoAvailableProviderError)
+  })
+
+  it('passes a per-provider webhook URL', async () => {
+    const spy = vi.fn().mockResolvedValue({ redirectUrl: 'x', providerRef: 'r', sandbox: false })
+    mockAdapters.set('pagopar', { createCheckoutSession: spy })
+
+    await createCheckoutWithFailover(fakeOrder, ['pagopar'], {
+      returnUrl: 'return',
+      webhookUrlFor: (p) => `https://example.com/api/webhooks/${p}`,
+    })
+
+    expect(spy).toHaveBeenCalledWith(fakeOrder, {
+      returnUrl: 'return',
+      webhookUrl: 'https://example.com/api/webhooks/pagopar',
+    })
+  })
+})

--- a/web/tests/unit/commerce/router.test.ts
+++ b/web/tests/unit/commerce/router.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { rankProviders, NoEligibleProviderError } from '@/lib/payments/router'
+
+describe('rankProviders', () => {
+  it('PY/PYG → pagopar wins (basePriority 1)', () => {
+    const ranked = rankProviders({ country: 'PY', currency: 'PYG' })
+    expect(ranked[0]).toBe('pagopar')
+  })
+
+  it('respects preferred provider when eligible', () => {
+    const ranked = rankProviders({ country: 'PY', currency: 'PYG', preferred: 'bancard' })
+    expect(ranked[0]).toBe('bancard')
+    expect(ranked).toContain('pagopar')
+  })
+
+  it('ignores preferred provider when not eligible (different country)', () => {
+    const ranked = rankProviders({ country: 'BR', currency: 'BRL', preferred: 'pagopar' })
+    expect(ranked[0]).toBe('dlocal')
+    expect(ranked).not.toContain('pagopar')
+  })
+
+  it('BR/BRL → dlocal wins (only eligible)', () => {
+    const ranked = rankProviders({ country: 'BR', currency: 'BRL' })
+    expect(ranked).toEqual(['dlocal'])
+  })
+
+  it('throws NoEligibleProviderError for unsupported country', () => {
+    expect(() => rankProviders({ country: 'JP', currency: 'JPY' })).toThrow(NoEligibleProviderError)
+  })
+
+  it('throws when currency mismatches even if country supported', () => {
+    // PY supports PYG only; USD on PY → no eligible provider
+    expect(() => rankProviders({ country: 'PY', currency: 'USD' })).toThrow(NoEligibleProviderError)
+  })
+
+  it('respects available filter (merchant has limited credentials)', () => {
+    const ranked = rankProviders({ country: 'PY', currency: 'PYG', available: ['bancard'] })
+    expect(ranked).toEqual(['bancard'])
+  })
+
+  it('returns empty-eligible-set throws even with available filter', () => {
+    expect(() =>
+      rankProviders({ country: 'PY', currency: 'PYG', available: ['dlocal'] }),
+    ).toThrow(NoEligibleProviderError)
+  })
+
+  it('case-insensitive on country and currency', () => {
+    const ranked = rankProviders({ country: 'py', currency: 'pyg' })
+    expect(ranked[0]).toBe('pagopar')
+  })
+})


### PR DESCRIPTION
## Summary

Replaces hardcoded provider in checkout with a pluggable router.

- `capabilities.ts` — per-provider matrix (countries, currencies, methods, fee tier, basePriority)
- `router.ts` — `rankProviders` + `rankProvidersForOrder` with `available` filter for PR 4 merchant credentials
- `failover.ts` — `createCheckoutWithFailover` skips on 5xx/timeout/not_implemented, bubbles on 4xx
- Checkout route: 422 on no-eligible-provider, 502 on all-providers-failed; persists failover attempts to `storefront_transactions.raw_payload`
- 15 new tests (9 router + 6 failover)

## Stacked on PR #74 → PR #73

Merge order: #73 → #74 → this PR. Diff will simplify after upstream merges.

## Test plan

- [x] `npm run typecheck` clean
- [x] 56/56 commerce unit tests pass
- [ ] After PR 4 lands: end-to-end test with merchant who has PY+AR storefronts to verify per-country routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)