### PR TITLE
feat(pricing+admin): premium grace v2 copy + deals plan + /admin/tenants

### DIFF
--- a/docs/PRICING_DEALS_OFFERS.md
+++ b/docs/PRICING_DEALS_OFFERS.md
@@ -1,0 +1,189 @@
+# Pricing deals & offers · proposal
+
+> **Question from launch questionnaire (§6.3 / §E):**
+> "research what deals to implement and offers and all the stages we can offer
+> them and what best to offer based on the state of the client etc"
+
+This is the customer-state × offer matrix. Each offer is gated by where the
+client is in their lifecycle. Status of each: **proposed** until you green-light.
+Once approved, I'll wire each into copy, contracts, and admin tooling.
+
+---
+
+## Stage 0 · First-touch / browsing the site
+
+Goal: get them into the qualifier and onto your WhatsApp.
+
+| Offer | Hook | Why | Risk |
+|---|---|---|---|
+| **3 meses Profesional gratis · sin tarjeta** | Zero friction | Already approved (Plan Prueba) | Adverse selection — mitigated by the 3-month full-feature attention they get |
+| **Demo personalizada en 24h** | Removes "what would mine look like" friction | Already on the site | Time cost on you per demo; capped by your throughput |
+| **Auditoría gratuita del Instagram/sitio actual** | Optional add-on for businesses already online | High-value prospect identifier, signals expertise | Effort per audit (~20 min if templated) |
+
+**Recommendation:** add the audit as a third path on `/demo`. Keep the qualifier minimal but offer "¿Ya tenés sitio o IG con tracción? Te hacemos una auditoría gratis" as a checkbox.
+
+---
+
+## Stage 1 · Lead in qualifier · still deciding
+
+Goal: convert qualifier → paid signup with minimum friction.
+
+| Offer | Hook | Why | Cost to you |
+|---|---|---|---|
+| **Setup gratis si pagás 6 meses por adelantado** (Presencia: Gs 600K saved) | Removes upfront cost barrier | Trades cash-now for cash-later, gets them locked in | None if grace would have been free anyway |
+| **Setup -50% si decidís en 7 días** | Urgency + meaningful discount | Helps closes drag less | Gs 325K-1.1M depending on tier |
+| **Match best price** if they show a quote from another agency | Removes "let me think about it" | PY agencies cite Gs 3-5M; you're already 80% cheaper, but proves it | Tiny — most won't actually shop |
+| **First month free** add-on for the paid plan | Soft incentive | Less leverage than setup discount but easier to message | 1 monthly fee |
+
+**Recommendation:** **6 meses prepay → setup gratis** is the strongest. It anchors the conversation on long-term commitment instead of monthly tinkering. Use the "decide in 7 days for -50% setup" as a fallback if they hesitate.
+
+---
+
+## Stage 2 · Onboarding (month 0-1) · paid customer just signed up
+
+Goal: make month 1 feel premium so they don't churn before grace ends.
+
+| Offer | Hook | Why | Cost to you |
+|---|---|---|---|
+| **Welcome WhatsApp group + 30-min Calendly call** | Personal touch, sets expectations | Already in your comms cadence (Q6.3-C) | Time only |
+| **3 cambios de contenido extra el primer mes** | "Mientras te acostumbrás" | Defuses "I can't get it right" anxiety | Time, capped at 3 |
+| **Foto/video session AI-generada** (1 hero + 3 product photos) | High perceived value | Already part of your AI assets pipeline (~$2 cost) | <Gs 30K marginal |
+| **Prioridad de carga en `/c/<ciudad>`** for their vertical | Their listing first when prospects browse the city page | Costs you nothing, gives them visibility | None |
+
+**Recommendation:** bundle the 3 extra content changes + the AI hero/product asset session into **"Onboarding Profesional"** — included in every paid signup, not advertised as a discount but as a baseline. Frame it as "así arrancamos" instead of an offer.
+
+---
+
+## Stage 3 · Mid-grace (month 3-5) · checking if they're using it
+
+Goal: get usage data + identify upsell paths before grace ends.
+
+| Offer | Hook | Why | Cost to you |
+|---|---|---|---|
+| **Mid-grace audit call** | "How's it going? Here's what we observed" | Already in your comms cadence | 15-min call |
+| **Free reservas/booking activation** if they're a service vertical not using it | Inflates per-customer LTV before they downgrade | Booking is in Crecimiento+; gives a taste | Negligible if booking infra already built |
+| **Free additional language** if they have international clients | Shows they need Profesional | Pushes upgrade conversation organically | Translation cost (~$40 per locale via DeepL) |
+
+**Recommendation:** the audit call is the highest-leverage. Frame the upsell offers as "we noticed you'd use X — want us to enable it for the rest of grace?"
+
+---
+
+## Stage 4 · Grace expiring (month -1 before downgrade) · decision point
+
+Goal: convert grace-Profesional usage into a paid Profesional upgrade or annual prepay.
+
+| Offer | Hook | Why | Cost to you |
+|---|---|---|---|
+| **Pagar anual ahora = 2 meses gratis** | Standard SaaS annual discount (~17%) | Locks revenue, reduces churn risk | 2 months of monthly fee |
+| **Upgrade a Profesional con descuento del 30% el primer año** | Specific to their grace-period habit data | Most valuable offer if they're heavy users | 30% × Gs 300K × 12 = Gs 1.08M |
+| **Mantener Profesional con un setup adicional** (Gs 1.5M one-time → 6 más meses Profesional) | Lower commitment than annual upgrade | Bridges the "I'll decide later" customer | Gs 1.5M one-time vs Gs 1.8M revenue (6 × 300K) |
+| **Refer-a-friend: 1 mes Profesional extra por cada referido que paga** | Loyalty + acquisition combined | Cheapest CAC channel | 1 month Profesional × N referrals |
+
+**Recommendation:** Default offer is **annual prepay → 2 meses gratis**. Customer still expects to downgrade; you prove the value of staying premium with the discount.
+
+---
+
+## Stage 5 · Renewing or downgrading (month 8+) · post-grace
+
+Goal: maximize retention; minimize downgrades.
+
+| Offer | Hook | Why | Cost to you |
+|---|---|---|---|
+| **3 meses Profesional adicionales por Gs 200K** (vs Gs 900K full price) | "Una vuelta más antes de bajar" | Cheap retention buy | Gs 700K opportunity cost |
+| **Upgrade gradient**: Presencia → Crecimiento por Gs 100K extra/mes (vs Gs 50K diff) | Anchors on the absolute, hides the diff | Slight margin bump | Negligible |
+| **Loyalty perk: 6º mes gratis a quien lleva 6 meses pagando** | Retention reward | Returns 1 month per quarter retained | 1 month per loyal customer |
+| **Año 2 con descuento del 10%** if they renew | Long-term loyalty | Reduces churn at the highest-risk moment | 10% × annual fee |
+
+**Recommendation:** **3 meses extra Profesional por Gs 200K** is your churn-saver. Never advertise it; offer manually when they say "voy a bajar".
+
+---
+
+## Stage 6 · Churned customer · win-back
+
+Goal: bring back at the lowest cost.
+
+| Offer | Hook | Why | Cost to you |
+|---|---|---|---|
+| **30 días Profesional gratis para volver** | Re-engages without commitment | Already paid setup, infra exists | 1 month |
+| **Setup zero on the new plan** if they switched providers | Lower switching cost back | Recovers infra investment | Gs 650K-2.2M depending on plan |
+| **Annual at 50% off year 1** | Aggressive recovery | Worth it if you'd otherwise lose them forever | 50% of annual revenue |
+
+**Recommendation:** start with the 30-day free Profesional. If they don't engage in 7 days, escalate to annual at 50% off.
+
+---
+
+## Stage 7 · Expansion · happy customer wants more
+
+Goal: capture upsell revenue at zero acquisition cost.
+
+| Offer | Hook | Why | Cost to you |
+|---|---|---|---|
+| **Sitio adicional para otra marca tuya con 50% descuento del setup** | Bundle play | Same client owns multiple businesses (common in PY) | 50% setup |
+| **Multi-sucursal del mismo negocio: Gs 500K por sucursal extra** | Upsell to Profesional (5 sucursales already included) | Anchors on per-sucursal pricing | Capacity in plan |
+| **Domain pack**: registramos 5 dominios extras a Gs 200K/año | Operational value-add | Marginal cost ~$10/domain/year | Domain registrar fee |
+| **Dedicated dev hours** at Gs 250K/hora (Profesional includes 10h/month) | Custom integration revenue | Outside the pricing card; treats clients as deal candidates | Time only |
+
+**Recommendation:** the **multi-brand discount** is the cleanest. Customers who already trust you with one site are 5× easier to upsell than acquiring new ones.
+
+---
+
+## Cross-cutting: referral program
+
+| Mechanic | Suggested |
+|---|---|
+| Referrer gets | 1 mes Profesional gratis OR Gs 100K credit toward setup |
+| Referee gets | 20% setup discount OR 1 extra month grace |
+| Tracking | Manual at first (referrer name on intake form) → automated via short link in admin once volume justifies |
+| Cap | Max 6 free months per referrer per year |
+
+**Recommendation:** start manual. Code automation only after the 5th referral happens.
+
+---
+
+## Cross-cutting: annual prepay
+
+| Plan | Monthly | Annual prepay (1 month off) | Annual prepay (2 months off — 16.7% discount) |
+|---|---|---|---|
+| Presencia | Gs 100K × 12 = 1.2M | Gs 1.1M (saves 100K) | **Gs 1.0M** (saves 200K) |
+| Crecimiento | Gs 150K × 12 = 1.8M | Gs 1.65M (saves 150K) | **Gs 1.5M** (saves 300K) |
+| Profesional | Gs 300K × 12 = 3.6M | Gs 3.3M (saves 300K) | **Gs 3.0M** (saves 600K) |
+
+**Recommendation:** the **2-months-off** discount (16.7%) matches industry standard
+SaaS annual discount and is meaningful enough to influence the prepay decision.
+Don't go to 3 months off (25%) — too generous, hurts margins, and customers don't
+need that much to commit.
+
+---
+
+## Implementation order (when you green-light)
+
+| Order | Offer | Code work | Why first |
+|---|---|---|---|
+| 1 | Annual prepay 2 months off | Update `/precios` + add to `marketing-data.PLANS` + waMessage variants | Lowest effort, highest revenue impact |
+| 2 | "6 meses prepay → setup gratis" qualifier offer | New variant in DemoQualifier last step | Closes hesitating prospects |
+| 3 | Onboarding bundle (frame as baseline) | Update `/casos` and onboarding email | Sets expectation premium |
+| 4 | Mid-grace audit call automation | Cron at month 4-5 of `graceEndsAt` | Needs the tenants table first |
+| 5 | Refer-a-friend tracker | Admin field + intake-form question | Wait for 5+ referrals organically |
+| 6 | Win-back 30-day free | Admin button per churned tenant | Needs churn detection |
+| 7 | Multi-brand discount | Manual quote in WhatsApp; document the rate | No code needed |
+
+---
+
+## What NOT to offer (now)
+
+- Lifetime deals · creates support obligation forever
+- Free for nonprofits · gets gamed; offer 50% instead
+- "Pay what you want" · destroys price anchoring
+- Stackable discounts · pricing-page math becomes unreadable
+- Crypto / NFT anything · zero relevance to PY SMB market
+
+---
+
+## Open decisions before I implement
+
+1. **Annual prepay discount %** — 2 months free (16.7%) is my recommendation; confirm or change. ▶
+2. **6-month-prepay-setup-gratis** — offer it openly on `/precios` or only as a "if you decide today" sales tool? ▶
+3. **Referral reward** — 1 month Profesional vs Gs 100K credit? ▶
+4. **Stage 5 retention offer (3 meses por Gs 200K)** — keep it as an undocumented save, or list it on `/precios`? ▶ I lean undocumented (max-leverage save tool)
+
+Once you answer those four, I write the copy + admin scaffolding.

--- a/supabase/migrations/20260422000400_tenant_notes.sql
+++ b/supabase/migrations/20260422000400_tenant_notes.sql
@@ -1,0 +1,38 @@
+-- tenant_notes: free-form per-tenant log for admin observations during the
+-- premium grace period and beyond. Used by /admin/tenants/[slug].
+--
+-- RLS: service-role-only (matching analytics_events pattern). Admin pages
+-- access via the server-side createClient() that uses the service-role key.
+--
+-- Note: an earlier draft tried to gate via public.profiles.role = 'admin',
+-- but that table does not exist in this project. Existing /admin/leads page
+-- references it too — it currently fails the admin check at runtime. Pending
+-- a separate decision on whether to introduce a profiles table or keep
+-- service-role-only enforcement at the route level.
+
+create table if not exists public.tenant_notes (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.businesses(id) on delete cascade,
+  body text not null,
+  pinned boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists tenant_notes_business_id_created_at_idx
+  on public.tenant_notes (business_id, created_at desc);
+
+alter table public.tenant_notes enable row level security;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='tenant_notes' and policyname='service_role full access') then
+    create policy "service_role full access" on public.tenant_notes
+      for all to service_role using (true) with check (true);
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='tenant_notes' and policyname='anon no access') then
+    create policy "anon no access" on public.tenant_notes
+      for all to anon using (false) with check (false);
+  end if;
+end $$;
+
+comment on table public.tenant_notes is
+  'Free-form admin notes per tenant. Used during the premium grace period to log observations and decisions.';

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -99,6 +99,18 @@ export default async function AdminDashboard() {
               Pedidos, productos e inventario por tenant.
             </p>
           </Link>
+          <Link
+            href="/admin/tenants"
+            className="group rounded-lg border bg-white p-5 transition-all hover:-translate-y-0.5 hover:border-blue-300 hover:shadow-sm"
+          >
+            <p className="text-xs uppercase tracking-wider text-gray-500">Tenants</p>
+            <p className="mt-1 text-base font-semibold text-gray-900 group-hover:text-blue-700">
+              Negocios + grace status
+            </p>
+            <p className="mt-1 text-sm text-gray-500">
+              Suscripción, contacto, notas y eventos por tenant.
+            </p>
+          </Link>
         </div>
 
         {/* Business List */}

--- a/web/app/admin/tenants/[slug]/page.tsx
+++ b/web/app/admin/tenants/[slug]/page.tsx
@@ -1,0 +1,347 @@
+/**
+ * Admin: Tenant detail
+ *
+ * Per-tenant control panel. Shows business info, current subscription /
+ * grace status, recent analytics events, recent outreach events, and a
+ * notes log. Note-add posts to /api/admin/tenants/[slug]/notes.
+ *
+ * Auth: presence of an authenticated session (middleware blocks anon).
+ * TODO: gate by profiles.role='admin' once that table is introduced.
+ */
+import { notFound, redirect } from 'next/navigation'
+import Link from 'next/link'
+import { createClient } from '@/lib/supabase/server'
+import { logger } from '@/lib/logger'
+import { TenantNoteForm } from './tenant-note-form'
+
+export const runtime = 'nodejs'
+
+type Params = { slug: string }
+
+export const metadata = {
+  title: 'Admin · Tenant | ParaguAI',
+}
+
+type Business = {
+  id: string
+  slug: string
+  name: string
+  type: string
+  city: string | null
+  phone: string | null
+  whatsapp: string | null
+  email: string | null
+  instagram: string | null
+  status: string
+  data_json: Record<string, unknown> | null
+  created_at: string
+}
+
+type Subscription = {
+  id: string
+  plan_tier: string
+  plan_name: string
+  status: string
+  trial_ends_at: string | null
+  current_period_start: string
+  current_period_end: string
+}
+
+type AnalyticsEvent = {
+  id: string
+  event_type: string
+  metadata: Record<string, unknown> | null
+  created_at: string
+}
+
+type OutreachEvent = {
+  id: string
+  event_type: string
+  channel: string | null
+  message_template: string | null
+  created_at: string
+}
+
+type Note = {
+  id: string
+  body: string
+  pinned: boolean
+  created_at: string
+}
+
+function fmtDateTime(iso: string): string {
+  return new Date(iso).toLocaleString('es-PY', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function ago(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime()
+  const min = Math.round(ms / 60_000)
+  if (min < 60) return `hace ${Math.max(1, min)} min`
+  const hr = Math.round(min / 60)
+  if (hr < 24) return `hace ${hr} h`
+  const day = Math.round(hr / 24)
+  return `hace ${day} d`
+}
+
+export default async function TenantDetailPage({ params }: { params: Promise<Params> }) {
+  const { slug } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect('/login?error=unauthorized')
+
+  const { data: biz, error } = await supabase
+    .from('businesses')
+    .select('id, slug, name, type, city, phone, whatsapp, email, instagram, status, data_json, created_at')
+    .eq('slug', slug)
+    .single()
+
+  if (error || !biz) {
+    logger.warn('admin.tenant.not_found', { slug, error: error?.message })
+    notFound()
+  }
+  const business = biz as Business
+
+  // Parallel fetch the rest.
+  const [subRes, eventsRes, outreachRes, notesRes] = await Promise.all([
+    supabase
+      .from('subscriptions')
+      .select('id, plan_tier, plan_name, status, trial_ends_at, current_period_start, current_period_end')
+      .eq('business_id', business.id)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from('analytics_events')
+      .select('id, event_type, metadata, created_at')
+      .eq('business_id', business.id)
+      .order('created_at', { ascending: false })
+      .limit(20),
+    supabase
+      .from('outreach_events')
+      .select('id, event_type, channel, message_template, created_at')
+      .order('created_at', { ascending: false })
+      .limit(20),
+    supabase
+      .from('tenant_notes')
+      .select('id, body, pinned, created_at')
+      .eq('business_id', business.id)
+      .order('pinned', { ascending: false })
+      .order('created_at', { ascending: false }),
+  ])
+
+  const sub = subRes.data as Subscription | null
+  const events = (eventsRes.data ?? []) as AnalyticsEvent[]
+  const outreach = (outreachRes.data ?? []) as OutreachEvent[]
+  const notes = (notesRes.data ?? []) as Note[]
+
+  const data = business.data_json ?? {}
+  const whatsappGroupUrl = (data as Record<string, unknown>).whatsapp_group_url as string | undefined
+
+  // Date.now() is fine in a Server Component — re-renders per request.
+  // eslint-disable-next-line react-hooks/purity
+  const nowMs = Date.now()
+  const graceEnd = sub?.trial_ends_at
+  const inGrace = graceEnd ? new Date(graceEnd).getTime() > nowMs : false
+  const daysLeft = graceEnd
+    ? Math.max(0, Math.ceil((new Date(graceEnd).getTime() - nowMs) / 86_400_000))
+    : null
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <header className="border-b bg-white">
+        <div className="mx-auto max-w-6xl px-6 py-4">
+          <Link href="/admin/tenants" className="text-sm text-gray-500 hover:underline">
+            ← Tenants
+          </Link>
+          <div className="mt-2 flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">{business.name}</h1>
+              <p className="text-sm text-gray-500">
+                <code>{business.slug}</code> · {business.type} · {business.city ?? 'sin ciudad'}
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Link
+                href={`/${business.slug}`}
+                target="_blank"
+                className="rounded-lg border bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                Ver sitio público
+              </Link>
+              {whatsappGroupUrl && (
+                <a
+                  href={whatsappGroupUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+                >
+                  Abrir grupo WhatsApp
+                </a>
+              )}
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-6xl px-6 py-8 grid gap-6 md:grid-cols-3">
+        {/* Left: contact + subscription */}
+        <aside className="space-y-4 md:col-span-1">
+          <Card title="Suscripción">
+            {sub ? (
+              <div className="space-y-1.5 text-sm">
+                <Field label="Plan">{sub.plan_name} ({sub.plan_tier})</Field>
+                <Field label="Status">{sub.status}</Field>
+                <Field label="Grace ends">
+                  {graceEnd ? (
+                    <span className={inGrace ? 'font-bold text-green-700' : 'text-gray-500'}>
+                      {fmtDateTime(graceEnd)} {inGrace && `(${daysLeft}d restantes)`}
+                    </span>
+                  ) : (
+                    '—'
+                  )}
+                </Field>
+                <Field label="Period end">{fmtDateTime(sub.current_period_end)}</Field>
+              </div>
+            ) : (
+              <div className="text-sm text-gray-500">
+                Sin suscripción registrada en <code>subscriptions</code>.
+              </div>
+            )}
+          </Card>
+
+          <Card title="Contacto">
+            <div className="space-y-1.5 text-sm">
+              {business.whatsapp && (
+                <Field label="WhatsApp">
+                  <a
+                    href={`https://wa.me/${business.whatsapp.replace(/[^0-9]/g, '')}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-700 hover:underline"
+                  >
+                    {business.whatsapp}
+                  </a>
+                </Field>
+              )}
+              {business.phone && <Field label="Teléfono">{business.phone}</Field>}
+              {business.email && <Field label="Email">{business.email}</Field>}
+              {business.instagram && (
+                <Field label="Instagram">
+                  <a
+                    href={`https://instagram.com/${business.instagram.replace(/^@/, '')}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-700 hover:underline"
+                  >
+                    {business.instagram}
+                  </a>
+                </Field>
+              )}
+              {!whatsappGroupUrl && (
+                <p className="mt-3 rounded-md bg-yellow-50 p-2 text-xs text-yellow-800">
+                  Falta link al grupo de WhatsApp. Agregalo a{' '}
+                  <code>businesses.data_json.whatsapp_group_url</code> en Supabase.
+                </p>
+              )}
+            </div>
+          </Card>
+        </aside>
+
+        {/* Right: notes + activity */}
+        <section className="space-y-4 md:col-span-2">
+          <Card title={`Notas (${notes.length})`}>
+            <TenantNoteForm slug={business.slug} />
+            <ul className="mt-4 space-y-3">
+              {notes.length === 0 && (
+                <li className="text-sm text-gray-500">Sin notas todavía.</li>
+              )}
+              {notes.map((n) => (
+                <li
+                  key={n.id}
+                  className={`rounded-md border p-3 text-sm ${
+                    n.pinned ? 'border-yellow-300 bg-yellow-50' : 'border-gray-200 bg-white'
+                  }`}
+                >
+                  <p className="whitespace-pre-wrap text-gray-800">{n.body}</p>
+                  <p className="mt-2 text-xs text-gray-500">
+                    {ago(n.created_at)} · {fmtDateTime(n.created_at)}
+                    {n.pinned && ' · 📌 fijada'}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </Card>
+
+          <Card title={`Eventos analytics (${events.length} de últimos 20)`}>
+            {events.length === 0 ? (
+              <div className="text-sm text-gray-500">Sin eventos para este tenant.</div>
+            ) : (
+              <ul className="space-y-2 text-sm">
+                {events.map((e) => (
+                  <li key={e.id} className="flex items-start justify-between gap-3 border-b border-gray-100 pb-2 last:border-0">
+                    <div>
+                      <span className="font-mono text-xs font-medium">{e.event_type}</span>
+                      {e.metadata && Object.keys(e.metadata).length > 0 && (
+                        <pre className="mt-1 max-w-md overflow-x-auto rounded bg-gray-50 p-2 text-xs text-gray-700">
+                          {JSON.stringify(e.metadata, null, 2)}
+                        </pre>
+                      )}
+                    </div>
+                    <span className="shrink-0 text-xs text-gray-500">{ago(e.created_at)}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Card>
+
+          <Card title="Outreach (todos los tenants, últimos 20)">
+            {outreach.length === 0 ? (
+              <div className="text-sm text-gray-500">
+                <code>outreach_events</code> está vacío. Esta tabla se llena cuando enviás un
+                mensaje desde el CRM <Link href="/admin/leads" className="text-blue-700 hover:underline">/admin/leads</Link>.
+              </div>
+            ) : (
+              <ul className="space-y-1.5 text-sm">
+                {outreach.map((o) => (
+                  <li key={o.id} className="flex items-start justify-between gap-3">
+                    <div>
+                      <span className="font-mono text-xs">{o.event_type}</span>
+                      {o.channel && <span className="ml-2 text-xs text-gray-500">· {o.channel}</span>}
+                    </div>
+                    <span className="text-xs text-gray-500">{ago(o.created_at)}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Card>
+        </section>
+      </div>
+    </main>
+  )
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border bg-white p-5 shadow-sm">
+      <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-gray-500">{title}</h2>
+      {children}
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span className="text-xs uppercase tracking-wider text-gray-500">{label}</span>
+      <span className="text-right text-gray-900">{children}</span>
+    </div>
+  )
+}

--- a/web/app/admin/tenants/[slug]/tenant-note-form.tsx
+++ b/web/app/admin/tenants/[slug]/tenant-note-form.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export function TenantNoteForm({ slug }: { slug: string }) {
+  const router = useRouter()
+  const [body, setBody] = useState('')
+  const [pinned, setPinned] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!body.trim()) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/admin/tenants/${slug}/notes`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body, pinned }),
+      })
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string }
+        throw new Error(data.error || `HTTP ${res.status}`)
+      }
+      setBody('')
+      setPinned(false)
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'unknown error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Nota sobre este tenant — observación, decisión, próximo paso…"
+        rows={3}
+        disabled={submitting}
+        className="w-full rounded-md border border-gray-300 p-3 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:opacity-60"
+      />
+      <div className="flex items-center justify-between">
+        <label className="inline-flex items-center gap-2 text-xs text-gray-600">
+          <input
+            type="checkbox"
+            checked={pinned}
+            onChange={(e) => setPinned(e.target.checked)}
+            disabled={submitting}
+            className="rounded border-gray-300"
+          />
+          Fijar arriba
+        </label>
+        <button
+          type="submit"
+          disabled={submitting || !body.trim()}
+          className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {submitting ? 'Guardando…' : 'Agregar nota'}
+        </button>
+      </div>
+      {error && (
+        <p role="alert" className="text-xs text-red-600">
+          {error}
+        </p>
+      )}
+    </form>
+  )
+}

--- a/web/app/admin/tenants/page.tsx
+++ b/web/app/admin/tenants/page.tsx
@@ -1,0 +1,195 @@
+/**
+ * Admin: Tenants index
+ *
+ * One row per business in `public.businesses`. Click into a row to see
+ * subscription state, recent outreach + analytics events, notes, and the
+ * WhatsApp group link for that tenant. Built per pricing v2 §C
+ * (per-tenant WhatsApp group + admin tracking).
+ */
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { createClient } from '@/lib/supabase/server'
+import { logger } from '@/lib/logger'
+
+export const runtime = 'nodejs'
+
+export const metadata = {
+  title: 'Admin · Tenants | ParaguAI',
+  description: 'Per-tenant overview with grace status and contact log.',
+}
+
+type Tenant = {
+  id: string
+  slug: string
+  name: string
+  type: string
+  city: string | null
+  status: string
+  created_at: string
+}
+
+type Subscription = {
+  business_id: string
+  plan_tier: string
+  status: string
+  trial_ends_at: string | null
+  current_period_end: string
+}
+
+function ago(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime()
+  const d = Math.round(ms / 86_400_000)
+  if (d === 0) return 'hoy'
+  if (d === 1) return 'ayer'
+  if (d < 30) return `hace ${d} d`
+  const m = Math.round(d / 30)
+  return `hace ${m} m`
+}
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleDateString('es-PY', { year: 'numeric', month: 'short', day: '2-digit' })
+}
+
+export default async function TenantsIndexPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect('/login?error=unauthorized')
+
+  // Profiles table doesn't exist in this project (see migration comment in
+  // tenant_notes.sql). For now, presence of an authenticated session is the
+  // gate — middleware already blocks anon. TODO: add a profiles table or
+  // env-allowlisted admin emails before opening the panel to non-team users.
+
+  const { data: tenants, error } = await supabase
+    .from('businesses')
+    .select('id, slug, name, type, city, status, created_at')
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    logger.error('admin.tenants.list_failed', new Error(error.message))
+  }
+
+  const rows: Tenant[] = (tenants ?? []) as Tenant[]
+  const ids = rows.map((r) => r.id)
+
+  const { data: subs } = await supabase
+    .from('subscriptions')
+    .select('business_id, plan_tier, status, trial_ends_at, current_period_end')
+    .in('business_id', ids.length ? ids : ['00000000-0000-0000-0000-000000000000'])
+
+  const subByBiz = new Map<string, Subscription>()
+  for (const s of (subs ?? []) as Subscription[]) {
+    if (!subByBiz.has(s.business_id)) subByBiz.set(s.business_id, s)
+  }
+
+  const activeCount = rows.filter((r) => r.status === 'active').length
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <header className="border-b bg-white">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+          <div>
+            <Link href="/admin" className="text-sm text-gray-500 hover:underline">
+              ← Admin
+            </Link>
+            <h1 className="text-xl font-bold text-gray-900">Tenants</h1>
+            <p className="text-sm text-gray-500">
+              Negocios en <code>public.businesses</code> con suscripción y notas.
+            </p>
+          </div>
+          <div className="flex gap-4 text-sm">
+            <div className="rounded-lg border bg-white px-4 py-2 text-center">
+              <div className="text-xs uppercase tracking-wider text-gray-500">Total</div>
+              <div className="text-xl font-bold text-gray-900">{rows.length}</div>
+            </div>
+            <div className="rounded-lg border bg-white px-4 py-2 text-center">
+              <div className="text-xs uppercase tracking-wider text-gray-500">Activos</div>
+              <div className="text-xl font-bold text-gray-900">{activeCount}</div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-7xl px-6 py-8">
+        {rows.length === 0 ? (
+          <div className="rounded-lg border bg-white p-12 text-center text-gray-600">
+            Aún no hay tenants en la base.
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border bg-white shadow-sm">
+            <table className="w-full text-sm">
+              <thead className="border-b bg-gray-50 text-left text-xs uppercase tracking-wider text-gray-500">
+                <tr>
+                  <th className="px-4 py-3">Tenant</th>
+                  <th className="px-4 py-3">Tipo</th>
+                  <th className="px-4 py-3">Ciudad</th>
+                  <th className="px-4 py-3">Status</th>
+                  <th className="px-4 py-3">Plan</th>
+                  <th className="px-4 py-3">Grace ends</th>
+                  <th className="px-4 py-3">Alta</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {rows.map((t) => {
+                  const sub = subByBiz.get(t.id)
+                  const graceEnd = sub?.trial_ends_at
+                  const inGrace = graceEnd ? new Date(graceEnd) > new Date() : false
+                  return (
+                    <tr key={t.id} className="hover:bg-gray-50">
+                      <td className="px-4 py-3">
+                        <Link
+                          href={`/admin/tenants/${t.slug}`}
+                          className="font-medium text-blue-700 hover:underline"
+                        >
+                          {t.name}
+                        </Link>
+                        <div className="text-xs text-gray-500">{t.slug}</div>
+                      </td>
+                      <td className="px-4 py-3 text-gray-700">{t.type}</td>
+                      <td className="px-4 py-3 text-gray-700">{t.city ?? '—'}</td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                            t.status === 'active'
+                              ? 'bg-green-50 text-green-700'
+                              : 'bg-gray-100 text-gray-700'
+                          }`}
+                        >
+                          {t.status}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        {sub ? (
+                          <span className="text-xs">
+                            <strong>{sub.plan_tier}</strong> · {sub.status}
+                          </span>
+                        ) : (
+                          <span className="text-xs text-gray-400">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        {graceEnd ? (
+                          <span
+                            className={`text-xs ${inGrace ? 'font-bold text-green-700' : 'text-gray-500'}`}
+                          >
+                            {fmtDate(graceEnd)}
+                          </span>
+                        ) : (
+                          <span className="text-xs text-gray-400">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-500">{ago(t.created_at)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/web/app/api/admin/tenants/[slug]/notes/route.ts
+++ b/web/app/api/admin/tenants/[slug]/notes/route.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /api/admin/tenants/[slug]/notes — append a tenant_notes row.
+ *
+ * Auth: presence of an authenticated session (middleware blocks anon).
+ * TODO: gate by profiles.role='admin' once that table is introduced.
+ */
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createClient } from '@/lib/supabase/server'
+import { withRequestLog } from '@/lib/api/with-request-log'
+
+export const runtime = 'nodejs'
+
+const Schema = z.object({
+  body: z.string().min(1).max(4000),
+  pinned: z.boolean().optional().default(false),
+})
+
+export const POST = withRequestLog(async (req, { log }) => {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const url = new URL(req.url)
+  const slug = url.pathname.split('/').filter(Boolean).slice(-2, -1)[0]
+  if (!slug) {
+    return NextResponse.json({ error: 'missing slug' }, { status: 400 })
+  }
+
+  const parsed = Schema.safeParse(await req.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const { data: biz, error: lookupErr } = await supabase
+    .from('businesses')
+    .select('id')
+    .eq('slug', slug)
+    .single()
+  if (lookupErr || !biz) {
+    return NextResponse.json({ error: 'tenant not found', slug }, { status: 404 })
+  }
+
+  const { data, error } = await supabase
+    .from('tenant_notes')
+    .insert({
+      business_id: biz.id,
+      body: parsed.data.body,
+      pinned: parsed.data.pinned,
+    })
+    .select('id')
+    .single()
+
+  if (error) {
+    log.error('admin.tenant_notes.insert_failed', new Error(error.message))
+    return NextResponse.json({ error: 'insert_failed', detail: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true, id: data.id })
+})

--- a/web/app/precios/page.tsx
+++ b/web/app/precios/page.tsx
@@ -70,6 +70,31 @@ export default function PreciosPage() {
           </Container>
         </section>
 
+        {/* Premium grace explainer */}
+        <section className="pb-8">
+          <Container size="md">
+            <div className="mx-auto max-w-3xl rounded-3xl border-2 border-[var(--primary)]/30 bg-gradient-to-br from-[var(--primary)]/5 to-[var(--accent)]/5 p-6 md:p-8">
+              <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-[var(--primary)]/10 px-3 py-1 text-xs font-bold uppercase tracking-wider text-[var(--primary)]">
+                Cómo funciona el período Profesional incluido
+              </div>
+              <p className="text-base text-[var(--text)] md:text-lg">
+                Todos los planes (incluido el gratuito) <strong>arrancan con la experiencia
+                Profesional completa</strong>. Es nuestra forma de que conozcas todo lo que ofrecemos
+                antes de decidir qué necesitás a largo plazo.
+              </p>
+              <ul className="mt-4 space-y-2 text-sm text-[var(--text-light)]">
+                <li>· <strong className="text-[var(--text)]">Prueba</strong>: 3 meses Profesional · después seguís online con marca ParaguAI</li>
+                <li>· <strong className="text-[var(--text)]">Presencia</strong>: 7 meses Profesional · después tu plan Presencia</li>
+                <li>· <strong className="text-[var(--text)]">Crecimiento</strong>: 8 meses Profesional · después tu plan Crecimiento</li>
+                <li>· <strong className="text-[var(--text)]">Profesional</strong>: siempre completo, sin downgrades</li>
+              </ul>
+              <p className="mt-4 text-xs text-[var(--text-muted)]">
+                Durante el período Profesional tenés WhatsApp dedicado y check-in mensual con nosotros para entender qué features usás más y necesitás conservar.
+              </p>
+            </div>
+          </Container>
+        </section>
+
         {/* Plans grid */}
         <section className="py-12">
           <Container>

--- a/web/lib/landing/home-data.ts
+++ b/web/lib/landing/home-data.ts
@@ -9,7 +9,11 @@ export const HOME_FAQS = [
   },
   {
     q: '¿Puedo probar antes de pagar?',
-    a: 'Sí. Todos los planes incluyen una demo de tu sitio antes de pagar el setup. Además tenés 3 meses de prueba gratis en subdominio para validar que funciona.',
+    a: 'Sí. Todos los planes incluyen una demo de tu sitio antes de pagar el setup. Además tenés 3 meses con la experiencia Profesional completa sin costo — todo desbloqueado, sin tarjeta. Después podés seguir gratis (con marca ParaguAI) o pasar a un plan pago para conservar el dominio propio y la marca limpia.',
+  },
+  {
+    q: '¿Qué es el "período Profesional incluido" en los planes pagos?',
+    a: 'Los planes pagos arrancan con la experiencia Profesional completa por más tiempo del que cubre tu plan: Presencia da 7 meses Profesional, Crecimiento da 8. Después de ese período el sitio sigue funcionando con las features de tu plan elegido. Es nuestra forma de que conozcas todo antes de decidir si necesitás escalar.',
   },
   {
     q: '¿Cómo funciona el pago?',

--- a/web/lib/landing/marketing-data.ts
+++ b/web/lib/landing/marketing-data.ts
@@ -157,6 +157,15 @@ export type Plan = {
   cta: string
   waMessage: string
   popular: boolean
+  /**
+   * Months the customer enjoys full Profesional-tier features regardless of
+   * which plan they actually paid for. Honor-system enforced today; once the
+   * `graceEndsAt` field is wired into the tenants table we'll downgrade
+   * features automatically. See docs/PRICING_ITERATION_V2.md.
+   */
+  premiumGraceMonths: number
+  /** Highlight badge shown on the plan card. Replaces the `popular` flag in v2. */
+  badge?: string
 }
 
 export const PLANS: readonly Plan[] = [
@@ -165,50 +174,54 @@ export const PLANS: readonly Plan[] = [
     name: 'Prueba',
     setup: 'Gratis',
     monthly: '3 meses',
-    period: 'sin costo',
-    description: 'Para validar antes de invertir',
+    period: 'full Profesional, sin costo',
+    description: 'Probá todo lo que ofrecemos antes de pagar nada',
     features: [
-      { text: 'Subdominio (negocio.paragu-ai.com)', included: true },
-      { text: '1 página lista para compartir', included: true },
-      { text: 'WhatsApp + Google Maps', included: true },
-      { text: 'Certificado SSL incluido', included: true },
-      { text: 'Dominio propio', included: false },
-      { text: 'Sin branding ParaguAI', included: false },
-      { text: 'Soporte personalizado', included: false },
+      { text: '3 meses con la experiencia Profesional completa', included: true },
+      { text: 'Subdominio negocio.paragu-ai.com', included: true },
+      { text: 'WhatsApp Business + Google Maps + SSL', included: true },
+      { text: 'Soporte por WhatsApp durante la prueba', included: true },
+      { text: 'Después de los 3 meses: el sitio sigue online con marca ParaguAI', included: true },
+      { text: 'Dominio propio incluido', included: false },
+      { text: 'Sin marca ParaguAI', included: false },
     ],
-    cta: 'Solicitar demo',
-    waMessage: 'Hola, quiero probar ParaguAI gratis para mi negocio.',
+    cta: 'Probar gratis',
+    waMessage: 'Hola, quiero probar ParaguAI gratis (3 meses Profesional) para mi negocio.',
     popular: false,
+    premiumGraceMonths: 3,
   },
   {
     id: 'presencia',
     name: 'Presencia',
     setup: 'Gs 650.000',
     monthly: 'Gs 100.000',
-    period: 'por mes',
-    description: 'Tu primer sitio profesional',
+    period: 'por mes (después de 7 meses Profesional gratis)',
+    description: 'Tu primer sitio profesional · 7 meses con todo desbloqueado',
     features: [
-      { text: 'Hasta 5 páginas', included: true },
+      { text: '7 meses con la experiencia Profesional completa', included: true },
+      { text: 'Hasta 5 páginas en tu plan base', included: true },
       { text: 'Dominio propio (.com.py) incluido 1 año', included: true },
       { text: 'Hasta 15 fotos optimizadas', included: true },
       { text: 'Formulario + WhatsApp Business', included: true },
       { text: 'SEO básico + Google Maps', included: true },
       { text: '2 cambios de contenido al mes', included: true },
-      { text: 'Soporte por WhatsApp', included: true },
+      { text: 'WhatsApp dedicado + check-in mensual', included: true },
     ],
     cta: 'Comenzar Presencia',
-    waMessage: 'Hola, me interesa el plan Presencia (Gs 650.000 + 100.000/mes).',
+    waMessage: 'Hola, me interesa el plan Presencia (Gs 650.000 + 100.000/mes, con 7 meses Profesional incluidos).',
     popular: false,
+    premiumGraceMonths: 7,
   },
   {
     id: 'crecimiento',
     name: 'Crecimiento',
     setup: 'Gs 1.200.000',
     monthly: 'Gs 150.000',
-    period: 'por mes',
-    description: 'Reservas, blog y e-commerce',
+    period: 'por mes (después de 8 meses Profesional gratis)',
+    description: 'Reservas, blog y e-commerce · 8 meses con todo desbloqueado',
     features: [
-      { text: 'Todo lo de Presencia', included: true },
+      { text: '8 meses con la experiencia Profesional completa', included: true },
+      { text: 'Todo lo de Presencia en tu plan base', included: true },
       { text: 'Páginas ilimitadas', included: true },
       { text: 'Sistema de reservas online', included: true },
       { text: 'Catálogo con hasta 20 productos', included: true },
@@ -217,18 +230,21 @@ export const PLANS: readonly Plan[] = [
       { text: '5 cambios al mes + soporte prioritario', included: true },
     ],
     cta: 'Comenzar Crecimiento',
-    waMessage: 'Hola, me interesa el plan Crecimiento (Gs 1.200.000 + 150.000/mes).',
+    waMessage: 'Hola, me interesa el plan Crecimiento (Gs 1.200.000 + 150.000/mes, con 8 meses Profesional incluidos).',
     popular: true,
+    badge: 'Más recomendado',
+    premiumGraceMonths: 8,
   },
   {
     id: 'profesional',
     name: 'Profesional',
     setup: 'Gs 2.200.000',
     monthly: 'Gs 300.000',
-    period: 'por mes',
-    description: 'Cadenas, franquicias, multi-sucursal',
+    period: 'por mes · siempre full Profesional',
+    description: 'Cadenas, franquicias, multi-sucursal — sin downgrades, nunca',
     features: [
-      { text: 'Todo lo de Crecimiento', included: true },
+      { text: 'Experiencia Profesional completa, siempre', included: true },
+      { text: 'Todo lo de Crecimiento sin límite de tiempo', included: true },
       { text: 'Hasta 5 sucursales / locales', included: true },
       { text: 'Sitio multi-idioma (es/en/pt)', included: true },
       { text: 'Integraciones personalizadas', included: true },
@@ -239,6 +255,7 @@ export const PLANS: readonly Plan[] = [
     cta: 'Hablar con ventas',
     waMessage: 'Hola, me interesa el plan Profesional (Gs 2.200.000 + 300.000/mes).',
     popular: false,
+    premiumGraceMonths: 0,
   },
 ] as const
 


### PR DESCRIPTION
Three pieces from the launch questionnaire follow-up, in user's chosen order (1, 2, 4-already-shipped, 3):

## 1. Pricing v2 site copy
- Plans now expose `premiumGraceMonths`: Prueba=3, Presencia=7, Crecimiento=8, Profesional=∞
- New explainer card on `/precios` describing the grace model
- New FAQ entry
- "Más recomendado" badge on Crecimiento

## 2. Deals & offers research
`docs/PRICING_DEALS_OFFERS.md` — 7 customer-state stages × ranked offer matrix, referral program design, annual prepay (16.7% recommended), 4 open ▶ DECIDE blocks.

## 3. Language switcher
**Already shipped in PR #53** (verified live at /s/en/nexa-paraguay). No code needed.

## 4. /admin/tenants
- New list page + detail page reading from `businesses`, `subscriptions`, `analytics_events`, `outreach_events`, `tenant_notes`
- New `tenant_notes` table (migration 20260422000400, also applied via Supabase MCP)
- POST `/api/admin/tenants/[slug]/notes` for inline note adds
- Surfaces `businesses.data_json.whatsapp_group_url` as the "Abrir grupo WhatsApp" CTA — set manually per tenant in Supabase
- Tile added on `/admin` landing

## TODO captured in code
`/admin/leads` and the new `/admin/tenants` both gate on session-only because `profiles` table doesn't exist in the project. Future work: add profiles or env-allowlisted admin emails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)