### PR TITLE
feat(commerce): admin commission settings page (PR 7/8)

### DIFF
--- a/web/app/admin/billing/[businessId]/commission/page.tsx
+++ b/web/app/admin/billing/[businessId]/commission/page.tsx
@@ -1,0 +1,49 @@
+import { notFound } from 'next/navigation'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { CommissionSettingsForm } from '@/components/admin/commerce/commission-settings-form'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+interface BusinessRow {
+  id: string
+  slug: string
+  name: string
+  commission_percent: number
+  commission_flat_cents: number
+  commission_exempt_until: string | null
+}
+
+export default async function CommissionSettingsPage({
+  params,
+}: {
+  params: Promise<{ businessId: string }>
+}) {
+  const { businessId } = await params
+  const supabase = await createAdminClient()
+  const { data } = await supabase
+    .from('businesses')
+    .select('id, slug, name, commission_percent, commission_flat_cents, commission_exempt_until')
+    .eq('id', businessId)
+    .maybeSingle<BusinessRow>()
+
+  if (!data) notFound()
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <h1 className="mb-1 text-2xl font-bold">Comisión</h1>
+      <p className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">
+        Configurá cuánto se queda Paragu-AI por cada venta en la tienda de <strong>{data.name}</strong>. La comisión se cobra vía Pagopar split billing — el tenant recibe su parte y Paragu-AI la suya, sin que nosotros manejemos el dinero.
+      </p>
+
+      <CommissionSettingsForm
+        businessId={businessId}
+        initial={{
+          commissionPercent: data.commission_percent,
+          commissionFlatCents: data.commission_flat_cents,
+          commissionExemptUntil: data.commission_exempt_until,
+        }}
+      />
+    </div>
+  )
+}

--- a/web/app/api/admin/billing/[businessId]/commission/route.ts
+++ b/web/app/api/admin/billing/[businessId]/commission/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { requireAdminUser } from '@/lib/commerce/admin-auth'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+export const runtime = 'nodejs'
+
+const PutSchema = z.object({
+  commissionPercent: z.number().min(0).max(100),
+  commissionFlatCents: z.number().int().nonnegative().max(100_000_000),
+  commissionExemptUntil: z
+    .union([z.string().datetime(), z.null()])
+    .optional(),
+})
+
+export const GET = withRequestLog<{ businessId: string }>(async (_req, _ctx, { businessId }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const supabase = await createAdminClient()
+  const { data, error } = await supabase
+    .from('businesses')
+    .select('id, slug, name, commission_percent, commission_flat_cents, commission_exempt_until')
+    .eq('id', businessId)
+    .maybeSingle()
+
+  if (error || !data) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    businessId: data.id,
+    slug: data.slug,
+    name: data.name,
+    commissionPercent: data.commission_percent,
+    commissionFlatCents: data.commission_flat_cents,
+    commissionExemptUntil: data.commission_exempt_until,
+  })
+})
+
+export const PUT = withRequestLog<{ businessId: string }>(async (req, { log }, { businessId }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+
+  const parsed = PutSchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const supabase = await createAdminClient()
+  const { error } = await supabase
+    .from('businesses')
+    .update({
+      commission_percent: parsed.data.commissionPercent,
+      commission_flat_cents: parsed.data.commissionFlatCents,
+      commission_exempt_until: parsed.data.commissionExemptUntil ?? null,
+    })
+    .eq('id', businessId)
+
+  if (error) {
+    log.error('admin.commerce.commission.update_failed', new Error(error.message))
+    return NextResponse.json({ error: 'update_failed' }, { status: 500 })
+  }
+
+  log.info('admin.commerce.commission.updated', {
+    businessId,
+    percent: parsed.data.commissionPercent,
+    flatCents: parsed.data.commissionFlatCents,
+    exemptUntil: parsed.data.commissionExemptUntil,
+  })
+
+  return NextResponse.json({ ok: true })
+})

--- a/web/components/admin/commerce/commission-settings-form.tsx
+++ b/web/components/admin/commerce/commission-settings-form.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface InitialValues {
+  commissionPercent: number
+  commissionFlatCents: number
+  commissionExemptUntil: string | null
+}
+
+export function CommissionSettingsForm({
+  businessId,
+  initial,
+}: {
+  businessId: string
+  initial: InitialValues
+}) {
+  const router = useRouter()
+  const [submitting, setSubmitting] = useState(false)
+  const [feedback, setFeedback] = useState<{ ok: boolean; message: string } | null>(null)
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setSubmitting(true)
+    setFeedback(null)
+    const form = new FormData(event.currentTarget)
+    const exemptRaw = String(form.get('commissionExemptUntil') ?? '').trim()
+
+    const payload = {
+      commissionPercent: parseFloat(String(form.get('commissionPercent') ?? '0')) || 0,
+      commissionFlatCents: parseInt(String(form.get('commissionFlatCents') ?? '0').replace(/[^0-9]/g, ''), 10) || 0,
+      commissionExemptUntil: exemptRaw ? new Date(exemptRaw).toISOString() : null,
+    }
+
+    try {
+      const res = await fetch(`/api/admin/billing/${businessId}/commission`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data.error ?? 'update_failed')
+      setFeedback({ ok: true, message: 'Guardado. Se aplica desde la próxima orden.' })
+      router.refresh()
+    } catch (err) {
+      setFeedback({ ok: false, message: err instanceof Error ? err.message : 'Error al guardar' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // Default the datetime-local input to value in yyyy-MM-ddThh:mm form
+  const exemptDefault = initial.commissionExemptUntil
+    ? new Date(initial.commissionExemptUntil).toISOString().slice(0, 16)
+    : ''
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-6">
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">
+          Porcentaje de comisión (%)
+        </span>
+        <input
+          name="commissionPercent"
+          type="number"
+          min={0}
+          max={100}
+          step={0.01}
+          defaultValue={initial.commissionPercent}
+          className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+        />
+        <span className="mt-1 block text-xs text-[color:var(--text-muted,#9ca3af)]">
+          Se aplica sobre el subtotal (no sobre envío ni impuestos). Default 5%.
+        </span>
+      </label>
+
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">
+          Comisión fija por orden (Gs)
+        </span>
+        <input
+          name="commissionFlatCents"
+          type="text"
+          defaultValue={String(initial.commissionFlatCents)}
+          placeholder="0"
+          className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+        />
+        <span className="mt-1 block text-xs text-[color:var(--text-muted,#9ca3af)]">
+          Se suma al porcentaje. Útil para cubrir costos fijos. Dejá en 0 si no aplicás.
+        </span>
+      </label>
+
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">
+          Exento hasta (período de prueba / promo gratis)
+        </span>
+        <input
+          name="commissionExemptUntil"
+          type="datetime-local"
+          defaultValue={exemptDefault}
+          className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+        />
+        <span className="mt-1 block text-xs text-[color:var(--text-muted,#9ca3af)]">
+          Durante este período no se aplica comisión. Default: el promo de 3 meses gratis. Dejá vacío para cobrar inmediatamente.
+        </span>
+      </label>
+
+      {feedback ? (
+        <p
+          role={feedback.ok ? 'status' : 'alert'}
+          className={`rounded p-3 text-sm ${feedback.ok ? 'bg-green-50 text-green-800' : 'bg-red-50 text-red-700'}`}
+        >
+          {feedback.message}
+        </p>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="rounded-lg bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+      >
+        {submitting ? 'Guardando…' : 'Guardar'}
+      </button>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary

Per-tenant commission config UI on top of PR #81's split-billing mechanism.

- \`GET/PUT /api/admin/billing/[businessId]/commission\` — Zod-validated, admin-auth required
- \`/admin/billing/[businessId]/commission\` — form with percent / flat fee / exempt-until datetime

## Stacked on #81

Merge order: #73 → #74 → #75 → #77 → #78 → #81 → **this** → #??? (PR 8, SaaS billing).

## Test plan

- [x] Typecheck clean on commerce paths
- [x] 66/66 unit tests still pass (no new tests — math is covered by commission.test.ts in #81)
- [ ] After merge: visit \`/admin/billing/<id>/commission\`, tweak values, verify a storefront order reflects the new commission

🤖 Generated with [Claude Code](https://claude.com/claude-code)