### PR TITLE
feat(billing): SaaS Pagopar Link-de-pago generator (PR 8/8)

### DIFF
--- a/web/app/admin/billing/[businessId]/subscription/page.tsx
+++ b/web/app/admin/billing/[businessId]/subscription/page.tsx
@@ -1,0 +1,127 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { SubscriptionLinkGenerator } from '@/components/admin/commerce/subscription-link-generator'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+interface BusinessRow {
+  id: string
+  slug: string
+  name: string
+  email: string | null
+  whatsapp: string | null
+  phone: string | null
+  owner_name: string | null
+}
+
+interface SubscriptionRow {
+  id: string
+  plan_tier: string
+  plan_name: string
+  price_monthly: number
+  status: string
+  current_period_start: string
+  current_period_end: string
+  mercadopago_payment_id: string | null
+}
+
+export default async function SubscriptionPage({
+  params,
+}: {
+  params: Promise<{ businessId: string }>
+}) {
+  const { businessId } = await params
+  const supabase = await createAdminClient()
+
+  const { data: business } = await supabase
+    .from('businesses')
+    .select('id, slug, name, email, whatsapp, phone, owner_name')
+    .eq('id', businessId)
+    .maybeSingle<BusinessRow>()
+
+  if (!business) notFound()
+
+  const { data: subscriptions } = await supabase
+    .from('subscriptions')
+    .select('*')
+    .eq('business_id', businessId)
+    .order('created_at', { ascending: false })
+    .limit(10)
+
+  const subs = (Array.isArray(subscriptions) ? subscriptions : []) as SubscriptionRow[]
+  const active = subs.find((s) => s.status === 'active' || s.status === 'trialing') ?? null
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <Link href={`/admin/commerce/${businessId}/products`} className="mb-4 inline-block text-sm text-[color:var(--primary,#111)] underline">
+        ← Volver al negocio
+      </Link>
+
+      <h1 className="mb-1 text-2xl font-bold">Suscripción Paragu-AI</h1>
+      <p className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">
+        <strong>{business.name}</strong> paga su plan vía Pagopar link de pago — generás un link y se lo enviás por WhatsApp al dueño del comercio.
+      </p>
+
+      {active ? (
+        <div className="mb-6 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-6">
+          <div className="mb-4 flex items-center justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Plan actual</p>
+              <p className="text-lg font-semibold">{active.plan_name}</p>
+            </div>
+            <span className="rounded bg-green-100 px-2 py-0.5 text-xs text-green-800">{active.status}</span>
+          </div>
+          <p className="text-sm text-[color:var(--text-muted,#6b7280)]">
+            Gs {Number(active.price_monthly).toLocaleString('es-PY')} · período actual {new Date(active.current_period_start).toLocaleDateString('es-PY')} → {new Date(active.current_period_end).toLocaleDateString('es-PY')}
+          </p>
+
+          <SubscriptionLinkGenerator
+            businessId={businessId}
+            subscriptionId={active.id}
+            planLabel={active.plan_name}
+            defaultAmountCents={Math.round(Number(active.price_monthly))}
+            defaultEmail={business.email ?? ''}
+            defaultName={business.owner_name ?? business.name}
+            defaultPhone={business.whatsapp ?? business.phone ?? ''}
+          />
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed border-[color:var(--border,#e5e7eb)] p-6 text-center text-sm text-[color:var(--text-muted,#6b7280)]">
+          Este negocio no tiene una suscripción activa. Creá una en Supabase o vía API antes de generar un link de pago.
+        </div>
+      )}
+
+      {subs.length > 0 ? (
+        <div>
+          <h2 className="mb-2 mt-8 text-sm font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Historial</h2>
+          <div className="overflow-x-auto rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)]">
+            <table className="w-full text-sm">
+              <thead className="bg-[color:var(--surface-muted,#f9fafb)] text-left">
+                <tr>
+                  <th className="px-4 py-2 font-semibold">Plan</th>
+                  <th className="px-4 py-2 font-semibold">Estado</th>
+                  <th className="px-4 py-2 font-semibold">Precio</th>
+                  <th className="px-4 py-2 font-semibold">Período</th>
+                </tr>
+              </thead>
+              <tbody>
+                {subs.map((s) => (
+                  <tr key={s.id} className="border-t border-[color:var(--border,#e5e7eb)]">
+                    <td className="px-4 py-2">{s.plan_name}</td>
+                    <td className="px-4 py-2">{s.status}</td>
+                    <td className="px-4 py-2">Gs {Number(s.price_monthly).toLocaleString('es-PY')}</td>
+                    <td className="px-4 py-2 text-[color:var(--text-muted,#6b7280)]">
+                      {new Date(s.current_period_start).toLocaleDateString('es-PY')} → {new Date(s.current_period_end).toLocaleDateString('es-PY')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/web/app/api/admin/billing/[businessId]/generate-link/route.ts
+++ b/web/app/api/admin/billing/[businessId]/generate-link/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { requireAdminUser } from '@/lib/commerce/admin-auth'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { generateSaasPaymentLink, buildWhatsAppShareUrl } from '@/lib/billing/paragu-ai-saas'
+
+export const runtime = 'nodejs'
+
+const BodySchema = z.object({
+  subscriptionId: z.string().uuid(),
+  planLabel: z.string().min(1).max(80),
+  amountCents: z.number().int().positive().max(100_000_000),
+  payerEmail: z.string().email(),
+  payerName: z.string().min(1).max(200),
+  payerPhone: z.string().min(6).max(30).optional(),
+})
+
+export const POST = withRequestLog<{ businessId: string }>(async (req, { log }, { businessId }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+  const parsed = BodySchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const supabase = await createAdminClient()
+  const { data: sub } = await supabase
+    .from('subscriptions')
+    .select('id, business_id')
+    .eq('id', parsed.data.subscriptionId)
+    .eq('business_id', businessId)
+    .maybeSingle()
+  if (!sub) return NextResponse.json({ error: 'subscription_not_found' }, { status: 404 })
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://paragu-ai.com'
+
+  try {
+    const link = await generateSaasPaymentLink({
+      businessId,
+      subscriptionId: parsed.data.subscriptionId,
+      planLabel: parsed.data.planLabel,
+      amountCents: parsed.data.amountCents,
+      payerEmail: parsed.data.payerEmail,
+      payerName: parsed.data.payerName,
+      payerPhone: parsed.data.payerPhone,
+      webhookUrl: `${appUrl}/api/webhooks/pagopar`,
+      returnUrl: `${appUrl}/admin/billing/${businessId}/subscription`,
+    })
+
+    const whatsAppUrl = parsed.data.payerPhone
+      ? buildWhatsAppShareUrl(parsed.data.payerPhone, link.url, parsed.data.planLabel)
+      : null
+
+    log.info('admin.saas.link_generated', {
+      businessId,
+      subscriptionId: parsed.data.subscriptionId,
+      amountCents: parsed.data.amountCents,
+    })
+
+    return NextResponse.json({
+      paymentUrl: link.url,
+      hashPedido: link.hashPedido,
+      orderNumber: link.orderNumber,
+      whatsAppUrl,
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'link_failed'
+    if (message === 'paragu_ai_pagopar_not_configured') {
+      return NextResponse.json({ error: 'paragu_ai_pagopar_not_configured' }, { status: 503 })
+    }
+    log.error('admin.saas.link_failed', err instanceof Error ? err : new Error(message))
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+})

--- a/web/components/admin/commerce/subscription-link-generator.tsx
+++ b/web/components/admin/commerce/subscription-link-generator.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Props {
+  businessId: string
+  subscriptionId: string
+  planLabel: string
+  defaultAmountCents: number
+  defaultEmail: string
+  defaultName: string
+  defaultPhone: string
+}
+
+interface GeneratedLink {
+  paymentUrl: string
+  hashPedido: string
+  orderNumber: string
+  whatsAppUrl: string | null
+}
+
+export function SubscriptionLinkGenerator(props: Props) {
+  const [generating, setGenerating] = useState(false)
+  const [link, setLink] = useState<GeneratedLink | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  async function generate(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setGenerating(true)
+    setError(null)
+    setLink(null)
+    const form = new FormData(event.currentTarget)
+
+    const payload = {
+      subscriptionId: props.subscriptionId,
+      planLabel: String(form.get('planLabel') ?? props.planLabel),
+      amountCents: parseInt(String(form.get('amountCents') ?? '0').replace(/[^0-9]/g, ''), 10) || 0,
+      payerEmail: String(form.get('payerEmail') ?? ''),
+      payerName: String(form.get('payerName') ?? ''),
+      payerPhone: String(form.get('payerPhone') ?? '').trim() || undefined,
+    }
+
+    try {
+      const res = await fetch(`/api/admin/billing/${props.businessId}/generate-link`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data.error ?? 'generate_failed')
+      setLink(data as GeneratedLink)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al generar el link')
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  async function copyLink() {
+    if (!link) return
+    await navigator.clipboard.writeText(link.paymentUrl)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="mt-4 rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface-muted,#f9fafb)] p-4">
+      <p className="mb-3 text-xs font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Generar link de pago</p>
+
+      <form onSubmit={generate} className="grid gap-3 sm:grid-cols-2">
+        <input type="hidden" name="planLabel" defaultValue={props.planLabel} />
+
+        <label className="block">
+          <span className="mb-1 block text-xs text-[color:var(--text-muted,#6b7280)]">Monto (Gs)</span>
+          <input
+            name="amountCents"
+            defaultValue={String(props.defaultAmountCents)}
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] bg-white px-3 py-2 text-sm"
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-xs text-[color:var(--text-muted,#6b7280)]">Teléfono WhatsApp</span>
+          <input
+            name="payerPhone"
+            defaultValue={props.defaultPhone}
+            placeholder="+595 9XX XXX XXX"
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] bg-white px-3 py-2 text-sm"
+          />
+        </label>
+
+        <label className="block sm:col-span-2">
+          <span className="mb-1 block text-xs text-[color:var(--text-muted,#6b7280)]">Nombre del pagador</span>
+          <input
+            name="payerName"
+            defaultValue={props.defaultName}
+            required
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] bg-white px-3 py-2 text-sm"
+          />
+        </label>
+
+        <label className="block sm:col-span-2">
+          <span className="mb-1 block text-xs text-[color:var(--text-muted,#6b7280)]">Email del pagador</span>
+          <input
+            name="payerEmail"
+            type="email"
+            defaultValue={props.defaultEmail}
+            required
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] bg-white px-3 py-2 text-sm"
+          />
+        </label>
+
+        <div className="sm:col-span-2">
+          <button
+            type="submit"
+            disabled={generating}
+            className="rounded-lg bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            {generating ? 'Generando…' : 'Generar link de pago'}
+          </button>
+        </div>
+      </form>
+
+      {error ? (
+        <p role="alert" className="mt-3 rounded bg-red-50 p-3 text-sm text-red-700">
+          {error === 'paragu_ai_pagopar_not_configured'
+            ? 'Falta configurar PARAGU_AI_PAGOPAR_PUBLIC_TOKEN / PRIVATE_TOKEN en /etc/paragu-ai/env.'
+            : error}
+        </p>
+      ) : null}
+
+      {link ? (
+        <div className="mt-4 space-y-3 rounded bg-white p-4 text-sm">
+          <div>
+            <span className="block text-xs text-[color:var(--text-muted,#6b7280)]">Link de pago (copialo y mandalo al cliente)</span>
+            <div className="mt-1 flex gap-2">
+              <input
+                readOnly
+                value={link.paymentUrl}
+                className="flex-1 rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface-muted,#f9fafb)] px-3 py-2 font-mono text-xs"
+              />
+              <button
+                type="button"
+                onClick={copyLink}
+                className="rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+              >
+                {copied ? 'Copiado ✓' : 'Copiar'}
+              </button>
+            </div>
+          </div>
+
+          {link.whatsAppUrl ? (
+            <a
+              href={link.whatsAppUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg bg-[#25d366] px-4 py-2 text-sm font-semibold text-white hover:bg-[#20b85a]"
+            >
+              Abrir chat de WhatsApp con el cliente
+            </a>
+          ) : null}
+
+          <p className="text-xs text-[color:var(--text-muted,#9ca3af)]">
+            Orden: <code>{link.orderNumber}</code> · Hash: <code>{link.hashPedido}</code>
+          </p>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/web/lib/billing/paragu-ai-saas.ts
+++ b/web/lib/billing/paragu-ai-saas.ts
@@ -1,0 +1,152 @@
+import { pagoparFetch, signPagopar } from '@/lib/payments/pagopar/client'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { logger } from '@/lib/logger'
+
+/**
+ * Paragu-AI SaaS billing via Pagopar "Link de pago".
+ *
+ * Flow: admin clicks "Generar link de pago" → we call Pagopar's
+ * iniciar-transaccion using Paragu-AI's OWN Pagopar tokens (distinct from
+ * the tenant's storefront tokens) with the tenant's plan amount → Pagopar
+ * returns hash_pedido → we build the URL https://www.pagopar.com/pagos/{hash}
+ * → admin sends it to the tenant via WhatsApp / email.
+ *
+ * When the tenant pays, Pagopar's webhook to /api/webhooks/pagopar fires
+ * with the hash_pedido. We differentiate SaaS-billing orders from
+ * storefront orders by prefix on id_pedido_comercio: "SAAS-<subscriptionId>"
+ * vs "PRG-YYYY-NNNNNN". The webhook handler picks up the prefix and
+ * routes to the subscriptions state machine instead of orders.
+ */
+
+export interface PaymentLink {
+  url: string
+  hashPedido: string
+  orderNumber: string
+  amountCents: number
+}
+
+export async function generateSaasPaymentLink(opts: {
+  businessId: string
+  subscriptionId: string
+  planLabel: string              // "Starter mensual", "Professional mensual"
+  amountCents: number            // whole PYG (e.g. 150000 = Gs 150.000)
+  payerEmail: string
+  payerName: string
+  payerPhone?: string
+  webhookUrl: string
+  returnUrl: string
+}): Promise<PaymentLink> {
+  const publicToken = process.env.PARAGU_AI_PAGOPAR_PUBLIC_TOKEN
+  const privateToken = process.env.PARAGU_AI_PAGOPAR_PRIVATE_TOKEN
+  if (!publicToken || !privateToken) {
+    throw new Error('paragu_ai_pagopar_not_configured')
+  }
+
+  const orderNumber = `SAAS-${opts.subscriptionId.slice(0, 8)}-${Date.now()}`
+  const token = signPagopar(privateToken, `${orderNumber}${opts.amountCents}`)
+
+  const body = {
+    token,
+    public_key: publicToken,
+    tipo_pedido: 'VENTA-COMERCIO',
+    id_pedido_comercio: orderNumber,
+    monto_total: opts.amountCents,
+    descripcion_resumen: `Paragu-AI — ${opts.planLabel}`,
+    url_retorno_exitoso: `${opts.returnUrl}?status=success`,
+    url_retorno_cancelado: `${opts.returnUrl}?status=failure`,
+    url_post_confirmacion: opts.webhookUrl,
+    comprador: {
+      email: opts.payerEmail,
+      nombre: opts.payerName,
+      telefono: opts.payerPhone ?? '',
+      documento: '0',
+      tipo_documento: 'CI',
+      ruc: '',
+      ciudad: 1,
+      direccion: '',
+      coordenadas: '',
+      razon_social: '',
+      direccion_referencia: '',
+    },
+    compras_items: [
+      {
+        nombre: `Paragu-AI · ${opts.planLabel}`,
+        id_producto: 1,
+        precio_total: opts.amountCents,
+        cantidad: 1,
+        descripcion: `Suscripción mensual al plan ${opts.planLabel}`,
+        url_imagen: '',
+        categoria: 909,
+        ciudad: 1,
+        public_key: publicToken,
+        vendedor_telefono: '',
+        vendedor_direccion: '',
+        vendedor_direccion_referencia: '',
+        vendedor_direccion_coordenadas: '',
+      },
+    ],
+  }
+
+  const response = await pagoparFetch<{
+    resultado: Array<{ hash_pedido?: string; hash?: string }>
+    respuesta: boolean
+    mensajes?: Array<{ mensaje?: string }>
+  }>('/api/comercios/2.0/iniciar-transaccion', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+
+  if (!response.respuesta) {
+    const message = response.mensajes?.[0]?.mensaje ?? 'unknown_pagopar_error'
+    throw new Error(`pagopar_saas_init_failed:${message}`)
+  }
+
+  const hashPedido = response.resultado?.[0]?.hash_pedido ?? response.resultado?.[0]?.hash
+  if (!hashPedido) throw new Error('pagopar_saas_init_no_hash')
+
+  logger.info('[saas] payment link generated', {
+    action: 'saas.billing.link_generated',
+    businessId: opts.businessId,
+    subscriptionId: opts.subscriptionId,
+    amountCents: opts.amountCents,
+    orderNumber,
+  })
+
+  // Track the link in the existing subscriptions.mercadopago_payment_id /
+  // mercadopago_order_id columns — we're repurposing them as generic
+  // "provider payment ref" columns because the schema was built around MP.
+  // A follow-up migration will rename these to provider_* once we've
+  // stabilized on Pagopar.
+  try {
+    const supabase = await createAdminClient()
+    await supabase
+      .from('subscriptions')
+      .update({
+        mercadopago_payment_id: hashPedido,
+        mercadopago_payer_id: orderNumber,
+      })
+      .eq('id', opts.subscriptionId)
+  } catch (err) {
+    // Non-blocking: the link still works; we just lose the backlink.
+    logger.warn('[saas] link persistence failed (non-blocking)', {
+      subscriptionId: opts.subscriptionId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+
+  return {
+    url: `https://www.pagopar.com/pagos/${hashPedido}`,
+    hashPedido,
+    orderNumber,
+    amountCents: opts.amountCents,
+  }
+}
+
+export function buildWhatsAppShareUrl(phone: string, paymentUrl: string, planLabel: string): string {
+  const body = encodeURIComponent(
+    `Hola 👋 Te paso el link de pago de tu suscripción ${planLabel} en Paragu-AI: ${paymentUrl}\n\n` +
+      `Es un link único, seguro y podés pagar con tarjeta, Tigo Money, Personal o en efectivo en Aquí Pago/Pago Express.`,
+  )
+  const cleanPhone = phone.replace(/[^0-9]/g, '')
+  return `https://wa.me/${cleanPhone}?text=${body}`
+}


### PR DESCRIPTION
## Summary

Completes the 3-flow money architecture. Flow A (tenant pays Paragu-AI) now has admin tooling.

Admin clicks "Generar link de pago" → server hits Pagopar iniciar-transaccion with Paragu-AI's own tokens → returns a hosted-checkout URL → admin copies + sends to tenant via WhatsApp.

## Files

- \`lib/billing/paragu-ai-saas.ts\` — \`generateSaasPaymentLink\` + \`buildWhatsAppShareUrl\`
- \`POST /api/admin/billing/[businessId]/generate-link\` — admin-auth, Zod-validated
- \`/admin/billing/[businessId]/subscription\` — subscription page w/ active plan + history + link generator
- \`SubscriptionLinkGenerator\` client component — copy-to-clipboard + WhatsApp deep link

## Per launch-source-of-truth

> Checkout deferred — WhatsApp-only sales for now.

This PR matches that decision. Future upgrade: Pagopar Suscripciones (auto-recurring charge) when ready.

## Stacked on #82 → #81 → #78 → #77 → #75 → #74 → #73

Merge order: #73 → #74 → #75 → #77 → #78 → #81 → #82 → **this**.

## Known follow-ups (not in this PR)

1. Webhook router: detect \`SAAS-*\` prefix in \`id_pedido_comercio\` → route to subscription state machine instead of storefront orders
2. Subscription lifecycle: trial → active → past_due → canceled
3. Rename \`subscriptions.mercadopago_payment_id\` → \`provider_payment_id\` (migration)

## Test plan

- [x] Typecheck clean on billing paths
- [x] 75/75 commerce+billing unit tests pass
- [ ] After merge: sign up Paragu-AI for its own Pagopar account, put tokens on VPS, generate a link for a real subscription, pay it with a sandbox card, confirm webhook fires (currently webhook handler doesn't know about SAAS prefix — that's a follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)