### PR TITLE
fix(prod): URL parse crashes + /nexaparaguay alias redirect

### DIFF
--- a/web/app/[business]/page.tsx
+++ b/web/app/[business]/page.tsx
@@ -16,6 +16,10 @@ import type { Metadata } from 'next'
  * Returns the locale-prefixed path if a matching site exists, else null.
  */
 function siteRedirectPath(slug: string): string | null {
+  // Legacy alias: /nexaparaguay (one-word) was the broken duplicate tenant
+  // before it was deleted. Anyone with the old URL bookmarked or in social
+  // graphs gets redirected to the canonical multi-locale route.
+  if (slug === 'nexaparaguay') return '/s/en/nexa-paraguay'
   try {
     const siteSlugs = listSiteSlugs()
     if (!siteSlugs.includes(slug)) return null

--- a/web/app/admin/demo-requests/page.tsx
+++ b/web/app/admin/demo-requests/page.tsx
@@ -162,7 +162,10 @@ export default async function DemoRequestsPage() {
                       {PRESENCE_LABEL[r.metadata?.presence ?? ''] ?? r.metadata?.presence ?? '—'}
                     </td>
                     <td className="px-4 py-3 text-xs text-gray-500">
-                      {r.referrer ? new URL(r.referrer).pathname : '—'}
+                      {(() => {
+                        if (!r.referrer) return '—'
+                        try { return new URL(r.referrer).pathname } catch { return r.referrer.slice(0, 60) }
+                      })()}
                     </td>
                     <td className="px-4 py-3 font-mono text-xs text-gray-500">
                       {r.lead_id?.slice(0, 8) ?? '—'}

--- a/web/app/api/cron/leads-digest/route.ts
+++ b/web/app/api/cron/leads-digest/route.ts
@@ -75,7 +75,16 @@ function buildHtml(rows: EventRow[]): string {
         hour: '2-digit',
         minute: '2-digit',
       })
-      const ref = r.referrer ? new URL(r.referrer).pathname : '—'
+      // Referrer is whatever the browser sent — sometimes "direct", sometimes
+      // a URL, sometimes garbage. Don't let one bad row blow up the digest.
+      let ref = '—'
+      if (r.referrer) {
+        try {
+          ref = new URL(r.referrer).pathname
+        } catch {
+          ref = r.referrer.slice(0, 60)
+        }
+      }
       return `
         <tr>
           <td style="padding:8px 12px; border-bottom:1px solid #eee; font-family:monospace; color:#666;">${escapeHtml(time)}</td>


### PR DESCRIPTION
Two bugs found by an end-to-end prospect-flow smoke test (Task #3 from "do it"):

1. `/api/cron/leads-digest` crashed with `Invalid URL` when an `analytics_events` row had a non-URL referrer. One bad row killed the entire daily digest. Wrapped in try/catch with a 60-char fallback. Same fix in `/admin/demo-requests` JSX.
2. `/nexaparaguay` returned **500** ("c.map is not a function") instead of redirecting. The duplicate tenant was deleted in PR #72 but the flat route still tried to render its content. Aliased explicitly to `/s/en/nexa-paraguay` in `siteRedirectPath`.

Funnel now end-to-end green: landing → `/p/[rubro]` → demo URLs → `/demo` → analytics track → leads-digest cron → email arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)