### PR TITLE
feat(registry+landing): close 15 P2-P5 rubro gaps + /p/ demo fallback

### DIFF
--- a/src/registry/copier_dealer_service.type.json
+++ b/src/registry/copier_dealer_service.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "copier_dealer_service",
+  "nameEs": "Fotocopiadoras e Impresoras",
+  "nameEn": "Copier & Printer Dealer",
+  "verticalId": "b2b-professional",
+  "subVertical": "office-equipment",
+  "extends": "professional_services_base",
+  "tokens": "copier_dealer_service",
+  "seo": {
+    "schemaType": "ProfessionalService",
+    "titleTemplate": "{{businessName}} - Fotocopiadoras e Impresoras en {{city}}",
+    "descriptionTemplate": "Venta, alquiler y mantenimiento de fotocopiadoras e impresoras para oficinas en {{city}}. Contratos por volumen y servicio tecnico.",
+    "keywords": [
+      "fotocopiadoras {{city}}",
+      "alquiler impresoras {{city}}",
+      "servicio tecnico copiadoras {{neighborhood}}",
+      "toner {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Fotocopiadoras e Impresoras",
+    "subheadlineTemplate": "Venta, alquiler y mantenimiento de equipos de oficina en {{city}}."
+  }
+}

--- a/src/registry/event_equipment_rental.type.json
+++ b/src/registry/event_equipment_rental.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "event_equipment_rental",
+  "nameEs": "Alquiler de Equipos para Eventos",
+  "nameEn": "Event Equipment Rental",
+  "verticalId": "arts-entertainment-venues",
+  "subVertical": "event-rental",
+  "extends": "entertainment_base",
+  "tokens": "event_equipment_rental",
+  "seo": {
+    "schemaType": "ProfessionalService",
+    "titleTemplate": "{{businessName}} - Alquiler de Equipos para Eventos en {{city}}",
+    "descriptionTemplate": "Alquiler de carpas, escenarios, mobiliario, iluminacion y sonido para eventos en {{city}}. Armado y desarme incluido.",
+    "keywords": [
+      "alquiler carpas {{city}}",
+      "alquiler escenarios {{city}}",
+      "alquiler mobiliario eventos {{neighborhood}}",
+      "alquiler iluminacion sonido {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Alquiler para Eventos",
+    "subheadlineTemplate": "Carpas, escenarios, mobiliario e iluminacion para tu evento en {{city}}."
+  }
+}

--- a/src/registry/event_staffing_hospitality.type.json
+++ b/src/registry/event_staffing_hospitality.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "event_staffing_hospitality",
+  "nameEs": "Personal Gastronomico para Eventos",
+  "nameEn": "Event Hospitality Staffing",
+  "verticalId": "food-beverage",
+  "subVertical": "event-staffing",
+  "extends": "restaurant",
+  "tokens": "event_staffing_hospitality",
+  "seo": {
+    "schemaType": "ProfessionalService",
+    "titleTemplate": "{{businessName}} - Personal Gastronomico para Eventos en {{city}}",
+    "descriptionTemplate": "Mozos, bartenders, cocineros y personal de servicio para eventos en {{city}}. Uniformados y con experiencia.",
+    "keywords": [
+      "mozos eventos {{city}}",
+      "bartender {{city}}",
+      "personal gastronomico {{neighborhood}}",
+      "servicio eventos {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Personal para Eventos",
+    "subheadlineTemplate": "Mozos, bartenders y cocineros profesionales para tu evento en {{city}}."
+  }
+}

--- a/src/registry/fitness_equipment_dealer.type.json
+++ b/src/registry/fitness_equipment_dealer.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "fitness_equipment_dealer",
+  "nameEs": "Venta de Equipos de Fitness",
+  "nameEn": "Fitness Equipment Dealer",
+  "verticalId": "retail-local",
+  "subVertical": "sporting-goods",
+  "extends": "retail_base",
+  "tokens": "fitness_equipment_dealer",
+  "seo": {
+    "schemaType": "Store",
+    "titleTemplate": "{{businessName}} - Equipos de Fitness en {{city}}",
+    "descriptionTemplate": "Venta de maquinas de gimnasio, pesas, cintas y accesorios en {{city}}. Envios e instalacion a domicilio.",
+    "keywords": [
+      "equipos fitness {{city}}",
+      "maquinas gimnasio {{city}}",
+      "pesas {{neighborhood}}",
+      "cinta correr {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Equipos de Fitness",
+    "subheadlineTemplate": "Maquinas, pesas y accesorios para tu gimnasio u hogar en {{city}}."
+  }
+}

--- a/src/registry/lubricentro.type.json
+++ b/src/registry/lubricentro.type.json
@@ -1,0 +1,23 @@
+{
+  "id": "lubricentro",
+  "nameEs": "Lubricentro",
+  "nameEn": "Oil Change & Lube Center",
+  "verticalId": "automotive",
+  "subVertical": "maintenance",
+  "extends": "automotive_base",
+  "tokens": "lubricentro",
+  "seo": {
+    "schemaType": "AutomotiveBusiness",
+    "titleTemplate": "{{businessName}} - Lubricentro en {{city}}",
+    "descriptionTemplate": "Cambio de aceite, filtros y lubricantes en {{city}}. Servicio rapido, atencion sin turno.",
+    "keywords": [
+      "lubricentro {{city}}",
+      "cambio de aceite {{city}}",
+      "lubricacion {{neighborhood}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Lubricentro",
+    "subheadlineTemplate": "Cambio de aceite y lubricacion profesional en {{city}}. Sin turno previo."
+  }
+}

--- a/src/registry/mechanics_trade_school.type.json
+++ b/src/registry/mechanics_trade_school.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "mechanics_trade_school",
+  "nameEs": "Escuela de Mecanica",
+  "nameEn": "Mechanics Trade School",
+  "verticalId": "education-training",
+  "subVertical": "trade-school",
+  "extends": "educacion",
+  "tokens": "mechanics_trade_school",
+  "seo": {
+    "schemaType": "EducationalOrganization",
+    "titleTemplate": "{{businessName}} - Escuela de Mecanica en {{city}}",
+    "descriptionTemplate": "Cursos de mecanica automotriz, diesel y motos en {{city}}. Practica en taller, certificacion oficial y salida laboral.",
+    "keywords": [
+      "escuela mecanica {{city}}",
+      "curso mecanica automotriz {{city}}",
+      "mecanica motos {{neighborhood}}",
+      "curso diesel {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Escuela de Mecanica",
+    "subheadlineTemplate": "Cursos practicos de mecanica con salida laboral en {{city}}."
+  }
+}

--- a/src/registry/orthopedic_supply.type.json
+++ b/src/registry/orthopedic_supply.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "orthopedic_supply",
+  "nameEs": "Ortopedia",
+  "nameEn": "Orthopedic Supply",
+  "verticalId": "health-wellness",
+  "subVertical": "medical-supply",
+  "extends": "health_wellness_base",
+  "tokens": "orthopedic_supply",
+  "seo": {
+    "schemaType": "MedicalBusiness",
+    "titleTemplate": "{{businessName}} - Ortopedia en {{city}}",
+    "descriptionTemplate": "Productos ortopedicos, sillas de ruedas, muletas, plantillas y fajas en {{city}}. Entrega a domicilio y obras sociales.",
+    "keywords": [
+      "ortopedia {{city}}",
+      "sillas de ruedas {{city}}",
+      "plantillas ortopedicas {{neighborhood}}",
+      "muletas andadores {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Ortopedia",
+    "subheadlineTemplate": "Productos ortopedicos con entrega a domicilio en {{city}}."
+  }
+}

--- a/src/registry/pet_transport_service.type.json
+++ b/src/registry/pet_transport_service.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "pet_transport_service",
+  "nameEs": "Traslado de Mascotas",
+  "nameEn": "Pet Transport Service",
+  "verticalId": "pets-animals",
+  "subVertical": "transport",
+  "extends": "pets_base",
+  "tokens": "pet_transport_service",
+  "seo": {
+    "schemaType": "ProfessionalService",
+    "titleTemplate": "{{businessName}} - Traslado de Mascotas en {{city}}",
+    "descriptionTemplate": "Traslados puerta a puerta para mascotas en {{city}}. Vehiculos acondicionados, personal capacitado, seguro incluido.",
+    "keywords": [
+      "traslado mascotas {{city}}",
+      "transporte perros {{city}}",
+      "traslado veterinaria {{neighborhood}}",
+      "pet taxi {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Traslado de Mascotas",
+    "subheadlineTemplate": "Traslados seguros y comodos para tu mascota en {{city}}."
+  }
+}

--- a/src/registry/photography_academy.type.json
+++ b/src/registry/photography_academy.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "photography_academy",
+  "nameEs": "Academia de Fotografia",
+  "nameEn": "Photography Academy",
+  "verticalId": "education-training",
+  "subVertical": "arts-training",
+  "extends": "educacion",
+  "tokens": "photography_academy",
+  "seo": {
+    "schemaType": "EducationalOrganization",
+    "titleTemplate": "{{businessName}} - Academia de Fotografia en {{city}}",
+    "descriptionTemplate": "Cursos de fotografia: basico, retrato, producto, bodas e iluminacion en {{city}}. Practica de estudio incluida, cupos reducidos.",
+    "keywords": [
+      "academia fotografia {{city}}",
+      "curso fotografia {{city}}",
+      "aprender fotografia {{neighborhood}}",
+      "curso iluminacion fotografica {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Academia de Fotografia",
+    "subheadlineTemplate": "Cursos de fotografia con practica de estudio en {{city}}."
+  }
+}

--- a/src/registry/prepaid_health_plan.type.json
+++ b/src/registry/prepaid_health_plan.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "prepaid_health_plan",
+  "nameEs": "Prepaga de Salud",
+  "nameEn": "Prepaid Health Plan",
+  "verticalId": "finance-insurance",
+  "subVertical": "health-insurance",
+  "extends": "finance_insurance_base",
+  "tokens": "prepaid_health_plan",
+  "seo": {
+    "schemaType": "InsuranceAgency",
+    "titleTemplate": "{{businessName}} - Prepaga de Salud en {{city}}",
+    "descriptionTemplate": "Planes de salud prepagos en {{city}}. Cobertura integral, red de prestadores, internacion y emergencias.",
+    "keywords": [
+      "prepaga salud {{city}}",
+      "medicina prepaga {{city}}",
+      "plan de salud {{neighborhood}}",
+      "cobertura medica {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Prepaga de Salud",
+    "subheadlineTemplate": "Planes de salud con cobertura integral en {{city}}."
+  }
+}

--- a/src/registry/tattoo_academy.type.json
+++ b/src/registry/tattoo_academy.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "tattoo_academy",
+  "nameEs": "Academia de Tatuajes",
+  "nameEn": "Tattoo Academy",
+  "verticalId": "education-training",
+  "subVertical": "arts-training",
+  "extends": "educacion",
+  "tokens": "tattoo_academy",
+  "seo": {
+    "schemaType": "EducationalOrganization",
+    "titleTemplate": "{{businessName}} - Academia de Tatuajes en {{city}}",
+    "descriptionTemplate": "Cursos de tatuaje desde cero hasta profesional en {{city}}. Tecnicas tradicionales, realismo, blackwork. Kit incluido y practica con modelos.",
+    "keywords": [
+      "academia tatuajes {{city}}",
+      "curso tatuaje {{city}}",
+      "aprender tatuar {{neighborhood}}",
+      "tattoo school {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Academia de Tatuajes",
+    "subheadlineTemplate": "Cursos profesionales de tatuaje, practica con modelos en {{city}}."
+  }
+}

--- a/src/registry/vending_water_dispenser_service.type.json
+++ b/src/registry/vending_water_dispenser_service.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "vending_water_dispenser_service",
+  "nameEs": "Dispensers y Maquinas Expendedoras",
+  "nameEn": "Vending & Water Dispenser Service",
+  "verticalId": "b2b-professional",
+  "subVertical": "office-equipment",
+  "extends": "professional_services_base",
+  "tokens": "vending_water_dispenser_service",
+  "seo": {
+    "schemaType": "ProfessionalService",
+    "titleTemplate": "{{businessName}} - Dispensers y Expendedoras en {{city}}",
+    "descriptionTemplate": "Dispensers de agua, maquinas de cafe y expendedoras de snacks para oficinas y empresas en {{city}}. Recarga mensual incluida.",
+    "keywords": [
+      "dispenser agua {{city}}",
+      "maquina cafe oficina {{city}}",
+      "vending machine {{neighborhood}}",
+      "expendedora snacks {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Dispensers y Expendedoras",
+    "subheadlineTemplate": "Dispensers de agua, cafe y snacks para tu oficina en {{city}}."
+  }
+}

--- a/src/registry/voice_over_studio.type.json
+++ b/src/registry/voice_over_studio.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "voice_over_studio",
+  "nameEs": "Estudio de Locucion",
+  "nameEn": "Voice-Over Studio",
+  "verticalId": "portfolio-professional",
+  "subVertical": "music-audio",
+  "extends": "diseno_grafico",
+  "tokens": "voice_over_studio",
+  "seo": {
+    "schemaType": "ProfessionalService",
+    "titleTemplate": "{{businessName}} - Estudio de Locucion en {{city}}",
+    "descriptionTemplate": "Locucion comercial, institucional y de personajes en {{city}}. Estudio profesional, entregas en 48hs, voces en espanol y guarani.",
+    "keywords": [
+      "locucion comercial {{city}}",
+      "voice over {{city}}",
+      "estudio grabacion voz {{neighborhood}}",
+      "locutor publicidad {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Estudio de Locucion",
+    "subheadlineTemplate": "Locucion profesional en espanol y guarani, entregas en 48hs. {{city}}."
+  }
+}

--- a/src/registry/watch_jeweler_shop.type.json
+++ b/src/registry/watch_jeweler_shop.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "watch_jeweler_shop",
+  "nameEs": "Relojeria y Joyeria",
+  "nameEn": "Watch & Jewelry Shop",
+  "verticalId": "retail-local",
+  "subVertical": "jewelry-accessories",
+  "extends": "retail_base",
+  "tokens": "watch_jeweler_shop",
+  "seo": {
+    "schemaType": "JewelryStore",
+    "titleTemplate": "{{businessName}} - Relojeria y Joyeria en {{city}}",
+    "descriptionTemplate": "Venta y reparacion de relojes y joyas en {{city}}. Cambio de malla, pila, pulido y tasacion.",
+    "keywords": [
+      "relojeria {{city}}",
+      "joyeria {{city}}",
+      "reparacion relojes {{neighborhood}}",
+      "cambio malla reloj {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Relojeria y Joyeria",
+    "subheadlineTemplate": "Venta y reparacion de relojes y joyas en {{city}}."
+  }
+}

--- a/src/registry/web_hosting_provider.type.json
+++ b/src/registry/web_hosting_provider.type.json
@@ -1,0 +1,24 @@
+{
+  "id": "web_hosting_provider",
+  "nameEs": "Hosting Web",
+  "nameEn": "Web Hosting Provider",
+  "verticalId": "technology-digital",
+  "subVertical": "infrastructure",
+  "extends": "technology_base",
+  "tokens": "web_hosting_provider",
+  "seo": {
+    "schemaType": "ProfessionalService",
+    "titleTemplate": "{{businessName}} - Hosting Web en {{city}}",
+    "descriptionTemplate": "Hosting, dominios y correo corporativo en {{city}}. Soporte local en espanol.",
+    "keywords": [
+      "hosting web {{city}}",
+      "dominios {{city}}",
+      "correo corporativo {{neighborhood}}",
+      "servidor dedicado {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}} - Hosting Web",
+    "subheadlineTemplate": "Hosting confiable con soporte local en {{city}}."
+  }
+}

--- a/web/app/p/[rubro]/page.tsx
+++ b/web/app/p/[rubro]/page.tsx
@@ -6,15 +6,38 @@ import { Container } from '@/components/ui/container'
 import { SiteNav } from '@/components/landing/site-nav'
 import { SiteFooter } from '@/components/landing/site-footer'
 import { LIVE_TEMPLATES, TEMPLATES, waLink, type Template } from '@/lib/landing/marketing-data'
+import { listSiteSlugs } from '@/lib/engine/site-loader'
 
 type Params = { rubro: string }
 
 function findTemplate(rubro: string): Template | undefined {
-  return LIVE_TEMPLATES.find((t) => (t.seoSlug ?? t.id.replace(/_/g, '-')) === rubro)
+  // Search full TEMPLATES (not just LIVE_TEMPLATES) so templates with only
+  // a batch-generated demo (demoSlug: null, but sites/demo-<rubro>/ exists)
+  // still resolve via the seoSlug/id match.
+  return TEMPLATES.find((t) => (t.seoSlug ?? t.id.replace(/_/g, '-')) === rubro)
+}
+
+// Returns the /demo/<rubro> href when a batch-generated demo tenant exists
+// for this rubro (see sites/_demo-roster.json + /demo/[rubro] route).
+// Used as a fallback when a template has no curated demoSlug.
+function batchDemoHref(rubro: string): string | null {
+  const slug = `demo-${rubro}`
+  return listSiteSlugs().includes(slug) ? `/demo/${rubro}` : null
 }
 
 export function generateStaticParams() {
-  return LIVE_TEMPLATES.map((t) => ({ rubro: t.seoSlug ?? t.id.replace(/_/g, '-') }))
+  // Include any template that has EITHER a curated demo (LIVE_TEMPLATES) OR
+  // a batch-generated demo tenant (sites/demo-<rubro>/). This opens up SEO
+  // landing pages for templates like inmobiliaria/maquillaje that were
+  // previously invisible because their curated demoSlug was null.
+  const demoSlugs = new Set(listSiteSlugs())
+  return TEMPLATES
+    .filter((t) => {
+      if (t.demoSlug !== null) return true
+      const rubro = t.seoSlug ?? t.id.replace(/_/g, '-')
+      return demoSlugs.has(`demo-${rubro}`)
+    })
+    .map((t) => ({ rubro: t.seoSlug ?? t.id.replace(/_/g, '-') }))
 }
 
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
@@ -47,6 +70,11 @@ export default async function VerticalLandingPage({ params }: { params: Promise<
     `Plantilla profesional pensada específicamente para ${t.name.toLowerCase()}. Vos no tocás nada — nosotros publicamos.`
 
   const waMessage = `Hola, me interesa la plantilla de ${t.name} para mi negocio en Paraguay.`
+
+  // Demo target priority: curated tenant slug wins (more polished copy/photos);
+  // fall back to the batch-generated /demo/<rubro> tenant when no curated one
+  // exists. Kept as a single button — users don't need to choose between demos.
+  const demoHref = t.demoSlug ? `/${t.demoSlug}` : batchDemoHref(rubro)
 
   const sister = LIVE_TEMPLATES.filter((x) => x.id !== t.id).slice(0, 4)
 
@@ -125,9 +153,9 @@ export default async function VerticalLandingPage({ params }: { params: Promise<
                   Pedir demo gratis
                   <ArrowRight size={20} className="transition-transform group-hover:translate-x-1" />
                 </a>
-                {t.demoSlug && (
+                {demoHref && (
                   <Link
-                    href={`/${t.demoSlug}`}
+                    href={demoHref}
                     className="inline-flex items-center gap-2 rounded-2xl border-2 border-[var(--border)] bg-[var(--surface)] px-8 py-4 text-lg font-bold text-[var(--text)] transition-all hover:border-[var(--primary)] hover:text-[var(--primary)]"
                   >
                     Ver demo en vivo


### PR DESCRIPTION
## Summary
Paired change that completes the Paraguay rubro coverage started in PR #85:

1. **Close 15 P2–P5 registry gaps** — combined with PR #85's P1 closures, the leads repo `PARAGUAY_RUBROS_TAXONOMY.md` §4 is now 100% covered. Every rubro in the ClasiPar-style directory has a matching `type.json`.
2. **Make `/p/[rubro]` resilient** — fall back to `/demo/<rubro>` when a template has no curated `demoSlug`, and widen `generateStaticParams` to include templates that only have a batch demo.

## Registry additions (15)
| Slug | Vertical | Covers dir ID |
|---|---|---|
| `lubricentro` | automotive | 103 |
| `fitness_equipment_dealer` | retail-local | 138 |
| `watch_jeweler_shop` | retail-local | 152 |
| `web_hosting_provider` | technology-digital | 150 |
| `event_equipment_rental` | arts-entertainment-venues | 68/69/70/72 (covers 4 as variants) |
| `event_staffing_hospitality` | food-beverage | 77 |
| `pet_transport_service` | pets-animals | 133 |
| `copier_dealer_service` | b2b-professional | 139 |
| `vending_water_dispenser_service` | b2b-professional | 137 |
| `orthopedic_supply` | health-wellness | 115 |
| `prepaid_health_plan` | finance-insurance | 112 |
| `mechanics_trade_school` | education-training | 59 |
| `tattoo_academy` | education-training | 60 |
| `photography_academy` | education-training | 54 |
| `voice_over_studio` | portfolio-professional | 41 |

All follow the minimal extends-from-base pattern established in PR #85.

## /p/[rubro] changes
- **`findTemplate`** now searches `TEMPLATES` (not just `LIVE_TEMPLATES`) — templates with `demoSlug: null` can still resolve
- **`generateStaticParams`** includes any template where either a curated demo exists OR `sites/demo-<rubro>/` exists — this unlocks SEO landing pages for `/p/inmobiliaria`, `/p/maquillaje`, etc.
- **`batchDemoHref(rubro)`** helper checks `sites/demo-<rubro>/` via `listSiteSlugs()` and returns `/demo/<rubro>` if present
- **`demoHref`** prefers the curated `t.demoSlug` when set; falls back to `batchDemoHref(rubro)`. Single button — no UX clutter

Effect: templates like `inmobiliaria` (demoSlug: null, but `sites/demo-inmobiliaria/` was created in PR #85) now have a working `/p/inmobiliaria` page with a "Ver demo en vivo" button → `/demo/inmobiliaria`.

## Validation
- `npm run validate:sites` → **115/115 OK** (no tenant regressions)
- `validate-registry.ts` has pre-existing module resolution error unrelated to this change — NOT introduced here

## Out of scope / follow-up
- 72 country×cluster compliance templates (blocks Wave 3 promotion — tracked in leads repo `LATAM_RUBROS_LANDSCAPE.md §5`)
- Admin filters on `demo: true` / `demoWave` in `/admin/tiles` + `/admin/leads`
- Marketing copy for the newly-live `/p/<rubro>` pages (currently falls back to generic `seoHeadline`)

## Test plan
- [ ] `npm run validate:sites` → 115 OK
- [ ] `npm run typecheck` passes
- [ ] `npm run build` — confirm `/p/inmobiliaria` prerenders (previously didn't)
- [ ] `/p/peluqueria` still links to the curated demo (`/salon-maria`), not the batch demo
- [ ] `/p/inmobiliaria` renders with the batch demo button → `/demo/inmobiliaria`

🤖 Generated with [Claude Code](https://claude.com/claude-code)