### PR TITLE
feat(commerce): credentials + commission + SaaS billing (consolidated)

### DIFF
--- a/src/registry/relocation.type.json
+++ b/src/registry/relocation.type.json
@@ -167,5 +167,24 @@
       "text": "Ver paquetes",
       "action": "scrollTo:packages"
     }
+  },
+  "commerce": {
+    "enabled": true,
+    "launchPhase": "pilot",
+    "provider": "pagopar",
+    "currency": "PYG",
+    "catalog": {
+      "source": "supabase"
+    },
+    "checkout": {
+      "anonymousAllowed": true,
+      "shippingRequired": false,
+      "phoneRequired": true
+    },
+    "shopperUx": {
+      "productAspectRatio": "4:5",
+      "showLowStockBadge": false,
+      "showWhatsappShare": true
+    }
   }
 }

--- a/supabase/migrations/20260422000100_business_payment_credentials.sql
+++ b/supabase/migrations/20260422000100_business_payment_credentials.sql
@@ -1,0 +1,35 @@
+-- =============================================================================
+-- Per-business payment credentials (PR 4 of 5)
+-- =============================================================================
+-- Each merchant brings their own Pagopar (and eventually MP/dLocal) tokens.
+-- Tokens are encrypted in the app layer with AES-256-GCM keyed by
+-- COMMERCE_CREDENTIALS_KEY before insert; the DB sees only ciphertext + iv +
+-- tag JSON. RLS = service_role only — never reachable from anon/authenticated.
+-- =============================================================================
+
+CREATE TABLE business_payment_credentials (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  business_id UUID NOT NULL REFERENCES businesses(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL CHECK (provider IN ('pagopar', 'bancard', 'dlocal', 'manual')),
+  -- Encrypted credentials blob: { fields: { name: { iv, ct, tag } } }
+  encrypted_secrets JSONB NOT NULL,
+  -- Non-secret per-provider config (environment, region, public key safe to log).
+  public_config JSONB NOT NULL DEFAULT '{}'::jsonb,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'paused', 'archived')),
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (business_id, provider)
+);
+
+CREATE INDEX idx_payment_creds_business_active
+  ON business_payment_credentials(business_id, provider)
+  WHERE status = 'active';
+
+ALTER TABLE business_payment_credentials ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Service role full access" ON business_payment_credentials
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE TRIGGER business_payment_credentials_updated_at
+  BEFORE UPDATE ON business_payment_credentials
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/supabase/migrations/20260422000200_business_commission.sql
+++ b/supabase/migrations/20260422000200_business_commission.sql
@@ -1,0 +1,26 @@
+-- =============================================================================
+-- Platform commission on tenant sales (PR 6 of 8)
+-- =============================================================================
+-- Pagopar split billing at the gateway: each order becomes tipo_pedido
+-- "COMERCIO-HEREDADO" and we prepend a commission compras_items entry with
+-- Paragu-AI's own public_key. Pagopar settles the tenant's share to their
+-- bank, our commission to Paragu-AI's bank — we never hold the money.
+--
+-- commission_percent: 0.00–100.00, default 5.00 (5%)
+-- commission_flat_cents: fixed PYG fee per order, default 0
+-- commission_exempt_until: during the 3-month free-premium window, no
+--   commission line is added. NULL means "not exempt".
+-- =============================================================================
+
+ALTER TABLE businesses
+  ADD COLUMN commission_percent NUMERIC(5,2) NOT NULL DEFAULT 5.00
+    CHECK (commission_percent >= 0 AND commission_percent <= 100),
+  ADD COLUMN commission_flat_cents INTEGER NOT NULL DEFAULT 0
+    CHECK (commission_flat_cents >= 0),
+  ADD COLUMN commission_exempt_until TIMESTAMPTZ;
+
+-- Index for fast lookup when building storefront analytics ("how much
+-- commission did we earn from businesses NOT in the free-premium window").
+CREATE INDEX idx_businesses_commission_exempt
+  ON businesses(commission_exempt_until)
+  WHERE commission_exempt_until IS NOT NULL;

--- a/web/app/admin/billing/[businessId]/commission/page.tsx
+++ b/web/app/admin/billing/[businessId]/commission/page.tsx
@@ -1,0 +1,49 @@
+import { notFound } from 'next/navigation'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { CommissionSettingsForm } from '@/components/admin/commerce/commission-settings-form'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+interface BusinessRow {
+  id: string
+  slug: string
+  name: string
+  commission_percent: number
+  commission_flat_cents: number
+  commission_exempt_until: string | null
+}
+
+export default async function CommissionSettingsPage({
+  params,
+}: {
+  params: Promise<{ businessId: string }>
+}) {
+  const { businessId } = await params
+  const supabase = await createAdminClient()
+  const { data } = await supabase
+    .from('businesses')
+    .select('id, slug, name, commission_percent, commission_flat_cents, commission_exempt_until')
+    .eq('id', businessId)
+    .maybeSingle<BusinessRow>()
+
+  if (!data) notFound()
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <h1 className="mb-1 text-2xl font-bold">Comisión</h1>
+      <p className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">
+        Configurá cuánto se queda Paragu-AI por cada venta en la tienda de <strong>{data.name}</strong>. La comisión se cobra vía Pagopar split billing — el tenant recibe su parte y Paragu-AI la suya, sin que nosotros manejemos el dinero.
+      </p>
+
+      <CommissionSettingsForm
+        businessId={businessId}
+        initial={{
+          commissionPercent: data.commission_percent,
+          commissionFlatCents: data.commission_flat_cents,
+          commissionExemptUntil: data.commission_exempt_until,
+        }}
+      />
+    </div>
+  )
+}

--- a/web/app/admin/billing/[businessId]/subscription/page.tsx
+++ b/web/app/admin/billing/[businessId]/subscription/page.tsx
@@ -1,0 +1,143 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { BankTransferInstructions } from '@/components/admin/commerce/bank-transfer-instructions'
+import { SubscriptionLinkGenerator } from '@/components/admin/commerce/subscription-link-generator'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+interface BusinessRow {
+  id: string
+  slug: string
+  name: string
+  email: string | null
+  whatsapp: string | null
+  phone: string | null
+  owner_name: string | null
+}
+
+interface SubscriptionRow {
+  id: string
+  plan_tier: string
+  plan_name: string
+  price_monthly: number
+  status: string
+  current_period_start: string
+  current_period_end: string
+  mercadopago_payment_id: string | null
+}
+
+export default async function SubscriptionPage({
+  params,
+}: {
+  params: Promise<{ businessId: string }>
+}) {
+  const { businessId } = await params
+  const supabase = await createAdminClient()
+
+  const { data: business } = await supabase
+    .from('businesses')
+    .select('id, slug, name, email, whatsapp, phone, owner_name')
+    .eq('id', businessId)
+    .maybeSingle<BusinessRow>()
+
+  if (!business) notFound()
+
+  const { data: subscriptions } = await supabase
+    .from('subscriptions')
+    .select('*')
+    .eq('business_id', businessId)
+    .order('created_at', { ascending: false })
+    .limit(10)
+
+  const subs = (Array.isArray(subscriptions) ? subscriptions : []) as SubscriptionRow[]
+  const active = subs.find((s) => s.status === 'active' || s.status === 'trialing') ?? null
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <Link href={`/admin/commerce/${businessId}/products`} className="mb-4 inline-block text-sm text-[color:var(--primary,#111)] underline">
+        ← Volver al negocio
+      </Link>
+
+      <h1 className="mb-1 text-2xl font-bold">Suscripción Paragu-AI</h1>
+      <p className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">
+        <strong>{business.name}</strong> paga su plan por transferencia al alias y manda el comprobante por WhatsApp. Lo activás manualmente una vez que confirmás el comprobante.
+      </p>
+
+      {active ? (
+        <div className="mb-6 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-6">
+          <div className="mb-4 flex items-center justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Plan actual</p>
+              <p className="text-lg font-semibold">{active.plan_name}</p>
+            </div>
+            <span className="rounded bg-green-100 px-2 py-0.5 text-xs text-green-800">{active.status}</span>
+          </div>
+          <p className="text-sm text-[color:var(--text-muted,#6b7280)]">
+            Gs {Number(active.price_monthly).toLocaleString('es-PY')} · período actual {new Date(active.current_period_start).toLocaleDateString('es-PY')} → {new Date(active.current_period_end).toLocaleDateString('es-PY')}
+          </p>
+
+          <BankTransferInstructions
+            businessName={business.name}
+            planLabel={active.plan_name}
+            defaultAmountCents={Math.round(Number(active.price_monthly))}
+            tenantWhatsapp={business.whatsapp ?? business.phone ?? null}
+          />
+
+          <details className="mt-4 rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface-muted,#f9fafb)] p-3 text-sm">
+            <summary className="cursor-pointer text-xs font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">
+              Avanzado — generar link Pagopar (requiere PARAGU_AI_PAGOPAR_* en env)
+            </summary>
+            <div className="mt-3 text-xs text-[color:var(--text-muted,#6b7280)]">
+              Usá esto si el cliente prefiere pagar con tarjeta o efectivo en Pago Express/Aquí Pago. Si todavía no configuraste la cuenta Pagopar de Paragu-AI, el botón va a fallar con <code>paragu_ai_pagopar_not_configured</code> — está bien, es el default. Priorizá la transferencia de arriba.
+            </div>
+            <SubscriptionLinkGenerator
+              businessId={businessId}
+              subscriptionId={active.id}
+              planLabel={active.plan_name}
+              defaultAmountCents={Math.round(Number(active.price_monthly))}
+              defaultEmail={business.email ?? ''}
+              defaultName={business.owner_name ?? business.name}
+              defaultPhone={business.whatsapp ?? business.phone ?? ''}
+            />
+          </details>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed border-[color:var(--border,#e5e7eb)] p-6 text-center text-sm text-[color:var(--text-muted,#6b7280)]">
+          Este negocio no tiene una suscripción activa. Creá una en Supabase o vía API antes de cobrarle.
+        </div>
+      )}
+
+      {subs.length > 0 ? (
+        <div>
+          <h2 className="mb-2 mt-8 text-sm font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Historial</h2>
+          <div className="overflow-x-auto rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)]">
+            <table className="w-full text-sm">
+              <thead className="bg-[color:var(--surface-muted,#f9fafb)] text-left">
+                <tr>
+                  <th className="px-4 py-2 font-semibold">Plan</th>
+                  <th className="px-4 py-2 font-semibold">Estado</th>
+                  <th className="px-4 py-2 font-semibold">Precio</th>
+                  <th className="px-4 py-2 font-semibold">Período</th>
+                </tr>
+              </thead>
+              <tbody>
+                {subs.map((s) => (
+                  <tr key={s.id} className="border-t border-[color:var(--border,#e5e7eb)]">
+                    <td className="px-4 py-2">{s.plan_name}</td>
+                    <td className="px-4 py-2">{s.status}</td>
+                    <td className="px-4 py-2">Gs {Number(s.price_monthly).toLocaleString('es-PY')}</td>
+                    <td className="px-4 py-2 text-[color:var(--text-muted,#6b7280)]">
+                      {new Date(s.current_period_start).toLocaleDateString('es-PY')} → {new Date(s.current_period_end).toLocaleDateString('es-PY')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/web/app/admin/commerce/[businessId]/payments/page.tsx
+++ b/web/app/admin/commerce/[businessId]/payments/page.tsx
@@ -1,0 +1,24 @@
+import { listCredentialsForBusiness } from '@/lib/commerce/payment-credentials'
+import { PaymentCredentialsManager } from '@/components/admin/commerce/payment-credentials-manager'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export default async function AdminPaymentsPage({
+  params,
+}: {
+  params: Promise<{ businessId: string }>
+}) {
+  const { businessId } = await params
+  const credentials = await listCredentialsForBusiness(businessId)
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <h1 className="mb-2 text-2xl font-bold">Métodos de pago</h1>
+      <p className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">
+        Conectá tus credenciales de Pagopar (y opcionalmente Bancard o dLocal) para que tu tienda pueda cobrar. Las claves se guardan cifradas; nunca las mostramos completas después de guardarlas.
+      </p>
+      <PaymentCredentialsManager businessId={businessId} initialCredentials={credentials} />
+    </div>
+  )
+}

--- a/web/app/api/admin/billing/[businessId]/commission/route.ts
+++ b/web/app/api/admin/billing/[businessId]/commission/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { requireAdminUser } from '@/lib/commerce/admin-auth'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+export const runtime = 'nodejs'
+
+const PutSchema = z.object({
+  commissionPercent: z.number().min(0).max(100),
+  commissionFlatCents: z.number().int().nonnegative().max(100_000_000),
+  commissionExemptUntil: z
+    .union([z.string().datetime(), z.null()])
+    .optional(),
+})
+
+export const GET = withRequestLog<{ businessId: string }>(async (_req, _ctx, { businessId }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const supabase = await createAdminClient()
+  const { data, error } = await supabase
+    .from('businesses')
+    .select('id, slug, name, commission_percent, commission_flat_cents, commission_exempt_until')
+    .eq('id', businessId)
+    .maybeSingle()
+
+  if (error || !data) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    businessId: data.id,
+    slug: data.slug,
+    name: data.name,
+    commissionPercent: data.commission_percent,
+    commissionFlatCents: data.commission_flat_cents,
+    commissionExemptUntil: data.commission_exempt_until,
+  })
+})
+
+export const PUT = withRequestLog<{ businessId: string }>(async (req, { log }, { businessId }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+
+  const parsed = PutSchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const supabase = await createAdminClient()
+  const { error } = await supabase
+    .from('businesses')
+    .update({
+      commission_percent: parsed.data.commissionPercent,
+      commission_flat_cents: parsed.data.commissionFlatCents,
+      commission_exempt_until: parsed.data.commissionExemptUntil ?? null,
+    })
+    .eq('id', businessId)
+
+  if (error) {
+    log.error('admin.commerce.commission.update_failed', new Error(error.message))
+    return NextResponse.json({ error: 'update_failed' }, { status: 500 })
+  }
+
+  log.info('admin.commerce.commission.updated', {
+    businessId,
+    percent: parsed.data.commissionPercent,
+    flatCents: parsed.data.commissionFlatCents,
+    exemptUntil: parsed.data.commissionExemptUntil,
+  })
+
+  return NextResponse.json({ ok: true })
+})

--- a/web/app/api/admin/billing/[businessId]/generate-link/route.ts
+++ b/web/app/api/admin/billing/[businessId]/generate-link/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { requireAdminUser } from '@/lib/commerce/admin-auth'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { generateSaasPaymentLink, buildWhatsAppShareUrl } from '@/lib/billing/paragu-ai-saas'
+
+export const runtime = 'nodejs'
+
+const BodySchema = z.object({
+  subscriptionId: z.string().uuid(),
+  planLabel: z.string().min(1).max(80),
+  amountCents: z.number().int().positive().max(100_000_000),
+  payerEmail: z.string().email(),
+  payerName: z.string().min(1).max(200),
+  payerPhone: z.string().min(6).max(30).optional(),
+})
+
+export const POST = withRequestLog<{ businessId: string }>(async (req, { log }, { businessId }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+  const parsed = BodySchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const supabase = await createAdminClient()
+  const { data: sub } = await supabase
+    .from('subscriptions')
+    .select('id, business_id')
+    .eq('id', parsed.data.subscriptionId)
+    .eq('business_id', businessId)
+    .maybeSingle()
+  if (!sub) return NextResponse.json({ error: 'subscription_not_found' }, { status: 404 })
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://paragu-ai.com'
+
+  try {
+    const link = await generateSaasPaymentLink({
+      businessId,
+      subscriptionId: parsed.data.subscriptionId,
+      planLabel: parsed.data.planLabel,
+      amountCents: parsed.data.amountCents,
+      payerEmail: parsed.data.payerEmail,
+      payerName: parsed.data.payerName,
+      payerPhone: parsed.data.payerPhone,
+      webhookUrl: `${appUrl}/api/webhooks/pagopar`,
+      returnUrl: `${appUrl}/admin/billing/${businessId}/subscription`,
+    })
+
+    const whatsAppUrl = parsed.data.payerPhone
+      ? buildWhatsAppShareUrl(parsed.data.payerPhone, link.url, parsed.data.planLabel)
+      : null
+
+    log.info('admin.saas.link_generated', {
+      businessId,
+      subscriptionId: parsed.data.subscriptionId,
+      amountCents: parsed.data.amountCents,
+    })
+
+    return NextResponse.json({
+      paymentUrl: link.url,
+      hashPedido: link.hashPedido,
+      orderNumber: link.orderNumber,
+      whatsAppUrl,
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'link_failed'
+    if (message === 'paragu_ai_pagopar_not_configured') {
+      return NextResponse.json({ error: 'paragu_ai_pagopar_not_configured' }, { status: 503 })
+    }
+    log.error('admin.saas.link_failed', err instanceof Error ? err : new Error(message))
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+})

--- a/web/app/api/admin/commerce/[businessId]/payment-credentials/route.ts
+++ b/web/app/api/admin/commerce/[businessId]/payment-credentials/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { requireAdminUser } from '@/lib/commerce/admin-auth'
+import {
+  upsertCredentials,
+  listCredentialsForBusiness,
+  deleteCredentials,
+} from '@/lib/commerce/payment-credentials'
+import { PaymentProviderSchema } from '@/lib/schemas/commerce/transaction'
+
+export const runtime = 'nodejs'
+
+const PutSchema = z.object({
+  provider: PaymentProviderSchema,
+  // secrets is a free-form key/value map; provider-specific shape is
+  // validated in the UI form. Empty values get filtered out so a partial
+  // update doesn't accidentally wipe a token.
+  secrets: z.record(z.string(), z.string().min(1)),
+  publicConfig: z.record(z.string(), z.unknown()).optional(),
+  notes: z.string().max(500).optional(),
+  status: z.enum(['active', 'paused', 'archived']).optional(),
+})
+
+const DeleteSchema = z.object({
+  provider: PaymentProviderSchema,
+})
+
+export const GET = withRequestLog<{ businessId: string }>(async (_req, _ctx, { businessId }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const credentials = await listCredentialsForBusiness(businessId)
+  return NextResponse.json({ credentials })
+})
+
+export const PUT = withRequestLog<{ businessId: string }>(async (req, { log }, { businessId }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+
+  const parsed = PutSchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+  }
+
+  try {
+    const record = await upsertCredentials({ businessId, ...parsed.data })
+    log.info('admin.commerce.credentials.upserted', { businessId, provider: parsed.data.provider })
+    return NextResponse.json({ credential: record })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'upsert_failed'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+})
+
+export const DELETE = withRequestLog<{ businessId: string }>(async (req, { log }, { businessId }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+
+  const parsed = DeleteSchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation' }, { status: 400 })
+  }
+
+  try {
+    await deleteCredentials(businessId, parsed.data.provider)
+    log.info('admin.commerce.credentials.deleted', { businessId, provider: parsed.data.provider })
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : 'delete_failed' }, { status: 500 })
+  }
+})

--- a/web/components/admin/commerce/bank-transfer-instructions.tsx
+++ b/web/components/admin/commerce/bank-transfer-instructions.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  PARAGU_AI_BANK_ALIAS,
+  PARAGU_AI_COMPROBANTE_WHATSAPP,
+  buildSaasOutreachMessage,
+  buildSaasOutreachWhatsAppUrl,
+} from '@/lib/billing/paragu-ai-bank'
+
+interface Props {
+  businessName: string
+  planLabel: string
+  defaultAmountCents: number
+  tenantWhatsapp: string | null
+}
+
+export function BankTransferInstructions(props: Props) {
+  const [amountCents, setAmountCents] = useState(String(props.defaultAmountCents))
+  const [customPlan, setCustomPlan] = useState(props.planLabel)
+  const [copied, setCopied] = useState<'alias' | 'whatsapp' | 'message' | null>(null)
+
+  const parsedAmount = parseInt(amountCents.replace(/[^0-9]/g, ''), 10) || 0
+
+  const messageBody = buildSaasOutreachMessage({
+    businessName: props.businessName,
+    planLabel: customPlan,
+    amountCents: parsedAmount,
+  })
+
+  const waUrl = props.tenantWhatsapp
+    ? buildSaasOutreachWhatsAppUrl(props.tenantWhatsapp, {
+        businessName: props.businessName,
+        planLabel: customPlan,
+        amountCents: parsedAmount,
+      })
+    : null
+
+  async function copy(which: 'alias' | 'whatsapp' | 'message', value: string) {
+    await navigator.clipboard.writeText(value)
+    setCopied(which)
+    setTimeout(() => setCopied(null), 2000)
+  }
+
+  return (
+    <div className="mt-4 space-y-4 rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface-muted,#f9fafb)] p-4">
+      <header>
+        <p className="text-xs font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Cobrar al cliente</p>
+        <h3 className="mt-1 text-base font-semibold">Transferencia bancaria + comprobante por WhatsApp</h3>
+        <p className="mt-1 text-xs text-[color:var(--text-muted,#6b7280)]">
+          El cliente transfiere al alias, te manda el comprobante por WhatsApp, y vos activás la suscripción manualmente. Para automatizar con Pagopar: mirá la opción avanzada abajo.
+        </p>
+      </header>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="block">
+          <span className="mb-1 block text-xs text-[color:var(--text-muted,#6b7280)]">Plan (texto para el mensaje)</span>
+          <input
+            value={customPlan}
+            onChange={(e) => setCustomPlan(e.target.value)}
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] bg-white px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs text-[color:var(--text-muted,#6b7280)]">Monto (Gs)</span>
+          <input
+            value={amountCents}
+            onChange={(e) => setAmountCents(e.target.value)}
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] bg-white px-3 py-2 text-sm font-mono"
+          />
+        </label>
+      </div>
+
+      <section className="grid gap-2 rounded bg-white p-4 text-sm">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-xs text-[color:var(--text-muted,#6b7280)]">Alias de transferencia</p>
+            <p className="font-mono">{PARAGU_AI_BANK_ALIAS}</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => copy('alias', PARAGU_AI_BANK_ALIAS)}
+            className="rounded border border-[color:var(--border,#e5e7eb)] px-3 py-1 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+          >
+            {copied === 'alias' ? 'Copiado ✓' : 'Copiar'}
+          </button>
+        </div>
+        <div className="flex items-center justify-between gap-3 border-t border-[color:var(--border,#e5e7eb)] pt-2">
+          <div>
+            <p className="text-xs text-[color:var(--text-muted,#6b7280)]">WhatsApp para el comprobante</p>
+            <p className="font-mono">{PARAGU_AI_COMPROBANTE_WHATSAPP}</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => copy('whatsapp', PARAGU_AI_COMPROBANTE_WHATSAPP)}
+            className="rounded border border-[color:var(--border,#e5e7eb)] px-3 py-1 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+          >
+            {copied === 'whatsapp' ? 'Copiado ✓' : 'Copiar'}
+          </button>
+        </div>
+      </section>
+
+      <section>
+        <div className="mb-2 flex items-center justify-between">
+          <p className="text-xs font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Mensaje para enviar</p>
+          <button
+            type="button"
+            onClick={() => copy('message', messageBody)}
+            className="rounded border border-[color:var(--border,#e5e7eb)] px-3 py-1 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+          >
+            {copied === 'message' ? 'Copiado ✓' : 'Copiar mensaje'}
+          </button>
+        </div>
+        <textarea
+          readOnly
+          value={messageBody}
+          rows={14}
+          className="block w-full rounded border border-[color:var(--border,#e5e7eb)] bg-white px-3 py-2 font-mono text-xs leading-relaxed"
+        />
+      </section>
+
+      <div className="flex flex-wrap gap-3">
+        {waUrl ? (
+          <a
+            href={waUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg bg-[#25d366] px-4 py-2 text-sm font-semibold text-white hover:bg-[#20b85a]"
+          >
+            Abrir WhatsApp con el cliente
+          </a>
+        ) : (
+          <p className="text-xs text-[color:var(--text-muted,#9ca3af)]">
+            El negocio no tiene WhatsApp cargado — copiá el mensaje y enviálo manualmente.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/components/admin/commerce/commission-settings-form.tsx
+++ b/web/components/admin/commerce/commission-settings-form.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface InitialValues {
+  commissionPercent: number
+  commissionFlatCents: number
+  commissionExemptUntil: string | null
+}
+
+export function CommissionSettingsForm({
+  businessId,
+  initial,
+}: {
+  businessId: string
+  initial: InitialValues
+}) {
+  const router = useRouter()
+  const [submitting, setSubmitting] = useState(false)
+  const [feedback, setFeedback] = useState<{ ok: boolean; message: string } | null>(null)
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setSubmitting(true)
+    setFeedback(null)
+    const form = new FormData(event.currentTarget)
+    const exemptRaw = String(form.get('commissionExemptUntil') ?? '').trim()
+
+    const payload = {
+      commissionPercent: parseFloat(String(form.get('commissionPercent') ?? '0')) || 0,
+      commissionFlatCents: parseInt(String(form.get('commissionFlatCents') ?? '0').replace(/[^0-9]/g, ''), 10) || 0,
+      commissionExemptUntil: exemptRaw ? new Date(exemptRaw).toISOString() : null,
+    }
+
+    try {
+      const res = await fetch(`/api/admin/billing/${businessId}/commission`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data.error ?? 'update_failed')
+      setFeedback({ ok: true, message: 'Guardado. Se aplica desde la próxima orden.' })
+      router.refresh()
+    } catch (err) {
+      setFeedback({ ok: false, message: err instanceof Error ? err.message : 'Error al guardar' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // Default the datetime-local input to value in yyyy-MM-ddThh:mm form
+  const exemptDefault = initial.commissionExemptUntil
+    ? new Date(initial.commissionExemptUntil).toISOString().slice(0, 16)
+    : ''
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-6">
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">
+          Porcentaje de comisión (%)
+        </span>
+        <input
+          name="commissionPercent"
+          type="number"
+          min={0}
+          max={100}
+          step={0.01}
+          defaultValue={initial.commissionPercent}
+          className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+        />
+        <span className="mt-1 block text-xs text-[color:var(--text-muted,#9ca3af)]">
+          Se aplica sobre el subtotal (no sobre envío ni impuestos). Default 5%.
+        </span>
+      </label>
+
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">
+          Comisión fija por orden (Gs)
+        </span>
+        <input
+          name="commissionFlatCents"
+          type="text"
+          defaultValue={String(initial.commissionFlatCents)}
+          placeholder="0"
+          className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+        />
+        <span className="mt-1 block text-xs text-[color:var(--text-muted,#9ca3af)]">
+          Se suma al porcentaje. Útil para cubrir costos fijos. Dejá en 0 si no aplicás.
+        </span>
+      </label>
+
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">
+          Exento hasta (período de prueba / promo gratis)
+        </span>
+        <input
+          name="commissionExemptUntil"
+          type="datetime-local"
+          defaultValue={exemptDefault}
+          className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+        />
+        <span className="mt-1 block text-xs text-[color:var(--text-muted,#9ca3af)]">
+          Durante este período no se aplica comisión. Default: el promo de 3 meses gratis. Dejá vacío para cobrar inmediatamente.
+        </span>
+      </label>
+
+      {feedback ? (
+        <p
+          role={feedback.ok ? 'status' : 'alert'}
+          className={`rounded p-3 text-sm ${feedback.ok ? 'bg-green-50 text-green-800' : 'bg-red-50 text-red-700'}`}
+        >
+          {feedback.message}
+        </p>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="rounded-lg bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+      >
+        {submitting ? 'Guardando…' : 'Guardar'}
+      </button>
+    </form>
+  )
+}

--- a/web/components/admin/commerce/payment-credentials-manager.tsx
+++ b/web/components/admin/commerce/payment-credentials-manager.tsx
@@ -1,0 +1,270 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type { CredentialPublicView } from '@/lib/commerce/payment-credentials'
+import type { PaymentProvider } from '@/lib/schemas/commerce/transaction'
+
+interface Props {
+  businessId: string
+  initialCredentials: CredentialPublicView[]
+}
+
+interface ProviderTemplate {
+  provider: PaymentProvider
+  label: string
+  fields: Array<{ key: string; label: string; placeholder?: string; type?: 'text' | 'password' }>
+  publicConfigKeys?: Array<{ key: string; label: string; default?: string }>
+  helpUrl?: string
+}
+
+const TEMPLATES: ProviderTemplate[] = [
+  {
+    provider: 'pagopar',
+    label: 'Pagopar (Paraguay)',
+    fields: [
+      { key: 'public_token', label: 'Public Token', placeholder: 'p_xxx...' },
+      { key: 'private_token', label: 'Private Token', placeholder: 's_xxx...', type: 'password' },
+    ],
+    publicConfigKeys: [{ key: 'environment', label: 'Entorno', default: 'sandbox' }],
+    helpUrl: 'https://soporte.pagopar.com/portal/es/kb/articles/api-integracion-medios-pagos',
+  },
+  {
+    provider: 'bancard',
+    label: 'Bancard VPOS 2.0 (Phase 3 — direct cards)',
+    fields: [
+      { key: 'public_key', label: 'Public Key', placeholder: 'PK_xxx...' },
+      { key: 'private_key', label: 'Private Key', placeholder: 'SK_xxx...', type: 'password' },
+    ],
+    publicConfigKeys: [{ key: 'environment', label: 'Entorno', default: 'sandbox' }],
+  },
+  {
+    provider: 'dlocal',
+    label: 'dLocal (LATAM cross-border)',
+    fields: [
+      { key: 'x_login', label: 'X-Login', placeholder: 'login_xxx' },
+      { key: 'x_trans_key', label: 'X-Trans-Key', placeholder: 'key_xxx', type: 'password' },
+      { key: 'secret_key', label: 'Secret Key (HMAC)', placeholder: 'secret_xxx', type: 'password' },
+    ],
+    publicConfigKeys: [{ key: 'country', label: 'País (ISO-2)', default: 'PY' }],
+  },
+]
+
+export function PaymentCredentialsManager({ businessId, initialCredentials }: Props) {
+  const router = useRouter()
+  const [credentials, setCredentials] = useState(initialCredentials)
+  const [openProvider, setOpenProvider] = useState<PaymentProvider | null>(null)
+
+  const installed = new Set(credentials.map((c) => c.provider))
+
+  const refresh = async () => {
+    const res = await fetch(`/api/admin/commerce/${businessId}/payment-credentials`)
+    const data = await res.json()
+    setCredentials(data.credentials ?? [])
+    router.refresh()
+  }
+
+  const handleSave = async (template: ProviderTemplate, secrets: Record<string, string>, publicConfig: Record<string, string>) => {
+    const res = await fetch(`/api/admin/commerce/${businessId}/payment-credentials`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: template.provider,
+        secrets,
+        publicConfig,
+        status: 'active',
+      }),
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.error ?? 'save_failed')
+    }
+    await refresh()
+    setOpenProvider(null)
+  }
+
+  const handleDelete = async (provider: PaymentProvider) => {
+    if (!confirm(`Quitar credenciales de ${provider}? Tu tienda dejará de poder cobrar con este proveedor.`)) return
+    await fetch(`/api/admin/commerce/${businessId}/payment-credentials`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider }),
+    })
+    await refresh()
+  }
+
+  return (
+    <div className="space-y-4">
+      {credentials.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-[color:var(--border,#e5e7eb)] p-6 text-center text-sm text-[color:var(--text-muted,#6b7280)]">
+          Aún no conectaste ningún proveedor de pagos. Empezá con Pagopar.
+        </div>
+      ) : (
+        credentials.map((cred) => (
+          <div key={cred.id} className="flex items-center justify-between rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4">
+            <div>
+              <p className="font-medium">{TEMPLATES.find((t) => t.provider === cred.provider)?.label ?? cred.provider}</p>
+              <p className="text-xs text-[color:var(--text-muted,#6b7280)]">
+                {Object.entries(cred.secretPreviews)
+                  .map(([k, v]) => `${k}: ${v}`)
+                  .join(' · ')}
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setOpenProvider(cred.provider)}
+                className="rounded border border-[color:var(--border,#e5e7eb)] px-3 py-1 text-sm hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+              >
+                Editar
+              </button>
+              <button
+                type="button"
+                onClick={() => handleDelete(cred.provider)}
+                className="rounded border border-red-200 px-3 py-1 text-sm text-red-700 hover:bg-red-50"
+              >
+                Quitar
+              </button>
+            </div>
+          </div>
+        ))
+      )}
+
+      <div>
+        <h2 className="mb-2 mt-8 text-sm font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Conectar otro proveedor</h2>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {TEMPLATES.filter((t) => !installed.has(t.provider)).map((t) => (
+            <button
+              key={t.provider}
+              type="button"
+              onClick={() => setOpenProvider(t.provider)}
+              className="rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4 text-left hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+            >
+              <p className="font-medium">+ {t.label}</p>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {openProvider && (
+        <CredentialFormModal
+          template={TEMPLATES.find((t) => t.provider === openProvider)!}
+          existing={credentials.find((c) => c.provider === openProvider) ?? null}
+          onSave={handleSave}
+          onClose={() => setOpenProvider(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+function CredentialFormModal({
+  template,
+  existing,
+  onSave,
+  onClose,
+}: {
+  template: ProviderTemplate
+  existing: CredentialPublicView | null
+  onSave: (template: ProviderTemplate, secrets: Record<string, string>, publicConfig: Record<string, string>) => Promise<void>
+  onClose: () => void
+}) {
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    const form = new FormData(event.currentTarget)
+    const secrets: Record<string, string> = {}
+    for (const f of template.fields) {
+      const v = String(form.get(f.key) ?? '').trim()
+      if (v) secrets[f.key] = v
+    }
+    if (Object.keys(secrets).length === 0) {
+      setError('Completá al menos un campo')
+      setSubmitting(false)
+      return
+    }
+    const publicConfig: Record<string, string> = {}
+    for (const f of template.publicConfigKeys ?? []) {
+      const v = String(form.get(`pc_${f.key}`) ?? '').trim()
+      if (v) publicConfig[f.key] = v
+    }
+    try {
+      await onSave(template, secrets, publicConfig)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'save_failed')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
+      <form
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={handleSubmit}
+        className="w-full max-w-md rounded-lg bg-[color:var(--surface,#fff)] p-6 shadow-xl"
+      >
+        <h3 className="mb-1 text-lg font-semibold">{template.label}</h3>
+        {existing ? (
+          <p className="mb-4 rounded bg-yellow-50 p-2 text-xs text-yellow-800">
+            Estás reemplazando las credenciales actuales. Los valores existentes no se muestran por seguridad — pegá las nuevas claves completas.
+          </p>
+        ) : null}
+        {template.helpUrl ? (
+          <p className="mb-4 text-xs text-[color:var(--text-muted,#6b7280)]">
+            <a href={template.helpUrl} target="_blank" rel="noreferrer" className="underline">
+              ¿Dónde encuentro estas claves?
+            </a>
+          </p>
+        ) : null}
+
+        <div className="space-y-3">
+          {template.fields.map((f) => (
+            <label key={f.key} className="block">
+              <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">{f.label}</span>
+              <input
+                name={f.key}
+                type={f.type ?? 'text'}
+                placeholder={f.placeholder}
+                autoComplete="off"
+                className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm font-mono"
+              />
+            </label>
+          ))}
+          {template.publicConfigKeys?.map((f) => (
+            <label key={f.key} className="block">
+              <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">{f.label}</span>
+              <input
+                name={`pc_${f.key}`}
+                defaultValue={f.default}
+                className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+              />
+            </label>
+          ))}
+        </div>
+
+        {error ? <p role="alert" className="mt-3 rounded bg-red-50 p-2 text-sm text-red-700">{error}</p> : null}
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-3 py-2 text-sm hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-lg bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            {submitting ? 'Guardando…' : 'Guardar'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/web/components/admin/commerce/subscription-link-generator.tsx
+++ b/web/components/admin/commerce/subscription-link-generator.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Props {
+  businessId: string
+  subscriptionId: string
+  planLabel: string
+  defaultAmountCents: number
+  defaultEmail: string
+  defaultName: string
+  defaultPhone: string
+}
+
+interface GeneratedLink {
+  paymentUrl: string
+  hashPedido: string
+  orderNumber: string
+  whatsAppUrl: string | null
+}
+
+export function SubscriptionLinkGenerator(props: Props) {
+  const [generating, setGenerating] = useState(false)
+  const [link, setLink] = useState<GeneratedLink | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  async function generate(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setGenerating(true)
+    setError(null)
+    setLink(null)
+    const form = new FormData(event.currentTarget)
+
+    const payload = {
+      subscriptionId: props.subscriptionId,
+      planLabel: String(form.get('planLabel') ?? props.planLabel),
+      amountCents: parseInt(String(form.get('amountCents') ?? '0').replace(/[^0-9]/g, ''), 10) || 0,
+      payerEmail: String(form.get('payerEmail') ?? ''),
+      payerName: String(form.get('payerName') ?? ''),
+      payerPhone: String(form.get('payerPhone') ?? '').trim() || undefined,
+    }
+
+    try {
+      const res = await fetch(`/api/admin/billing/${props.businessId}/generate-link`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data.error ?? 'generate_failed')
+      setLink(data as GeneratedLink)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al generar el link')
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  async function copyLink() {
+    if (!link) return
+    await navigator.clipboard.writeText(link.paymentUrl)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="mt-4 rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface-muted,#f9fafb)] p-4">
+      <p className="mb-3 text-xs font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Generar link de pago</p>
+
+      <form onSubmit={generate} className="grid gap-3 sm:grid-cols-2">
+        <input type="hidden" name="planLabel" defaultValue={props.planLabel} />
+
+        <label className="block">
+          <span className="mb-1 block text-xs text-[color:var(--text-muted,#6b7280)]">Monto (Gs)</span>
+          <input
+            name="amountCents"
+            defaultValue={String(props.defaultAmountCents)}
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] bg-white px-3 py-2 text-sm"
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-xs text-[color:var(--text-muted,#6b7280)]">Teléfono WhatsApp</span>
+          <input
+            name="payerPhone"
+            defaultValue={props.defaultPhone}
+            placeholder="+595 9XX XXX XXX"
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] bg-white px-3 py-2 text-sm"
+          />
+        </label>
+
+        <label className="block sm:col-span-2">
+          <span className="mb-1 block text-xs text-[color:var(--text-muted,#6b7280)]">Nombre del pagador</span>
+          <input
+            name="payerName"
+            defaultValue={props.defaultName}
+            required
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] bg-white px-3 py-2 text-sm"
+          />
+        </label>
+
+        <label className="block sm:col-span-2">
+          <span className="mb-1 block text-xs text-[color:var(--text-muted,#6b7280)]">Email del pagador</span>
+          <input
+            name="payerEmail"
+            type="email"
+            defaultValue={props.defaultEmail}
+            required
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] bg-white px-3 py-2 text-sm"
+          />
+        </label>
+
+        <div className="sm:col-span-2">
+          <button
+            type="submit"
+            disabled={generating}
+            className="rounded-lg bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            {generating ? 'Generando…' : 'Generar link de pago'}
+          </button>
+        </div>
+      </form>
+
+      {error ? (
+        <p role="alert" className="mt-3 rounded bg-red-50 p-3 text-sm text-red-700">
+          {error === 'paragu_ai_pagopar_not_configured'
+            ? 'Falta configurar PARAGU_AI_PAGOPAR_PUBLIC_TOKEN / PRIVATE_TOKEN en /etc/paragu-ai/env.'
+            : error}
+        </p>
+      ) : null}
+
+      {link ? (
+        <div className="mt-4 space-y-3 rounded bg-white p-4 text-sm">
+          <div>
+            <span className="block text-xs text-[color:var(--text-muted,#6b7280)]">Link de pago (copialo y mandalo al cliente)</span>
+            <div className="mt-1 flex gap-2">
+              <input
+                readOnly
+                value={link.paymentUrl}
+                className="flex-1 rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface-muted,#f9fafb)] px-3 py-2 font-mono text-xs"
+              />
+              <button
+                type="button"
+                onClick={copyLink}
+                className="rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+              >
+                {copied ? 'Copiado ✓' : 'Copiar'}
+              </button>
+            </div>
+          </div>
+
+          {link.whatsAppUrl ? (
+            <a
+              href={link.whatsAppUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg bg-[#25d366] px-4 py-2 text-sm font-semibold text-white hover:bg-[#20b85a]"
+            >
+              Abrir chat de WhatsApp con el cliente
+            </a>
+          ) : null}
+
+          <p className="text-xs text-[color:var(--text-muted,#9ca3af)]">
+            Orden: <code>{link.orderNumber}</code> · Hash: <code>{link.hashPedido}</code>
+          </p>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/web/lib/billing/paragu-ai-bank.ts
+++ b/web/lib/billing/paragu-ai-bank.ts
@@ -1,0 +1,56 @@
+/**
+ * Paragu-AI SaaS billing — manual bank-transfer details.
+ *
+ * Tenant transfers Gs to the alias below, then sends the comprobante
+ * (receipt screenshot) to the WhatsApp number. The admin manually marks
+ * the subscription as `active` once the comprobante is confirmed.
+ *
+ * See memory/saas-billing-current.md for the rationale and when to revisit.
+ */
+
+export const PARAGU_AI_BANK_ALIAS = 'weissvanderpol.ivan@gmail.com'
+export const PARAGU_AI_COMPROBANTE_WHATSAPP = '+595981324569'
+
+export interface BillingOutreachContext {
+  businessName: string
+  planLabel: string
+  amountCents: number
+  pagoparEnabled?: boolean
+}
+
+/**
+ * Spanish, Paraguay-appropriate WhatsApp message. Opens with the plan
+ * + price, then the transfer instructions, then the "open to talk
+ * pricing + demo + checkout flexibility" triad.
+ */
+export function buildSaasOutreachMessage(ctx: BillingOutreachContext): string {
+  const priceStr = `Gs ${ctx.amountCents.toLocaleString('es-PY')}`
+  const lines = [
+    `Hola 👋 Acá el plan para ${ctx.businessName}.`,
+    '',
+    `*Plan:* ${ctx.planLabel}`,
+    `*Importe mensual:* ${priceStr}`,
+    '',
+    '*Cómo pagar:*',
+    `1. Transferí el monto al alias: *${PARAGU_AI_BANK_ALIAS}*`,
+    `2. Mandame el comprobante por WhatsApp al *${PARAGU_AI_COMPROBANTE_WHATSAPP}*`,
+    '3. Confirmo la activación del mismo día',
+    '',
+    '*También podemos:*',
+    '• Conversar sobre el precio o ajustarlo a lo que realmente necesitás',
+    '• Armarte un demo del sitio con imágenes y textos ya actualizados (gratis, sin compromiso)',
+    '• Usar checkout por WhatsApp para tu tienda (default)',
+    ctx.pagoparEnabled
+      ? '• O activar Pagopar para cobros con tarjeta — si ya tenés cuenta podés pasarme las credenciales y lo configuramos'
+      : '• O activar Pagopar para cobros con tarjeta — si querés te ayudo con el alta',
+    '',
+    'Cualquier duda me escribís por acá. 🙌',
+  ]
+  return lines.join('\n')
+}
+
+export function buildSaasOutreachWhatsAppUrl(phone: string, ctx: BillingOutreachContext): string {
+  const body = encodeURIComponent(buildSaasOutreachMessage(ctx))
+  const cleanPhone = phone.replace(/[^0-9]/g, '')
+  return `https://wa.me/${cleanPhone}?text=${body}`
+}

--- a/web/lib/billing/paragu-ai-saas.ts
+++ b/web/lib/billing/paragu-ai-saas.ts
@@ -1,0 +1,152 @@
+import { pagoparFetch, signPagopar } from '@/lib/payments/pagopar/client'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { logger } from '@/lib/logger'
+
+/**
+ * Paragu-AI SaaS billing via Pagopar "Link de pago".
+ *
+ * Flow: admin clicks "Generar link de pago" → we call Pagopar's
+ * iniciar-transaccion using Paragu-AI's OWN Pagopar tokens (distinct from
+ * the tenant's storefront tokens) with the tenant's plan amount → Pagopar
+ * returns hash_pedido → we build the URL https://www.pagopar.com/pagos/{hash}
+ * → admin sends it to the tenant via WhatsApp / email.
+ *
+ * When the tenant pays, Pagopar's webhook to /api/webhooks/pagopar fires
+ * with the hash_pedido. We differentiate SaaS-billing orders from
+ * storefront orders by prefix on id_pedido_comercio: "SAAS-<subscriptionId>"
+ * vs "PRG-YYYY-NNNNNN". The webhook handler picks up the prefix and
+ * routes to the subscriptions state machine instead of orders.
+ */
+
+export interface PaymentLink {
+  url: string
+  hashPedido: string
+  orderNumber: string
+  amountCents: number
+}
+
+export async function generateSaasPaymentLink(opts: {
+  businessId: string
+  subscriptionId: string
+  planLabel: string              // "Starter mensual", "Professional mensual"
+  amountCents: number            // whole PYG (e.g. 150000 = Gs 150.000)
+  payerEmail: string
+  payerName: string
+  payerPhone?: string
+  webhookUrl: string
+  returnUrl: string
+}): Promise<PaymentLink> {
+  const publicToken = process.env.PARAGU_AI_PAGOPAR_PUBLIC_TOKEN
+  const privateToken = process.env.PARAGU_AI_PAGOPAR_PRIVATE_TOKEN
+  if (!publicToken || !privateToken) {
+    throw new Error('paragu_ai_pagopar_not_configured')
+  }
+
+  const orderNumber = `SAAS-${opts.subscriptionId.slice(0, 8)}-${Date.now()}`
+  const token = signPagopar(privateToken, `${orderNumber}${opts.amountCents}`)
+
+  const body = {
+    token,
+    public_key: publicToken,
+    tipo_pedido: 'VENTA-COMERCIO',
+    id_pedido_comercio: orderNumber,
+    monto_total: opts.amountCents,
+    descripcion_resumen: `Paragu-AI — ${opts.planLabel}`,
+    url_retorno_exitoso: `${opts.returnUrl}?status=success`,
+    url_retorno_cancelado: `${opts.returnUrl}?status=failure`,
+    url_post_confirmacion: opts.webhookUrl,
+    comprador: {
+      email: opts.payerEmail,
+      nombre: opts.payerName,
+      telefono: opts.payerPhone ?? '',
+      documento: '0',
+      tipo_documento: 'CI',
+      ruc: '',
+      ciudad: 1,
+      direccion: '',
+      coordenadas: '',
+      razon_social: '',
+      direccion_referencia: '',
+    },
+    compras_items: [
+      {
+        nombre: `Paragu-AI · ${opts.planLabel}`,
+        id_producto: 1,
+        precio_total: opts.amountCents,
+        cantidad: 1,
+        descripcion: `Suscripción mensual al plan ${opts.planLabel}`,
+        url_imagen: '',
+        categoria: 909,
+        ciudad: 1,
+        public_key: publicToken,
+        vendedor_telefono: '',
+        vendedor_direccion: '',
+        vendedor_direccion_referencia: '',
+        vendedor_direccion_coordenadas: '',
+      },
+    ],
+  }
+
+  const response = await pagoparFetch<{
+    resultado: Array<{ hash_pedido?: string; hash?: string }>
+    respuesta: boolean
+    mensajes?: Array<{ mensaje?: string }>
+  }>('/api/comercios/2.0/iniciar-transaccion', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+
+  if (!response.respuesta) {
+    const message = response.mensajes?.[0]?.mensaje ?? 'unknown_pagopar_error'
+    throw new Error(`pagopar_saas_init_failed:${message}`)
+  }
+
+  const hashPedido = response.resultado?.[0]?.hash_pedido ?? response.resultado?.[0]?.hash
+  if (!hashPedido) throw new Error('pagopar_saas_init_no_hash')
+
+  logger.info('[saas] payment link generated', {
+    action: 'saas.billing.link_generated',
+    businessId: opts.businessId,
+    subscriptionId: opts.subscriptionId,
+    amountCents: opts.amountCents,
+    orderNumber,
+  })
+
+  // Track the link in the existing subscriptions.mercadopago_payment_id /
+  // mercadopago_order_id columns — we're repurposing them as generic
+  // "provider payment ref" columns because the schema was built around MP.
+  // A follow-up migration will rename these to provider_* once we've
+  // stabilized on Pagopar.
+  try {
+    const supabase = await createAdminClient()
+    await supabase
+      .from('subscriptions')
+      .update({
+        mercadopago_payment_id: hashPedido,
+        mercadopago_payer_id: orderNumber,
+      })
+      .eq('id', opts.subscriptionId)
+  } catch (err) {
+    // Non-blocking: the link still works; we just lose the backlink.
+    logger.warn('[saas] link persistence failed (non-blocking)', {
+      subscriptionId: opts.subscriptionId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+
+  return {
+    url: `https://www.pagopar.com/pagos/${hashPedido}`,
+    hashPedido,
+    orderNumber,
+    amountCents: opts.amountCents,
+  }
+}
+
+export function buildWhatsAppShareUrl(phone: string, paymentUrl: string, planLabel: string): string {
+  const body = encodeURIComponent(
+    `Hola 👋 Te paso el link de pago de tu suscripción ${planLabel} en Paragu-AI: ${paymentUrl}\n\n` +
+      `Es un link único, seguro y podés pagar con tarjeta, Tigo Money, Personal o en efectivo en Aquí Pago/Pago Express.`,
+  )
+  const cleanPhone = phone.replace(/[^0-9]/g, '')
+  return `https://wa.me/${cleanPhone}?text=${body}`
+}

--- a/web/lib/commerce/business-commission.ts
+++ b/web/lib/commerce/business-commission.ts
@@ -1,0 +1,22 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import type { CommissionConfig } from '@/lib/payments/pagopar/commission'
+
+/**
+ * Loads the commission config for a business. Defaults to 5% / 0 flat / no
+ * exemption if the business row lacks the columns (pre-migration rows) or
+ * the lookup fails — fail-safe to "commission applies."
+ */
+export async function loadCommissionConfig(businessId: string): Promise<CommissionConfig> {
+  const supabase = await createAdminClient()
+  const { data } = await supabase
+    .from('businesses')
+    .select('commission_percent, commission_flat_cents, commission_exempt_until')
+    .eq('id', businessId)
+    .maybeSingle()
+
+  return {
+    percent: typeof data?.commission_percent === 'number' ? data.commission_percent : 5,
+    flatCents: typeof data?.commission_flat_cents === 'number' ? data.commission_flat_cents : 0,
+    exemptUntil: data?.commission_exempt_until ? new Date(data.commission_exempt_until) : null,
+  }
+}

--- a/web/lib/commerce/credential-crypto.ts
+++ b/web/lib/commerce/credential-crypto.ts
@@ -1,0 +1,70 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
+
+const ALGO = 'aes-256-gcm'
+
+interface EncryptedField {
+  iv: string  // hex
+  ct: string  // hex
+  tag: string // hex
+}
+
+export interface EncryptedSecrets {
+  fields: Record<string, EncryptedField>
+}
+
+function getKey(): Buffer {
+  const hex = process.env.COMMERCE_CREDENTIALS_KEY
+  if (!hex) {
+    throw new Error('COMMERCE_CREDENTIALS_KEY not set — generate with: openssl rand -hex 32')
+  }
+  if (hex.length !== 64) {
+    throw new Error('COMMERCE_CREDENTIALS_KEY must be 64 hex chars (32 bytes / AES-256)')
+  }
+  return Buffer.from(hex, 'hex')
+}
+
+function encryptField(plaintext: string): EncryptedField {
+  const iv = randomBytes(12) // 96-bit IV recommended for GCM
+  const cipher = createCipheriv(ALGO, getKey(), iv)
+  const ct = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+  return {
+    iv: iv.toString('hex'),
+    ct: ct.toString('hex'),
+    tag: tag.toString('hex'),
+  }
+}
+
+function decryptField(field: EncryptedField): string {
+  const decipher = createDecipheriv(ALGO, getKey(), Buffer.from(field.iv, 'hex'))
+  decipher.setAuthTag(Buffer.from(field.tag, 'hex'))
+  const pt = Buffer.concat([
+    decipher.update(Buffer.from(field.ct, 'hex')),
+    decipher.final(),
+  ])
+  return pt.toString('utf8')
+}
+
+/** Encrypt every value in plain → store as EncryptedSecrets blob. */
+export function encryptSecrets(plain: Record<string, string>): EncryptedSecrets {
+  const fields: Record<string, EncryptedField> = {}
+  for (const [k, v] of Object.entries(plain)) {
+    fields[k] = encryptField(v)
+  }
+  return { fields }
+}
+
+/** Decrypt every field in blob → return plain map. Throws on auth-tag mismatch. */
+export function decryptSecrets(blob: EncryptedSecrets): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(blob.fields ?? {})) {
+    out[k] = decryptField(v)
+  }
+  return out
+}
+
+/** Returns last 4 chars of the plaintext for display ("•••• 1234"). */
+export function preview(value: string | undefined): string {
+  if (!value || value.length < 4) return '••••'
+  return `•••• ${value.slice(-4)}`
+}

--- a/web/lib/commerce/payment-credentials.ts
+++ b/web/lib/commerce/payment-credentials.ts
@@ -1,0 +1,140 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import { logger } from '@/lib/logger'
+import { encryptSecrets, decryptSecrets, preview } from './credential-crypto'
+import type { PaymentProvider } from '@/lib/schemas/commerce/transaction'
+
+export interface CredentialRecord {
+  id: string
+  businessId: string
+  provider: PaymentProvider
+  publicConfig: Record<string, unknown>
+  status: 'active' | 'paused' | 'archived'
+  notes: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CredentialWithSecrets extends CredentialRecord {
+  secrets: Record<string, string>
+}
+
+/** UI-safe view: never includes plaintext secrets, only previews. */
+export interface CredentialPublicView extends CredentialRecord {
+  secretPreviews: Record<string, string>
+}
+
+/** Save (insert-or-update) credentials for a business+provider pair. */
+export async function upsertCredentials(opts: {
+  businessId: string
+  provider: PaymentProvider
+  secrets: Record<string, string>
+  publicConfig?: Record<string, unknown>
+  notes?: string
+  status?: 'active' | 'paused' | 'archived'
+}): Promise<CredentialRecord> {
+  const supabase = await createAdminClient()
+  const encrypted = encryptSecrets(opts.secrets)
+
+  const { data, error } = await supabase
+    .from('business_payment_credentials')
+    .upsert(
+      {
+        business_id: opts.businessId,
+        provider: opts.provider,
+        encrypted_secrets: encrypted,
+        public_config: opts.publicConfig ?? {},
+        notes: opts.notes ?? null,
+        status: opts.status ?? 'active',
+      },
+      { onConflict: 'business_id,provider' },
+    )
+    .select('*')
+    .single()
+
+  if (error || !data) {
+    logger.error('[commerce] upsertCredentials failed', {
+      businessId: opts.businessId,
+      provider: opts.provider,
+      error: error?.message,
+    })
+    throw new Error('credential_upsert_failed')
+  }
+  return rowToRecord(data)
+}
+
+/** Internal: load + decrypt for use by checkout/router. NEVER expose to UI. */
+export async function loadCredentialsWithSecrets(
+  businessId: string,
+  provider: PaymentProvider,
+): Promise<CredentialWithSecrets | null> {
+  const supabase = await createAdminClient()
+  const { data, error } = await supabase
+    .from('business_payment_credentials')
+    .select('*')
+    .eq('business_id', businessId)
+    .eq('provider', provider)
+    .eq('status', 'active')
+    .maybeSingle()
+
+  if (error) {
+    logger.error('[commerce] loadCredentialsWithSecrets failed', { businessId, provider, error: error.message })
+    return null
+  }
+  if (!data) return null
+
+  return {
+    ...rowToRecord(data),
+    secrets: decryptSecrets(data.encrypted_secrets),
+  }
+}
+
+/** UI-safe list of all configured providers for a business. */
+export async function listCredentialsForBusiness(businessId: string): Promise<CredentialPublicView[]> {
+  const supabase = await createAdminClient()
+  const { data } = await supabase
+    .from('business_payment_credentials')
+    .select('*')
+    .eq('business_id', businessId)
+    .order('provider', { ascending: true })
+
+  return (Array.isArray(data) ? data : []).map((row) => {
+    const secrets = decryptSecrets(row.encrypted_secrets)
+    const previews: Record<string, string> = {}
+    for (const [k, v] of Object.entries(secrets)) previews[k] = preview(v)
+    return { ...rowToRecord(row), secretPreviews: previews }
+  })
+}
+
+/** Returns the active providers a business has credentials for. Used by router. */
+export async function listAvailableProviders(businessId: string): Promise<PaymentProvider[]> {
+  const supabase = await createAdminClient()
+  const { data } = await supabase
+    .from('business_payment_credentials')
+    .select('provider')
+    .eq('business_id', businessId)
+    .eq('status', 'active')
+  return (Array.isArray(data) ? data : []).map((r) => r.provider as PaymentProvider)
+}
+
+export async function deleteCredentials(businessId: string, provider: PaymentProvider): Promise<void> {
+  const supabase = await createAdminClient()
+  const { error } = await supabase
+    .from('business_payment_credentials')
+    .delete()
+    .eq('business_id', businessId)
+    .eq('provider', provider)
+  if (error) throw new Error(error.message)
+}
+
+function rowToRecord(data: Record<string, unknown>): CredentialRecord {
+  return {
+    id: data.id as string,
+    businessId: data.business_id as string,
+    provider: data.provider as PaymentProvider,
+    publicConfig: (data.public_config as Record<string, unknown>) ?? {},
+    status: data.status as CredentialRecord['status'],
+    notes: (data.notes as string | null) ?? null,
+    createdAt: data.created_at as string,
+    updatedAt: data.updated_at as string,
+  }
+}

--- a/web/lib/env.ts
+++ b/web/lib/env.ts
@@ -143,6 +143,15 @@ export const env = {
   PAGOPAR_PRIVATE_TOKEN: optionalEnvOrUndefined('PAGOPAR_PRIVATE_TOKEN'),
   PAGOPAR_ENVIRONMENT: optionalEnv('PAGOPAR_ENVIRONMENT', 'sandbox'),
 
+  // Paragu-AI's OWN Pagopar account — for split-billing commission
+  // on tenant sales + future SaaS auto-invoicing. Optional.
+  PARAGU_AI_PAGOPAR_PUBLIC_TOKEN: optionalEnvOrUndefined('PARAGU_AI_PAGOPAR_PUBLIC_TOKEN'),
+  PARAGU_AI_PAGOPAR_PRIVATE_TOKEN: optionalEnvOrUndefined('PARAGU_AI_PAGOPAR_PRIVATE_TOKEN'),
+
+  // AES-256 key (64 hex) used to encrypt per-merchant payment
+  // credentials at rest. Generate: openssl rand -hex 32
+  COMMERCE_CREDENTIALS_KEY: optionalEnvOrUndefined('COMMERCE_CREDENTIALS_KEY'),
+
   COMMERCE_SESSION_SECRET: optionalEnvOrUndefined('COMMERCE_SESSION_SECRET'),
 
   get commerceConfigured(): boolean {

--- a/web/lib/payments/pagopar/adapter.ts
+++ b/web/lib/payments/pagopar/adapter.ts
@@ -13,9 +13,9 @@ export const pagoparAdapter: PaymentProviderAdapter = {
     const { publicToken, privateToken } = getPagoparTokens()
     const cancelUrl = opts.returnUrl.replace(/([?&])status=\w+/, '') + (opts.returnUrl.includes('?') ? '&' : '?') + 'status=failure'
 
-    // Commission is loaded inside the adapter so the router/failover never
+    // Commission is loaded INSIDE the adapter so the router/failover never
     // needs to know about billing rules. Failures fall back to "no commission"
-    // rather than blocking the sale — better to miss a fee than lose a sale.
+    // rather than blocking the sale — better to miss a fee than to lose a sale.
     let commission
     try {
       commission = await loadCommissionConfig(order.businessId)

--- a/web/lib/payments/pagopar/commission.ts
+++ b/web/lib/payments/pagopar/commission.ts
@@ -1,0 +1,80 @@
+/**
+ * Commission math + Pagopar split-billing payload helpers.
+ *
+ * Architecture: per-order commission = percent * subtotal + flat_cents.
+ * Subtotal-only (not shipping/tax/discount) by locked decision (see memory
+ * payments-architecture.md). During the 3-month free-premium window
+ * (commission_exempt_until > now) the commission is zero and no split
+ * item is injected — order stays tipo_pedido "VENTA-COMERCIO".
+ */
+
+export interface CommissionConfig {
+  percent: number            // 0–100 (e.g. 5 = 5%)
+  flatCents: number          // PYG whole guaraníes
+  exemptUntil: Date | null
+}
+
+export function computeCommission(
+  subtotalCents: number,
+  config: CommissionConfig,
+  now: Date = new Date(),
+): number {
+  if (config.exemptUntil && config.exemptUntil > now) return 0
+  if (subtotalCents <= 0) return 0
+  const percentPart = Math.round((subtotalCents * config.percent) / 100)
+  return percentPart + config.flatCents
+}
+
+/**
+ * Returns the compras_items entry Pagopar needs to split the commission to
+ * Paragu-AI's own account. Returns null when commission is zero — in that
+ * case callers should use tipo_pedido "VENTA-COMERCIO" instead of
+ * "COMERCIO-HEREDADO".
+ */
+export function buildCommissionItem(opts: {
+  commissionCents: number
+  platformPublicKey: string
+  paddedProductId: number // must not collide with real item ids
+}): CommissionLineItem | null {
+  if (opts.commissionCents <= 0) return null
+  return {
+    nombre: 'Plataforma · servicio digital',
+    id_producto: opts.paddedProductId,
+    precio_total: opts.commissionCents,
+    cantidad: 1,
+    descripcion: 'Servicio de plataforma digital — comisión Paragu-AI',
+    url_imagen: '',
+    categoria: 909,
+    ciudad: 1,
+    public_key: opts.platformPublicKey,
+    vendedor_telefono: '',
+    vendedor_direccion: '',
+    vendedor_direccion_referencia: '',
+    vendedor_direccion_coordenadas: '',
+  }
+}
+
+// Shape exported for transactions.ts — matches the compras_items entries
+// already produced there, so the commission item slots in identically.
+export interface CommissionLineItem {
+  nombre: string
+  id_producto: number
+  precio_total: number
+  cantidad: number
+  descripcion: string
+  url_imagen: string
+  categoria: number
+  ciudad: number
+  public_key: string
+  vendedor_telefono: string
+  vendedor_direccion: string
+  vendedor_direccion_referencia: string
+  vendedor_direccion_coordenadas: string
+}
+
+export function getPlatformPagoparTokens(): { publicToken: string; privateToken: string } | null {
+  const publicToken = process.env.PARAGU_AI_PAGOPAR_PUBLIC_TOKEN
+  const privateToken = process.env.PARAGU_AI_PAGOPAR_PRIVATE_TOKEN
+  if (!publicToken || !privateToken) return null
+  return { publicToken, privateToken }
+}

--- a/web/lib/supabase/scoped.ts
+++ b/web/lib/supabase/scoped.ts
@@ -321,6 +321,7 @@ export const BUSINESS_SCOPED_TABLES = [
   'discounts',
   'discount_redemptions',
   'cart_recovery_touches',
+  'business_payment_credentials',
 ] as const
 
 export type BusinessScopedTable = (typeof BUSINESS_SCOPED_TABLES)[number]

--- a/web/tests/unit/commerce/commission.test.ts
+++ b/web/tests/unit/commerce/commission.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeCommission,
+  buildCommissionItem,
+} from '@/lib/payments/pagopar/commission'
+
+describe('computeCommission', () => {
+  it('applies the percent to subtotal (5% of 150.000 = 7.500)', () => {
+    expect(computeCommission(150_000, { percent: 5, flatCents: 0, exemptUntil: null })).toBe(7_500)
+  })
+
+  it('adds the flat fee on top of percent', () => {
+    expect(computeCommission(100_000, { percent: 3, flatCents: 2_000, exemptUntil: null })).toBe(5_000)
+  })
+
+  it('returns zero when the business is still in the exempt window', () => {
+    const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000) // 30 days out
+    expect(computeCommission(1_000_000, { percent: 5, flatCents: 0, exemptUntil: future })).toBe(0)
+  })
+
+  it('applies commission again once the exempt window has passed', () => {
+    const past = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000) // 1 day ago
+    expect(computeCommission(100_000, { percent: 5, flatCents: 0, exemptUntil: past })).toBe(5_000)
+  })
+
+  it('returns zero for empty subtotal', () => {
+    expect(computeCommission(0, { percent: 5, flatCents: 500, exemptUntil: null })).toBe(0)
+  })
+
+  it('rounds to integer PYG (no subunit)', () => {
+    // 5% of 12.345 = 617.25 → rounds to 617
+    expect(computeCommission(12_345, { percent: 5, flatCents: 0, exemptUntil: null })).toBe(617)
+  })
+
+  it('supports fractional percent (2.5% of 200.000 = 5.000)', () => {
+    expect(computeCommission(200_000, { percent: 2.5, flatCents: 0, exemptUntil: null })).toBe(5_000)
+  })
+})
+
+describe('buildCommissionItem', () => {
+  it('returns null when commission is zero', () => {
+    expect(
+      buildCommissionItem({ commissionCents: 0, platformPublicKey: 'p_x', paddedProductId: 900001 }),
+    ).toBeNull()
+  })
+
+  it('constructs a split-billing compras_items entry', () => {
+    const item = buildCommissionItem({
+      commissionCents: 7_500,
+      platformPublicKey: 'p_paragu_ai',
+      paddedProductId: 900005,
+    })
+    expect(item).not.toBeNull()
+    expect(item!.nombre).toBe('Plataforma · servicio digital')
+    expect(item!.precio_total).toBe(7_500)
+    expect(item!.public_key).toBe('p_paragu_ai')
+    expect(item!.id_producto).toBe(900005)
+    expect(item!.cantidad).toBe(1)
+  })
+
+  it('uses a distinct id_producto range (900000+) to avoid colliding with tenant items', () => {
+    const item = buildCommissionItem({
+      commissionCents: 1_000,
+      platformPublicKey: 'p_x',
+      paddedProductId: 900010,
+    })
+    expect(item!.id_producto).toBeGreaterThanOrEqual(900000)
+  })
+})

--- a/web/tests/unit/commerce/credential-crypto.test.ts
+++ b/web/tests/unit/commerce/credential-crypto.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { encryptSecrets, decryptSecrets, preview } from '@/lib/commerce/credential-crypto'
+
+beforeAll(() => {
+  // 64 hex chars = 32 bytes for AES-256
+  process.env.COMMERCE_CREDENTIALS_KEY = 'a'.repeat(64)
+})
+
+describe('encryptSecrets / decryptSecrets', () => {
+  it('round-trips a single field', () => {
+    const enc = encryptSecrets({ token: 'super-secret' })
+    expect(enc.fields.token).toHaveProperty('iv')
+    expect(enc.fields.token).toHaveProperty('ct')
+    expect(enc.fields.token).toHaveProperty('tag')
+    expect(enc.fields.token.ct).not.toBe('super-secret')
+
+    const dec = decryptSecrets(enc)
+    expect(dec.token).toBe('super-secret')
+  })
+
+  it('round-trips multiple fields independently', () => {
+    const enc = encryptSecrets({ public: 'p_abc', private: 's_xyz', other: 'meh' })
+    const dec = decryptSecrets(enc)
+    expect(dec).toEqual({ public: 'p_abc', private: 's_xyz', other: 'meh' })
+  })
+
+  it('produces different ciphertext on each encryption (random IV)', () => {
+    const a = encryptSecrets({ k: 'value' }).fields.k.ct
+    const b = encryptSecrets({ k: 'value' }).fields.k.ct
+    expect(a).not.toBe(b)
+  })
+
+  it('throws on tampered ciphertext', () => {
+    const enc = encryptSecrets({ k: 'value' })
+    enc.fields.k.ct = enc.fields.k.ct.replace(/^./, '0')
+    expect(() => decryptSecrets(enc)).toThrow()
+  })
+
+  it('throws on tampered auth tag', () => {
+    const enc = encryptSecrets({ k: 'value' })
+    enc.fields.k.tag = enc.fields.k.tag.replace(/^./, '0')
+    expect(() => decryptSecrets(enc)).toThrow()
+  })
+
+  it('throws if COMMERCE_CREDENTIALS_KEY is missing', () => {
+    const orig = process.env.COMMERCE_CREDENTIALS_KEY
+    delete process.env.COMMERCE_CREDENTIALS_KEY
+    expect(() => encryptSecrets({ k: 'v' })).toThrow(/COMMERCE_CREDENTIALS_KEY/)
+    process.env.COMMERCE_CREDENTIALS_KEY = orig
+  })
+
+  it('throws if key is wrong length', () => {
+    const orig = process.env.COMMERCE_CREDENTIALS_KEY
+    process.env.COMMERCE_CREDENTIALS_KEY = 'short'
+    expect(() => encryptSecrets({ k: 'v' })).toThrow(/64 hex chars/)
+    process.env.COMMERCE_CREDENTIALS_KEY = orig
+  })
+})
+
+describe('preview', () => {
+  it('shows last 4 chars', () => {
+    expect(preview('sk_live_abcdef1234')).toBe('•••• 1234')
+  })
+
+  it('full bullets for short or missing values', () => {
+    expect(preview(undefined)).toBe('••••')
+    expect(preview('abc')).toBe('••••')
+  })
+})

--- a/web/tests/unit/commerce/saas-outreach.test.ts
+++ b/web/tests/unit/commerce/saas-outreach.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PARAGU_AI_BANK_ALIAS,
+  PARAGU_AI_COMPROBANTE_WHATSAPP,
+  buildSaasOutreachMessage,
+  buildSaasOutreachWhatsAppUrl,
+} from '@/lib/billing/paragu-ai-bank'
+
+describe('buildSaasOutreachMessage', () => {
+  const ctx = {
+    businessName: 'Tienda Acme',
+    planLabel: 'Crecimiento mensual',
+    amountCents: 150_000,
+  }
+
+  it('includes the alias and WhatsApp number', () => {
+    const msg = buildSaasOutreachMessage(ctx)
+    expect(msg).toContain(PARAGU_AI_BANK_ALIAS)
+    expect(msg).toContain(PARAGU_AI_COMPROBANTE_WHATSAPP)
+  })
+
+  it('mentions the business name and plan', () => {
+    const msg = buildSaasOutreachMessage(ctx)
+    expect(msg).toContain('Tienda Acme')
+    expect(msg).toContain('Crecimiento mensual')
+  })
+
+  it('formats the price in Paraguayan Gs', () => {
+    const msg = buildSaasOutreachMessage(ctx)
+    expect(msg).toMatch(/Gs\s*150[.,]000/)
+  })
+
+  it('offers the price-negotiation / demo / checkout-options triad', () => {
+    const msg = buildSaasOutreachMessage(ctx)
+    expect(msg).toMatch(/precio|precio|conversar/i)
+    expect(msg).toMatch(/demo/i)
+    expect(msg).toMatch(/WhatsApp/i)
+    expect(msg).toMatch(/Pagopar/i)
+  })
+
+  it('switches Pagopar copy when tenant already has credentials', () => {
+    const without = buildSaasOutreachMessage(ctx)
+    const with_ = buildSaasOutreachMessage({ ...ctx, pagoparEnabled: true })
+    expect(without).not.toBe(with_)
+    expect(with_).toMatch(/credenciales/i)
+  })
+})
+
+describe('buildSaasOutreachWhatsAppUrl', () => {
+  it('strips non-digits from the phone', () => {
+    const url = buildSaasOutreachWhatsAppUrl('+595 981 324 569', {
+      businessName: 'A',
+      planLabel: 'B',
+      amountCents: 1_000,
+    })
+    expect(url).toMatch(/^https:\/\/wa\.me\/595981324569\?text=/)
+  })
+
+  it('url-encodes the message body', () => {
+    const url = buildSaasOutreachWhatsAppUrl('595981324569', {
+      businessName: 'Tienda',
+      planLabel: 'Plan',
+      amountCents: 100_000,
+    })
+    // Encoded newlines + spaces
+    expect(url).toContain('%20')
+    expect(url).toContain('%0A')
+  })
+})


### PR DESCRIPTION
## Summary

Consolidates unique work from the closed stacked PRs #77, #81, #82, #83, #87 onto a single clean branch off current Main (earlier ancestors #73-#75, #78 had already been superseded by parallel Main PRs).

## Lands here

1. **Per-merchant payment credentials** (ex-#77) — AES-256-GCM table + admin CRUD UI
2. **Commission via Pagopar split billing** (ex-#81 + #82) — 5% default, subtotal-only, exempt-window-aware, admin settings page
3. **SaaS billing admin** (ex-#83 + #87) — bank transfer + WhatsApp comprobante primary, Pagopar Link-de-pago collapsed

## Tests

82/82 commerce unit tests pass (22 new). Typecheck clean on commerce paths.

## Post-merge migrations

I'll apply via Supabase MCP once merged:
- \`20260422000100_business_payment_credentials.sql\`
- \`20260422000200_business_commission.sql\`

## Opt-out defaults

- Commission requires \`PARAGU_AI_PAGOPAR_*\` env vars to activate. Without them, commerce runs unchanged — no commission skim.
- SaaS billing is bank-transfer primary (alias \`weissvanderpol.ivan@gmail.com\` + WhatsApp \`+595981324569\`). No Paragu-AI Pagopar account needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)