### PR TITLE
feat(auth): /auth/callback for magic links (PKCE + implicit flow)

### DIFF
--- a/web/app/auth/callback/callback-hash-handler.tsx
+++ b/web/app/auth/callback/callback-hash-handler.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { createClient } from '@/lib/supabase/client'
+
+/**
+ * Client-side handler for Supabase's implicit-flow magic link.
+ * Reads window.location.hash, extracts access_token + refresh_token,
+ * calls setSession (which persists cookies), then navigates to `next`.
+ */
+export function CallbackHashHandler({ next }: { next: string }) {
+  const router = useRouter()
+  const [state, setState] = useState<'processing' | 'error'>('processing')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function exchange() {
+      const hash = typeof window !== 'undefined' ? window.location.hash : ''
+      if (!hash) {
+        if (!cancelled) {
+          setErrorMessage('no_auth_data')
+          setState('error')
+        }
+        return
+      }
+
+      const params = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash)
+      const accessToken = params.get('access_token')
+      const refreshToken = params.get('refresh_token')
+
+      if (!accessToken || !refreshToken) {
+        if (!cancelled) {
+          setErrorMessage(params.get('error_description') ?? params.get('error') ?? 'missing_tokens')
+          setState('error')
+        }
+        return
+      }
+
+      try {
+        const supabase = createClient()
+        const { error } = await supabase.auth.setSession({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        })
+        if (error) throw error
+
+        // Strip the hash from the URL bar before navigating.
+        window.history.replaceState(null, '', next)
+        router.replace(next)
+        router.refresh()
+      } catch (err) {
+        if (!cancelled) {
+          setErrorMessage(err instanceof Error ? err.message : String(err))
+          setState('error')
+        }
+      }
+    }
+
+    exchange()
+    return () => {
+      cancelled = true
+    }
+  }, [next, router])
+
+  if (state === 'error') {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center px-4 text-center">
+        <h1 className="mb-2 text-xl font-semibold">No pudimos completar el inicio de sesión</h1>
+        <p className="mb-4 text-sm text-[color:var(--text-muted,#6b7280)]">
+          {errorMessage === 'no_auth_data' || errorMessage === 'missing_tokens'
+            ? 'El link ya fue usado o expiró. Pedí un link nuevo desde la página de login.'
+            : errorMessage}
+        </p>
+        <a href="/login" className="text-sm font-medium text-[color:var(--primary,#111)] underline">
+          Ir al login
+        </a>
+      </main>
+    )
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center px-4 text-center">
+      <p className="text-sm text-[color:var(--text-muted,#6b7280)]">Completando inicio de sesión…</p>
+    </main>
+  )
+}

--- a/web/app/auth/callback/page.tsx
+++ b/web/app/auth/callback/page.tsx
@@ -1,0 +1,59 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { logger } from '@/lib/logger'
+import { CallbackHashHandler } from './callback-hash-handler'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+/**
+ * Magic-link / OAuth callback.
+ *
+ * Two auth flows to handle:
+ *   1. PKCE (query `?code=...`): server-exchanges for session via
+ *      supabase.auth.exchangeCodeForSession, then redirects.
+ *   2. Implicit (hash `#access_token=...&refresh_token=...`): the tokens
+ *      never reach the server (URL fragments aren't sent in the HTTP
+ *      request). We render a client component that reads window.location.hash,
+ *      calls supabase.auth.setSession, and router.push(next).
+ *
+ * Supabase's current admin generate_link API uses the implicit flow by
+ * default, so path #2 is the hot path today. Path #1 is ready for when
+ * we add a login UI that calls signInWithOtp with flowType:'pkce'.
+ */
+export default async function AuthCallbackPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ code?: string; next?: string; error?: string; error_description?: string }>
+}) {
+  const params = await searchParams
+  const next = params.next && params.next.startsWith('/') ? params.next : '/admin'
+
+  // Surface provider-side errors as a redirect to /login with the message
+  if (params.error) {
+    const msg = encodeURIComponent(params.error_description ?? params.error)
+    redirect(`/login?error=${msg}`)
+  }
+
+  // PKCE path — exchange on the server, set cookies, redirect.
+  if (params.code) {
+    try {
+      const supabase = await createClient()
+      const { error } = await supabase.auth.exchangeCodeForSession(params.code)
+      if (error) {
+        logger.warn('auth.callback.pkce_exchange_failed', { error: error.message })
+        redirect(`/login?error=${encodeURIComponent(error.message)}`)
+      }
+    } catch (err) {
+      // next/navigation redirect() throws internally; re-throw so it propagates.
+      if (err instanceof Error && err.message === 'NEXT_REDIRECT') throw err
+      logger.error('auth.callback.pkce_unhandled', err instanceof Error ? err : new Error(String(err)))
+      redirect('/login?error=auth_callback_failed')
+    }
+    redirect(next)
+  }
+
+  // Implicit path — tokens are in the URL hash, which we can't read server-side.
+  // Render a tiny client component that extracts them from window.location.hash.
+  return <CallbackHashHandler next={next} />
+}


### PR DESCRIPTION
## Why

Supabase admin-generated magic links drop tokens in the URL hash fragment (\`#access_token=...\`). Without a handler on the landing page, the fragment stays in the URL bar and no session cookie gets set, so \`/admin\` still bounces to \`/login\`. I hit this today trying to log in the admin user.

## What

\`/auth/callback\` handles both Supabase auth flows:

- **PKCE** (\`?code=\`): server-exchange via \`exchangeCodeForSession\`, set cookies, redirect. Ready for when a login UI calls \`signInWithOtp({ flowType: 'pkce' })\`.
- **Implicit** (\`#access_token=\`): server page renders a small client handler (\`CallbackHashHandler\`) that reads \`window.location.hash\`, calls \`setSession\`, strips the hash, and navigates to \`next\`.

## Safety

- \`next\` param only honored when it starts with \`/\` (open-redirect guard)
- Provider errors (\`?error=...\`) route to \`/login?error=<msg>\`
- Client-side failure shows "link expired/used" copy

## Test plan

- [x] Typecheck clean on new files
- [ ] After merge + deploy: regenerate magic link with \`redirect_to=https://paragu-ai.com/auth/callback?next=/admin\`
- [ ] Click → verify session cookie set → land on \`/admin\` logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)