### PR TITLE
fix(cf-pages): untrack stale agent worktree gitlink + gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ start-local.sh
 
 # Launch-readiness questionnaire (filled, contains real contact data)
 LAUNCH_READINESS_QUESTIONNAIRE.md
+
+# Claude Code isolated agent worktrees — ephemeral, never commit
+# (tracking these as gitlinks without .gitmodules breaks Cloudflare Pages)
+.claude/worktrees/

--- a/web/app/auth/callback/callback-hash-handler.tsx
+++ b/web/app/auth/callback/callback-hash-handler.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
 
 /**
@@ -74,9 +75,9 @@ export function CallbackHashHandler({ next }: { next: string }) {
             ? 'El link ya fue usado o expiró. Pedí un link nuevo desde la página de login.'
             : errorMessage}
         </p>
-        <a href="/login" className="text-sm font-medium text-[color:var(--primary,#111)] underline">
+        <Link href="/login" className="text-sm font-medium text-[color:var(--primary,#111)] underline">
           Ir al login
-        </a>
+        </Link>
       </main>
     )
   }


### PR DESCRIPTION
## Summary

Cloudflare Pages has been failing on every deploy for the past several commits with:

\`\`\`
fatal: No url found for submodule path '.claude/worktrees/agent-a4732141' in .gitmodules
Failed: error occurred while updating repository submodules
\`\`\`

Spotted by the user in the Cloudflare Pages build log.

## Root cause

An earlier session ran a Claude Code isolated-worktree agent at \`.claude/worktrees/agent-a4732141\`. That worktree directory ended up committed to Main as a **gitlink** (file mode 160000, the format Git uses for submodules), but there's no \`.gitmodules\` entry defining the upstream for it.

\`git ls-tree HEAD .claude/worktrees/\`:
\`\`\`
160000 commit 5a75ec5dd45594f0805cfe6c2e36f0d253a28715	.claude/worktrees/agent-a4732141
\`\`\`

Cloudflare Pages runs a strict submodule init during clone — it refuses to continue when a submodule path has no upstream URL. Local \`git clone\` is more forgiving, which is why we didn't catch this in dev.

## Fix

1. \`git rm -r --cached .claude/worktrees\` — drops the stale gitlink.
2. Adds \`.claude/worktrees/\` to \`.gitignore\` so future isolated-agent worktrees don't re-leak into tracked state.

## Test plan

- [ ] Cloudflare Pages deploy succeeds on the next Main push (post-merge)
- [ ] \`git ls-tree Main .claude\` shows no entry for \`worktrees/\`
- [ ] Spawning a new Claude Code isolated-worktree agent leaves \`git status\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)