### PR TITLE
feat(commerce): product image upload (drag-drop + Supabase Storage)

### DIFF
--- a/supabase/migrations/20260422000300_commerce_products_storage_bucket.sql
+++ b/supabase/migrations/20260422000300_commerce_products_storage_bucket.sql
@@ -1,0 +1,35 @@
+-- Storage bucket for commerce product images.
+-- Public read (CDN-served to shoppers) + service-role write (admin API only).
+-- Objects live under {business_id}/{product_id}/{uuid}.ext so cross-business
+-- access is structurally impossible from client-side.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'commerce-products',
+  'commerce-products',
+  true,
+  5242880, -- 5 MB per file
+  ARRAY['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+)
+ON CONFLICT (id) DO UPDATE
+  SET public = EXCLUDED.public,
+      file_size_limit = EXCLUDED.file_size_limit,
+      allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- RLS: anyone can read; only service_role can write/update/delete.
+-- The admin API (which runs as service_role via admin client) performs writes.
+-- Anon/authenticated clients never upload directly.
+
+DROP POLICY IF EXISTS "commerce_products_public_read" ON storage.objects;
+DROP POLICY IF EXISTS "commerce_products_service_role_write" ON storage.objects;
+
+CREATE POLICY "commerce_products_public_read"
+  ON storage.objects FOR SELECT
+  TO anon, authenticated
+  USING (bucket_id = 'commerce-products');
+
+CREATE POLICY "commerce_products_service_role_write"
+  ON storage.objects FOR ALL
+  TO service_role
+  USING (bucket_id = 'commerce-products')
+  WITH CHECK (bucket_id = 'commerce-products');

--- a/web/app/admin/commerce/[businessId]/products/[id]/page.tsx
+++ b/web/app/admin/commerce/[businessId]/products/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { scopedQueries } from '@/lib/supabase/scoped'
 import { EditProductForm } from '@/components/admin/commerce/edit-product-form'
+import { ProductImageUploader } from '@/components/admin/commerce/product-image-uploader'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -37,6 +38,15 @@ export default async function EditProductPage({ params }: { params: Promise<{ bu
         ← Volver
       </Link>
       <h1 className="mb-6 text-2xl font-bold">Editar producto</h1>
+
+      <div className="mb-6">
+        <ProductImageUploader
+          businessId={businessId}
+          productId={product.id}
+          images={product.images ?? []}
+        />
+      </div>
+
       <EditProductForm
         businessId={businessId}
         product={{

--- a/web/app/api/admin/commerce/[businessId]/products/[id]/images/route.ts
+++ b/web/app/api/admin/commerce/[businessId]/products/[id]/images/route.ts
@@ -1,0 +1,127 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { requireAdminUser } from '@/lib/commerce/admin-auth'
+import {
+  uploadProductImage,
+  deleteProductImage,
+  setCoverImage,
+  UploadError,
+} from '@/lib/commerce/product-images'
+
+export const runtime = 'nodejs'
+
+const uploadErrorStatus: Record<string, number> = {
+  unsupported_mime_type: 415,
+  file_too_large: 413,
+  product_not_found: 404,
+  image_not_found: 404,
+  storage_upload_failed: 502,
+  product_update_failed: 500,
+}
+
+/**
+ * POST — upload one image (multipart/form-data, field "file").
+ * Optional form fields: alt, isCover ("true"/"false").
+ */
+export const POST = withRequestLog<{ businessId: string; id: string }>(async (req, { log }, { businessId, id }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  let form: FormData
+  try {
+    form = await req.formData()
+  } catch {
+    return NextResponse.json({ error: 'invalid_multipart' }, { status: 400 })
+  }
+
+  const file = form.get('file')
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'missing_file' }, { status: 400 })
+  }
+
+  const alt = (form.get('alt') as string | null) ?? undefined
+  const isCover = String(form.get('isCover') ?? '').toLowerCase() === 'true'
+
+  const buffer = Buffer.from(await file.arrayBuffer())
+
+  try {
+    const product = await uploadProductImage({
+      businessId,
+      productId: id,
+      fileName: file.name,
+      mimeType: file.type,
+      data: buffer,
+      alt,
+      isCover,
+    })
+    log.info('admin.commerce.image.uploaded', { businessId, productId: id, size: buffer.byteLength })
+    return NextResponse.json({ product })
+  } catch (err) {
+    if (err instanceof UploadError) {
+      const status = uploadErrorStatus[err.code] ?? 400
+      return NextResponse.json({ error: err.code, message: err.message }, { status })
+    }
+    throw err
+  }
+})
+
+const DeleteSchema = z.object({ url: z.string().url() })
+
+export const DELETE = withRequestLog<{ businessId: string; id: string }>(async (req, { log }, { businessId, id }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+  const parsed = DeleteSchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+  }
+
+  try {
+    const product = await deleteProductImage({ businessId, productId: id, url: parsed.data.url })
+    log.info('admin.commerce.image.deleted', { businessId, productId: id })
+    return NextResponse.json({ product })
+  } catch (err) {
+    if (err instanceof UploadError) {
+      const status = uploadErrorStatus[err.code] ?? 400
+      return NextResponse.json({ error: err.code }, { status })
+    }
+    throw err
+  }
+})
+
+const PatchSchema = z.object({
+  action: z.literal('set_cover'),
+  url: z.string().url(),
+})
+
+export const PATCH = withRequestLog<{ businessId: string; id: string }>(async (req, _ctx, { businessId, id }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+  const parsed = PatchSchema.safeParse(json)
+  if (!parsed.success) return NextResponse.json({ error: 'validation' }, { status: 400 })
+
+  try {
+    const product = await setCoverImage({ businessId, productId: id, url: parsed.data.url })
+    return NextResponse.json({ product })
+  } catch (err) {
+    if (err instanceof UploadError) {
+      const status = uploadErrorStatus[err.code] ?? 400
+      return NextResponse.json({ error: err.code }, { status })
+    }
+    throw err
+  }
+})

--- a/web/components/admin/commerce/product-image-uploader.tsx
+++ b/web/components/admin/commerce/product-image-uploader.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { useState, useRef, type DragEvent } from 'react'
+import { useRouter } from 'next/navigation'
+import type { ProductImage } from '@/lib/schemas/commerce/product'
+
+interface Props {
+  businessId: string
+  productId: string
+  images: ProductImage[]
+}
+
+export function ProductImageUploader({ businessId, productId, images: initialImages }: Props) {
+  const router = useRouter()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [images, setImages] = useState(initialImages)
+  const [isDragging, setIsDragging] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const apiBase = `/api/admin/commerce/${businessId}/products/${productId}/images`
+
+  async function uploadFiles(files: FileList | File[]) {
+    setError(null)
+    setUploading(true)
+    try {
+      for (const file of Array.from(files)) {
+        if (!file.type.startsWith('image/')) {
+          setError(`${file.name} no es una imagen`)
+          continue
+        }
+        if (file.size > 5 * 1024 * 1024) {
+          setError(`${file.name} supera los 5MB`)
+          continue
+        }
+        const formData = new FormData()
+        formData.append('file', file)
+        formData.append('alt', '')
+        if (images.length === 0) formData.append('isCover', 'true')
+
+        const res = await fetch(apiBase, { method: 'POST', body: formData })
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}))
+          throw new Error(data.message ?? data.error ?? 'upload_failed')
+        }
+        const { product } = await res.json()
+        setImages(product.images)
+      }
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al subir')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  async function handleDrop(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault()
+    setIsDragging(false)
+    if (event.dataTransfer.files.length > 0) {
+      await uploadFiles(event.dataTransfer.files)
+    }
+  }
+
+  async function deleteImage(url: string) {
+    if (!confirm('Eliminar esta imagen?')) return
+    setError(null)
+    try {
+      const res = await fetch(apiBase, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url }),
+      })
+      if (!res.ok) throw new Error('delete_failed')
+      const { product } = await res.json()
+      setImages(product.images)
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al eliminar')
+    }
+  }
+
+  async function setCover(url: string) {
+    setError(null)
+    try {
+      const res = await fetch(apiBase, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'set_cover', url }),
+      })
+      if (!res.ok) throw new Error('set_cover_failed')
+      const { product } = await res.json()
+      setImages(product.images)
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al marcar portada')
+    }
+  }
+
+  return (
+    <section className="rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Imágenes del producto</h3>
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploading}
+          className="rounded border border-[color:var(--border,#e5e7eb)] px-3 py-1 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)] disabled:opacity-50"
+        >
+          {uploading ? 'Subiendo…' : 'Elegir archivos'}
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/gif"
+          multiple
+          className="hidden"
+          onChange={(e) => e.target.files && uploadFiles(e.target.files)}
+        />
+      </div>
+
+      <div
+        onDragOver={(e) => {
+          e.preventDefault()
+          setIsDragging(true)
+        }}
+        onDragLeave={() => setIsDragging(false)}
+        onDrop={handleDrop}
+        className={`rounded-lg border-2 border-dashed px-4 py-8 text-center transition-colors ${
+          isDragging
+            ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)]/5'
+            : 'border-[color:var(--border,#e5e7eb)]'
+        }`}
+      >
+        <p className="text-sm text-[color:var(--text-muted,#6b7280)]">
+          {uploading ? 'Subiendo imágenes…' : 'Arrastrá imágenes acá o hacé clic en "Elegir archivos"'}
+        </p>
+        <p className="mt-1 text-xs text-[color:var(--text-muted,#9ca3af)]">
+          JPG / PNG / WebP / GIF · máx 5MB · la primera imagen se marca como portada
+        </p>
+      </div>
+
+      {error ? (
+        <p role="alert" className="mt-3 rounded bg-red-50 p-2 text-xs text-red-700">
+          {error}
+        </p>
+      ) : null}
+
+      {images.length > 0 ? (
+        <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+          {images.map((img) => (
+            <div
+              key={img.url}
+              className="group relative overflow-hidden rounded-lg border border-[color:var(--border,#e5e7eb)]"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={img.url}
+                alt={img.alt ?? ''}
+                className="aspect-square w-full object-cover"
+                loading="lazy"
+              />
+              {img.isCover ? (
+                <span className="absolute left-2 top-2 rounded bg-[color:var(--primary,#111)] px-2 py-0.5 text-xs font-semibold text-white">
+                  Portada
+                </span>
+              ) : null}
+              <div className="absolute inset-x-0 bottom-0 flex justify-end gap-1 bg-gradient-to-t from-black/60 to-transparent p-2 opacity-0 transition-opacity group-hover:opacity-100">
+                {!img.isCover && (
+                  <button
+                    type="button"
+                    onClick={() => setCover(img.url)}
+                    className="rounded bg-white/90 px-2 py-1 text-xs font-medium hover:bg-white"
+                  >
+                    Portada
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => deleteImage(img.url)}
+                  className="rounded bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-700"
+                >
+                  Borrar
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/web/lib/commerce/product-images.ts
+++ b/web/lib/commerce/product-images.ts
@@ -1,0 +1,252 @@
+import { randomUUID } from 'crypto'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { logger } from '@/lib/logger'
+import type { Product, ProductImage } from '@/lib/schemas/commerce/product'
+
+const BUCKET = 'commerce-products'
+const MAX_FILE_BYTES = 5 * 1024 * 1024 // 5 MB — must match the bucket policy
+const ALLOWED_MIME = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif'])
+
+export class UploadError extends Error {
+  constructor(public code: string, message?: string) {
+    super(message ?? code)
+    this.name = 'UploadError'
+  }
+}
+
+function extensionFor(mime: string): string {
+  switch (mime) {
+    case 'image/jpeg':
+      return 'jpg'
+    case 'image/png':
+      return 'png'
+    case 'image/webp':
+      return 'webp'
+    case 'image/gif':
+      return 'gif'
+    default:
+      return 'bin'
+  }
+}
+
+/**
+ * Uploads a single image file (already received server-side as a Buffer) to
+ * the commerce-products bucket and appends it to products.images.
+ *
+ * Path convention: {business_id}/{product_id}/{uuid}.{ext}. Knowing business_id
+ * + product_id in the path makes orphan cleanup trivial and prevents a later
+ * migration to a different path convention from breaking existing URLs.
+ */
+export async function uploadProductImage(opts: {
+  businessId: string
+  productId: string
+  fileName: string
+  mimeType: string
+  data: Buffer
+  isCover?: boolean
+  alt?: string
+}): Promise<Product> {
+  if (!ALLOWED_MIME.has(opts.mimeType)) {
+    throw new UploadError('unsupported_mime_type', `Mime ${opts.mimeType} not allowed`)
+  }
+  if (opts.data.byteLength > MAX_FILE_BYTES) {
+    throw new UploadError('file_too_large', `Max ${MAX_FILE_BYTES} bytes`)
+  }
+
+  const supabase = await createAdminClient()
+
+  // Verify ownership — the admin API caller is trusted, but we still enforce
+  // business_id scoping defensively so a path-traversal or bad-input bug
+  // can't upload under the wrong tenant.
+  const { data: product, error: productError } = await supabase
+    .from('products')
+    .select('id, business_id, images')
+    .eq('id', opts.productId)
+    .eq('business_id', opts.businessId)
+    .maybeSingle()
+
+  if (productError || !product) {
+    throw new UploadError('product_not_found')
+  }
+
+  const id = randomUUID()
+  const ext = extensionFor(opts.mimeType)
+  const path = `${opts.businessId}/${opts.productId}/${id}.${ext}`
+
+  const { error: uploadError } = await supabase.storage
+    .from(BUCKET)
+    .upload(path, opts.data, {
+      contentType: opts.mimeType,
+      cacheControl: '31536000', // 1 year — objects are content-addressed by uuid
+      upsert: false,
+    })
+
+  if (uploadError) {
+    logger.error('[commerce] image upload failed', {
+      action: 'commerce.image.upload_failed',
+      businessId: opts.businessId,
+      productId: opts.productId,
+      error: uploadError.message,
+    })
+    throw new UploadError('storage_upload_failed', uploadError.message)
+  }
+
+  const { data: publicUrl } = supabase.storage.from(BUCKET).getPublicUrl(path)
+
+  // Append to images array. If the new image is marked cover, unset other covers.
+  const current = Array.isArray(product.images) ? (product.images as ProductImage[]) : []
+  const newImage: ProductImage = {
+    url: publicUrl.publicUrl,
+    alt: opts.alt,
+    isCover: opts.isCover ?? current.length === 0, // first image becomes cover by default
+  }
+  const updated: ProductImage[] = newImage.isCover
+    ? [newImage, ...current.map((i) => ({ ...i, isCover: false }))]
+    : [...current, newImage]
+
+  const { data: row, error: updateError } = await supabase
+    .from('products')
+    .update({ images: updated })
+    .eq('id', opts.productId)
+    .eq('business_id', opts.businessId)
+    .select('*')
+    .single()
+
+  if (updateError || !row) {
+    // Roll back the upload so we don't leave orphans in the bucket.
+    await supabase.storage.from(BUCKET).remove([path])
+    logger.error('[commerce] image DB update failed, storage rolled back', {
+      action: 'commerce.image.db_update_failed',
+      businessId: opts.businessId,
+      productId: opts.productId,
+      error: updateError?.message,
+    })
+    throw new UploadError('product_update_failed', updateError?.message)
+  }
+
+  logger.info('[commerce] image uploaded', {
+    action: 'commerce.image.uploaded',
+    businessId: opts.businessId,
+    productId: opts.productId,
+    path,
+    size: opts.data.byteLength,
+  })
+
+  return dbRowToProduct(row)
+}
+
+/**
+ * Remove an image by URL. Deletes from both the bucket (best-effort) and the
+ * products.images JSONB. The URL is parsed to extract the storage path —
+ * public URLs look like
+ *   https://<ref>.supabase.co/storage/v1/object/public/commerce-products/<path>
+ */
+export async function deleteProductImage(opts: {
+  businessId: string
+  productId: string
+  url: string
+}): Promise<Product> {
+  const supabase = await createAdminClient()
+
+  const { data: product, error: productError } = await supabase
+    .from('products')
+    .select('id, business_id, images')
+    .eq('id', opts.productId)
+    .eq('business_id', opts.businessId)
+    .maybeSingle()
+
+  if (productError || !product) {
+    throw new UploadError('product_not_found')
+  }
+
+  const current = Array.isArray(product.images) ? (product.images as ProductImage[]) : []
+  const remaining = current.filter((i) => i.url !== opts.url)
+
+  // Extract storage path from public URL. If the URL doesn't parse cleanly
+  // (e.g., external image that was pasted in manually), we skip the bucket
+  // delete but still remove it from the JSONB.
+  const marker = `/storage/v1/object/public/${BUCKET}/`
+  const markerIdx = opts.url.indexOf(marker)
+  if (markerIdx !== -1) {
+    const path = opts.url.slice(markerIdx + marker.length)
+    // Only delete objects under this business's own prefix — belt-and-suspenders.
+    if (path.startsWith(`${opts.businessId}/${opts.productId}/`)) {
+      await supabase.storage.from(BUCKET).remove([path])
+    }
+  }
+
+  // If the removed image was the cover and we have others, promote the first
+  // remaining image to cover.
+  if (current.find((i) => i.url === opts.url)?.isCover && remaining.length > 0) {
+    remaining[0] = { ...remaining[0], isCover: true }
+  }
+
+  const { data: row, error: updateError } = await supabase
+    .from('products')
+    .update({ images: remaining })
+    .eq('id', opts.productId)
+    .eq('business_id', opts.businessId)
+    .select('*')
+    .single()
+
+  if (updateError || !row) throw new UploadError('product_update_failed', updateError?.message)
+  return dbRowToProduct(row)
+}
+
+/** Sets a specific URL as cover; unsets others. */
+export async function setCoverImage(opts: {
+  businessId: string
+  productId: string
+  url: string
+}): Promise<Product> {
+  const supabase = await createAdminClient()
+  const { data: product, error } = await supabase
+    .from('products')
+    .select('images')
+    .eq('id', opts.productId)
+    .eq('business_id', opts.businessId)
+    .maybeSingle()
+
+  if (error || !product) throw new UploadError('product_not_found')
+  const current = Array.isArray(product.images) ? (product.images as ProductImage[]) : []
+  if (!current.some((i) => i.url === opts.url)) throw new UploadError('image_not_found')
+
+  const updated = current.map((i) => ({ ...i, isCover: i.url === opts.url }))
+  // Stable sort: move the cover to the front so storefront galleries render it first.
+  updated.sort((a, b) => Number(b.isCover ?? false) - Number(a.isCover ?? false))
+
+  const { data: row, error: updateError } = await supabase
+    .from('products')
+    .update({ images: updated })
+    .eq('id', opts.productId)
+    .eq('business_id', opts.businessId)
+    .select('*')
+    .single()
+  if (updateError || !row) throw new UploadError('product_update_failed', updateError?.message)
+  return dbRowToProduct(row)
+}
+
+function dbRowToProduct(row: Record<string, unknown>): Product {
+  return {
+    id: row.id as string,
+    businessId: row.business_id as string,
+    slug: row.slug as string,
+    name: row.name as string,
+    description: (row.description as string | null) ?? null,
+    category: (row.category as string | null) ?? null,
+    priceCents: row.price_cents as number,
+    compareAtPriceCents: (row.compare_at_price_cents as number | null) ?? null,
+    currency: row.currency as string,
+    sku: (row.sku as string | null) ?? null,
+    inventoryQty: row.inventory_qty as number,
+    inventoryPolicy: row.inventory_policy as Product['inventoryPolicy'],
+    lowStockThreshold: (row.low_stock_threshold as number | null) ?? null,
+    images: (row.images as ProductImage[]) ?? [],
+    weightGrams: (row.weight_grams as number | null) ?? null,
+    status: row.status as Product['status'],
+    isSeed: (row.is_seed as boolean) ?? false,
+    metadata: (row.metadata as Record<string, unknown>) ?? {},
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+  }
+}


### PR DESCRIPTION
## Summary

Closes the top merchant-onboarding blocker — no more pasting URLs. Drag-drop upload → Supabase Storage → DB → live storefront.

## What lands

- **Bucket** \`commerce-products\` (public read, service-role write, 5MB/image, JPG/PNG/WebP/GIF)
- **Path convention** \`{business_id}/{product_id}/{uuid}.{ext}\` — trivial orphan cleanup + structural tenant isolation
- **lib/commerce/product-images.ts** — \`uploadProductImage\` / \`deleteProductImage\` / \`setCoverImage\` with tamper-proof rollback if DB update fails after storage put
- **API** \`POST/DELETE/PATCH /api/admin/commerce/[id]/products/[id]/images\` — admin-auth gated, typed error codes (413 / 415 / 404 / 502)
- **UI** drag-drop + file picker, thumbnail grid, hover controls for cover/delete
- **Wired** into product edit page — uploader sits above the text form

## Migrations

- \`20260422000300_commerce_products_storage_bucket.sql\` — idempotent (ON CONFLICT / DROP POLICY IF EXISTS). Already applied to Supabase.

## Follow-ups (not in this PR)

- Client-side resize to 1600px
- Rate limit on POST
- Drag-to-reorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)