### PR TITLE
feat(granja-cabral): wire new sections into home page

### DIFF
--- a/sites/granja-cabral/content/es.json
+++ b/sites/granja-cabral/content/es.json
@@ -3,7 +3,15 @@
     "translationQuality": "native",
     "author": "Granja Cabral",
     "lastReviewed": "2026-04-20",
-    "notes": "Content sourced from web/lib/engine/demo-data.ts and src/content/egg_farm.content.json. Placeholders flagged in site.json.placeholderFields. Awaiting confirmation from owner Laura Cabral — see docs/onboarding-questionnaire.md."
+    "notes": "Content sourced from web/lib/engine/demo-data.ts and src/content/egg_farm.content.json. Placeholders flagged in site.json.placeholderFields. Awaiting confirmation from owner Laura Cabral — see docs/onboarding-questionnaire.md.",
+    "placeholders": [
+      "home.ourStory.business.story.founded — founding year needs confirmation from Laura Cabral",
+      "home.ourStory.business.story.mission/vision/values — drafted from research, pending Laura Cabral sign-off",
+      "home.ourStory.business.stats — counts are estimates (500 gallinas, 300 negocios); confirm with Laura Cabral",
+      "home.ourStory.business.sustainability — biogas flag is aspirational (planned, not yet operational)",
+      "home.enhancedFaq and home.wholesale — FAQ/tier/industry copy currently lives inside the components themselves (PR #108). Once those are moved to content-driven arrays, the text should be reviewed by Laura Cabral.",
+      "home.recipes — recipes list lives in web/lib/data/recipes.ts (15 Paraguayan recipes). Content-ref here only supplies business contact; recipe data itself is currently component-owned."
+    ]
   },
   "siteName": "Granja Cabral",
   "tagline": "Huevos frescos de granja en Coronel Oviedo",
@@ -135,6 +143,71 @@
       "whatsapp": "+595981324569",
       "email": "info@granjacabral.com",
       "address": "Ruta 2, Km 125-140, Coronel Oviedo"
+    },
+    "ourStory": {
+      "business": {
+        "name": "Granja Cabral",
+        "tagline": "Huevos frescos de granja en Coronel Oviedo",
+        "address": "Ruta 2, Km 125-140",
+        "city": "Coronel Oviedo",
+        "phone": "+595981324569",
+        "whatsapp": "+595981324569",
+        "email": "info@granjacabral.com",
+        "instagram": "@granjacabral",
+        "hours": {
+          "Lunes - Sabado": "07:00 - 18:00",
+          "Domingo": "Cerrado"
+        },
+        "story": {
+          "founded": "[AÑO]",
+          "mission": "Producir alimentos frescos, saludables y accesibles para las familias de Coronel Oviedo y zona, manteniendo practicas sostenibles y apoyando el desarrollo local.",
+          "vision": "Ser la granja avicola de referencia en Caaguazu, reconocida por calidad, sostenibilidad y compromiso comunitario. Expandir nuestro alcance mientras mantenemos los valores familiares que nos caracterizan.",
+          "values": [
+            "Calidad: Cada huevo es revisado antes de la venta",
+            "Sostenibilidad: Compostaje y gestion responsable del agua",
+            "Bienestar Animal: Gallinas en ambiente natural y saludable",
+            "Comunidad: Precios justos y apoyo a la economia local",
+            "Transparencia: Puertas abiertas para que conozcas nuestra granja"
+          ]
+        },
+        "stats": [
+          { "value": "500+", "label": "Gallinas ponedoras" },
+          { "value": "100%", "label": "Produccion local" },
+          { "value": "Diario", "label": "Recoleccion fresca" },
+          { "value": "300+", "label": "Negocios atendidos" },
+          { "value": "4-5", "label": "Semanas de frescura" }
+        ],
+        "sustainability": {
+          "composting": true,
+          "biogas": false,
+          "waterRecycling": true,
+          "organicFertilizer": true,
+          "description": "Creemos en producir alimentos de manera responsable con el medio ambiente. Implementamos compostaje de gallinaza, reutilizacion de agua y venta de fertilizante organico cerrando el ciclo de sustentabilidad."
+        }
+      }
+    },
+    "wholesale": {
+      "business": {
+        "name": "Granja Cabral",
+        "whatsapp": "+595981324569",
+        "phone": "+595981324569",
+        "email": "info@granjacabral.com",
+        "address": "Ruta 2, Km 125-140",
+        "city": "Coronel Oviedo"
+      }
+    },
+    "recipes": {
+      "business": {
+        "name": "Granja Cabral",
+        "whatsapp": "+595981324569"
+      }
+    },
+    "enhancedFaq": {
+      "business": {
+        "name": "Granja Cabral",
+        "whatsapp": "+595981324569",
+        "phone": "+595981324569"
+      }
     }
   },
   "footer": {

--- a/sites/granja-cabral/pages/home.json
+++ b/sites/granja-cabral/pages/home.json
@@ -14,14 +14,34 @@
       "content": "home.hero"
     },
     {
+      "id": "our-story",
+      "variant": "narrative",
+      "content": "home.ourStory"
+    },
+    {
       "id": "services",
       "variant": "cards",
       "content": "home.services"
     },
     {
+      "id": "b2b-wholesale",
+      "variant": "tiered",
+      "content": "home.wholesale"
+    },
+    {
+      "id": "recipes",
+      "variant": "grid",
+      "content": "home.recipes"
+    },
+    {
       "id": "testimonials",
       "variant": "carousel",
       "content": "home.testimonials"
+    },
+    {
+      "id": "enhanced-faq",
+      "variant": "searchable",
+      "content": "home.enhancedFaq"
     },
     {
       "id": "contact",

--- a/src/verticals/agriculture-agribusiness/vertical.json
+++ b/src/verticals/agriculture-agribusiness/vertical.json
@@ -23,7 +23,11 @@
     "contact",
     "google-maps",
     "footer",
-    "whatsapp-float"
+    "whatsapp-float",
+    "enhanced-faq",
+    "our-story",
+    "b2b-wholesale",
+    "recipes"
   ],
   "defaultStarterKit": "minimal",
   "locales": [

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -604,7 +604,7 @@ export default function HomePage() {
                         <Star key={i} size={16} className="fill-yellow-400 text-yellow-400" />
                       ))}
                     </div>
-                    <p className="mb-6 text-lg leading-relaxed">"{t.quote}"</p>
+                    <p className="mb-6 text-lg leading-relaxed">&ldquo;{t.quote}&rdquo;</p>
                     <div className="flex items-center gap-3">
                       <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white/20 text-lg font-bold">
                         {t.name.charAt(0)}
@@ -779,18 +779,18 @@ export default function HomePage() {
             <div>
               <h4 className="font-semibold text-gray-900">Producto</h4>
               <ul className="mt-4 space-y-2 text-sm">
-                <li><a href="/p" className="text-gray-600 hover:text-blue-600">Rubros</a></li>
-                <li><a href="/precios" className="text-gray-600 hover:text-blue-600">Precios</a></li>
-                <li><a href="/demo" className="text-gray-600 hover:text-blue-600">Demo</a></li>
+                <li><Link href="/p" className="text-gray-600 hover:text-blue-600">Rubros</Link></li>
+                <li><Link href="/precios" className="text-gray-600 hover:text-blue-600">Precios</Link></li>
+                <li><Link href="/demo" className="text-gray-600 hover:text-blue-600">Demo</Link></li>
               </ul>
             </div>
 
             <div>
               <h4 className="font-semibold text-gray-900">Recursos</h4>
               <ul className="mt-4 space-y-2 text-sm">
-                <li><a href="/casos" className="text-gray-600 hover:text-blue-600">Casos</a></li>
-                <li><a href="/blog" className="text-gray-600 hover:text-blue-600">Blog</a></li>
-                <li><a href="/seguridad" className="text-gray-600 hover:text-blue-600">Privacidad</a></li>
+                <li><Link href="/casos" className="text-gray-600 hover:text-blue-600">Casos</Link></li>
+                <li><Link href="/blog" className="text-gray-600 hover:text-blue-600">Blog</Link></li>
+                <li><Link href="/seguridad" className="text-gray-600 hover:text-blue-600">Privacidad</Link></li>
               </ul>
             </div>
 
@@ -807,7 +807,7 @@ export default function HomePage() {
                     WhatsApp
                   </a>
                 </li>
-                <li><a href="/admin" className="text-gray-600 hover:text-blue-600">Acceso clientes</a></li>
+                <li><Link href="/admin" className="text-gray-600 hover:text-blue-600">Acceso clientes</Link></li>
               </ul>
             </div>
           </div>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -9,6 +9,7 @@ import {
   Menu, X as XIcon, PlayCircle,
   UtensilsCrossed, Fish, CircleDot,
   RotateCcw, Activity, Unlock,
+  type LucideIcon,
 } from 'lucide-react'
 import Link from 'next/link'
 import { Container } from '@/components/ui/container'
@@ -20,7 +21,17 @@ import { FloatingShape } from '@/components/landing/chrome'
 
 /* ── Data Constants ─────────────────────────────────────────────── */
 
-const TEMPLATES = [
+type Template = {
+  id: string
+  name: string
+  icon: LucideIcon
+  leads: number
+  pct: number
+  color: string
+  demoSlug?: string
+}
+
+const TEMPLATES: Template[] = [
   { id: 'peluqueria', name: 'Peluquería', icon: Scissors, leads: 2393, pct: 81, color: '#b76e79', demoSlug: 'salon-maria' },
   { id: 'salon_belleza', name: 'Salón de Belleza', icon: Sparkles, leads: 1210, pct: 75, color: '#d4a574', demoSlug: 'studio-belleza' },
   { id: 'gimnasio', name: 'Gimnasio / Fitness', icon: Dumbbell, leads: 1087, pct: 72, color: '#2d6a4f', demoSlug: 'gymfit-py' },
@@ -37,7 +48,7 @@ const TEMPLATES = [
   { id: 'restaurant', name: 'Restaurante', icon: UtensilsCrossed, leads: 0, pct: 0, color: '#8B4513', demoSlug: 'la-trattoria' },
   { id: 'sushi_bar', name: 'Sushi Bar', icon: Fish, leads: 0, pct: 0, color: '#1A1A1A', demoSlug: 'sakura-sushi' },
   { id: 'kaiten_zushi', name: 'Sushi Cinta', icon: CircleDot, leads: 0, pct: 0, color: '#2196F3', demoSlug: 'kaiten-express' },
-] as const
+]
 
 const FEATURES = [
   { icon: Check, title: 'Todo incluido', desc: 'Diseño, textos, fotos, dominio .com.py, hosting y soporte. Vos solo nos mandás la info por WhatsApp.' },

--- a/web/lib/engine/section-registry.ts
+++ b/web/lib/engine/section-registry.ts
@@ -268,6 +268,31 @@ export const SECTION_CATALOG: Record<string, SectionManifest> = {
     variants: ['standard'],
     requiredContentFields: ['slots'],
   },
+  // Egg-farm / granja-cabral sections (PR #108)
+  'enhanced-faq': {
+    id: 'enhanced-faq',
+    defaultVariant: 'searchable',
+    variants: ['searchable'],
+    requiredContentFields: ['business'],
+  },
+  'our-story': {
+    id: 'our-story',
+    defaultVariant: 'narrative',
+    variants: ['narrative'],
+    requiredContentFields: ['business'],
+  },
+  'b2b-wholesale': {
+    id: 'b2b-wholesale',
+    defaultVariant: 'tiered',
+    variants: ['tiered'],
+    requiredContentFields: ['business'],
+  },
+  recipes: {
+    id: 'recipes',
+    defaultVariant: 'grid',
+    variants: ['grid'],
+    requiredContentFields: ['business'],
+  },
 }
 
 /**

--- a/web/lib/engine/site-renderer.tsx
+++ b/web/lib/engine/site-renderer.tsx
@@ -37,6 +37,11 @@ import { MembershipPlansSection } from '@/components/sections/membership-plans-s
 import { PortfolioSection } from '@/components/sections/portfolio-section'
 import { QuoteFormSection } from '@/components/sections/quote-form-section'
 import { RoomBookingSection } from '@/components/sections/room-booking-section'
+// Egg-farm / granja-cabral sections (PR #108)
+import { EnhancedFAQSection } from '@/components/sections/enhanced-faq-section'
+import { OurStorySection } from '@/components/sections/our-story-section'
+import { B2BWholesaleSection } from '@/components/sections/b2b-wholesale-section'
+import { RecipeSection } from '@/components/sections/recipe-section'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const COMPONENTS: Record<string, React.ComponentType<any>> = {
@@ -69,6 +74,11 @@ const COMPONENTS: Record<string, React.ComponentType<any>> = {
   portfolio: PortfolioSection,
   'quote-form': QuoteFormSection,
   'room-booking': RoomBookingSection,
+  // Egg-farm / granja-cabral sections (PR #108)
+  'enhanced-faq': EnhancedFAQSection,
+  'our-story': OurStorySection,
+  'b2b-wholesale': B2BWholesaleSection,
+  recipes: RecipeSection,
 }
 
 export function renderPage(page: ResolvedPage): React.ReactNode {


### PR DESCRIPTION
## Summary

PR #108 merged four new section components (enhanced-faq, our-story, b2b-wholesale, recipes) specifically for the granja-cabral egg-farm tenant, but none of them were referenced from any tenant's `pages/*.json` — they were dead code. This PR wires them in end-to-end.

## Changes

- **Registry** (`web/lib/engine/section-registry.ts`): register the four new sections in `SECTION_CATALOG` so `validate-sites` accepts them in tenant page configs.
- **Site renderer** (`web/lib/engine/site-renderer.tsx`): bind the four section ids to their React components (previously only `renderer.tsx` — used by the legacy per-business-type path — had `recipes`; the tenant/sites renderer had none of them).
- **Agriculture vertical** (`src/verticals/agriculture-agribusiness/vertical.json`): add `our-story`, `b2b-wholesale`, `enhanced-faq`, `recipes` to `allowedSections` so agriculture tenants may use them without tripping the vertical whitelist check.
- **Granja Cabral home page** (`sites/granja-cabral/pages/home.json`): replace the 7-section layout with a richer 11-section composition:
  `header → hero → our-story → services → b2b-wholesale → recipes → testimonials → enhanced-faq → contact → footer → whatsapp-float`
- **Granja Cabral content** (`sites/granja-cabral/content/es.json`): add `home.ourStory`, `home.wholesale`, `home.recipes`, `home.enhancedFaq` content refs. Each component expects a `business` prop (name, whatsapp, phone, address; plus story/stats/sustainability for our-story), so the content supplies that shape with real data (Coronel Oviedo, Laura Cabral, Ruta 2 Km 125-140, 500+ gallinas).

## Placeholder copy still needing real data

Flagged in `_meta.placeholders` in `content/es.json`:

- `home.ourStory.business.story.founded` — founding year unconfirmed.
- `home.ourStory.business.story.mission/vision/values` — drafted from research, pending Laura sign-off.
- `home.ourStory.business.stats` — `500+ gallinas`, `300+ negocios`, etc. are estimates.
- `home.ourStory.business.sustainability.biogas` — aspirational (planned, not operational).
- FAQ questions, B2B tiers/industries, and the recipe list are currently hard-coded inside the PR-#108 components themselves. A follow-up pass should move those arrays into content/es.json; for now the content ref only supplies business contact info so the components at least receive their required `business` prop.

## Validation

- `npm run validate:sites` — `116 site(s) OK`
- `npm run typecheck` — clean for changed files (3 pre-existing errors in `app/page.tsx` are unrelated, present on Main)
- `npm run lint` — 0 new errors in changed files (20 pre-existing errors in `app/page.tsx` are unrelated)
- `npx vitest run tests/unit/registry-contract.test.ts` — 9/9 pass
- `npx vitest run tests/unit/compose.test.ts` — 18/18 pass
- Full unit suite: 453 passed, 11 skipped (5 failures are pre-existing Playwright/e2e configuration issues, not related to this change)

## Test plan

- [ ] Hit `/s/es/granja-cabral` in dev and confirm all 11 sections render without runtime errors
- [ ] Visual review of section order + Laura's story block with the placeholder copy
- [ ] Follow-up ticket: move FAQ/B2B/recipe arrays out of components into content/es.json so content is editable without a code change

Generated with [Claude Code](https://claude.com/claude-code)