### PR TITLE
feat(a11y): skip-to-content link

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 70 | see closure log below |
+| ✅ Closed | 73 | see closure log below |
 | 🟡 In progress | 0 | — |
-| 🔴 Open | 430 | the rest |
+| 🔴 Open | 427 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -98,6 +98,10 @@ Closure log:
 - **#482** — per-route Cache-Control headers in `next.config.mjs`:
   admin/auth/login → `no-store`; sitemap/robots → 1d browser, 1w CDN;
   OG images + favicon → 1d browser, 1w CDN, 30d SWR.
+- **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
+  added id to `<main>` on landing + 11 high-traffic marketing routes.
+- **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).
+- **#488** — covered by `docs/runbooks/ENV_VARS.md` "How to rotate a secret" section (no separate doc needed).
 
 ## Blocked on user input
 

--- a/web/app/blog/[slug]/page.tsx
+++ b/web/app/blog/[slug]/page.tsx
@@ -59,7 +59,7 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
   return (
     <>
       <SiteNav />
-      <main className="pt-24 pb-20">
+      <main id="main-content" className="pt-24 pb-20">
         <Container size="md">
           <article className="mx-auto max-w-3xl">
             <Link

--- a/web/app/blog/page.tsx
+++ b/web/app/blog/page.tsx
@@ -20,7 +20,7 @@ export default function BlogIndexPage() {
   return (
     <>
       <SiteNav />
-      <main className="pt-24 pb-20">
+      <main id="main-content" className="pt-24 pb-20">
         <Container>
           <div className="mx-auto mb-16 max-w-2xl text-center">
             <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">

--- a/web/app/c/[ciudad]/[rubro]/page.tsx
+++ b/web/app/c/[ciudad]/[rubro]/page.tsx
@@ -66,7 +66,7 @@ export default async function CityVerticalPage({ params }: { params: Promise<Par
   return (
     <>
       <SiteNav />
-      <main>
+      <main id="main-content">
         {/* Hero */}
         <section className="relative overflow-hidden pt-32 pb-16 md:pt-40 md:pb-24">
           <div

--- a/web/app/c/[ciudad]/page.tsx
+++ b/web/app/c/[ciudad]/page.tsx
@@ -42,7 +42,7 @@ export default async function CityPage({ params }: { params: Promise<Params> }) 
   return (
     <>
       <SiteNav />
-      <main>
+      <main id="main-content">
         {/* Hero */}
         <section className="pt-32 pb-16 md:pt-40">
           <Container>

--- a/web/app/c/page.tsx
+++ b/web/app/c/page.tsx
@@ -17,7 +17,7 @@ export default function CitiesIndexPage() {
   return (
     <>
       <SiteNav />
-      <main className="pt-24 pb-20">
+      <main id="main-content" className="pt-24 pb-20">
         <Container>
           <div className="mx-auto mb-16 max-w-2xl text-center">
             <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">

--- a/web/app/casos/[cliente]/page.tsx
+++ b/web/app/casos/[cliente]/page.tsx
@@ -41,7 +41,7 @@ export default async function CaseStudyPage({ params }: { params: Promise<Params
     <>
       <SiteNav />
 
-      <main>
+      <main id="main-content">
         {/* Hero */}
         <section className="relative overflow-hidden pt-32 pb-12 md:pt-40 md:pb-20">
           <div

--- a/web/app/casos/page.tsx
+++ b/web/app/casos/page.tsx
@@ -18,7 +18,7 @@ export default function CaseStudiesIndexPage() {
   return (
     <>
       <SiteNav />
-      <main className="pt-24 pb-20">
+      <main id="main-content" className="pt-24 pb-20">
         <Container>
           <div className="mx-auto mb-16 max-w-2xl text-center">
             <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">

--- a/web/app/comparacion/page.tsx
+++ b/web/app/comparacion/page.tsx
@@ -57,7 +57,7 @@ export default function ComparacionPage() {
   return (
     <>
       <SiteNav />
-      <main className="pt-24 pb-20">
+      <main id="main-content" className="pt-24 pb-20">
         <Container>
           <div className="mx-auto mb-12 max-w-2xl text-center">
             <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">

--- a/web/app/demo/page.tsx
+++ b/web/app/demo/page.tsx
@@ -15,7 +15,7 @@ export default function DemoPage() {
   return (
     <>
       <SiteNav />
-      <main className="pt-24 pb-20">
+      <main id="main-content" className="pt-24 pb-20">
         <Container>
           <div className="mx-auto mb-10 max-w-2xl text-center">
             <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import './globals.css'
 import { HOME_FAQS, HOME_PLANS_SCHEMA, HOME_REVIEWS } from '@/lib/landing/home-data'
 import { WebVitalsReporter } from '@/components/analytics/web-vitals-reporter'
+import { SkipToContent } from '@/components/ui/skip-to-content'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://paragu-ai.com'),
@@ -120,6 +121,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body className="antialiased">
+        <SkipToContent />
         <WebVitalsReporter />
         {children}
       </body>

--- a/web/app/p/[rubro]/page.tsx
+++ b/web/app/p/[rubro]/page.tsx
@@ -115,7 +115,7 @@ export default async function VerticalLandingPage({ params }: { params: Promise<
       />
       <SiteNav />
 
-      <main>
+      <main id="main-content">
         {/* Hero */}
         <section className="relative overflow-hidden pt-32 pb-16 md:pt-40 md:pb-24">
           <div

--- a/web/app/p/page.tsx
+++ b/web/app/p/page.tsx
@@ -20,7 +20,7 @@ export default function TemplatesIndexPage() {
   return (
     <>
       <SiteNav />
-      <main className="pt-24 pb-20">
+      <main id="main-content" className="pt-24 pb-20">
         <Container>
           <div className="mx-auto mb-16 max-w-2xl text-center">
             <p className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--primary)]">

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -513,7 +513,7 @@ export default function HomePage() {
       />
       <Navigation />
 
-      <main>
+      <main id="main-content">
         {/* ── Hero ──────────────────────────────────────────────── */}
         <section className="relative min-h-screen overflow-hidden pt-32 pb-20 md:pt-40 md:pb-28">
           <div className="absolute inset-0 -z-10">

--- a/web/app/precios/page.tsx
+++ b/web/app/precios/page.tsx
@@ -51,7 +51,7 @@ export default function PreciosPage() {
     <>
       <SiteNav />
 
-      <main>
+      <main id="main-content">
         {/* Hero */}
         <section className="pt-32 pb-12 md:pt-40">
           <Container>

--- a/web/components/ui/skip-to-content.tsx
+++ b/web/components/ui/skip-to-content.tsx
@@ -1,0 +1,10 @@
+export function SkipToContent({ targetId = 'main-content' }: { targetId?: string }) {
+  return (
+    <a
+      href={`#${targetId}`}
+      className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-md focus:bg-[var(--primary)] focus:px-4 focus:py-2 focus:text-[var(--primary-foreground)] focus:shadow-lg focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-[var(--accent)]"
+    >
+      Saltar al contenido principal
+    </a>
+  )
+}


### PR DESCRIPTION
## Summary
- New `<SkipToContent>` component (sr-only, focusable) in root layout
- Anchored to `#main-content`; added id to `<main>` on 12 high-traffic routes
- Closes BUG_HUNT_500 #479 (skip-to-content), #487 (already in ADD_NEW_TENANT), #488 (already in ENV_VARS)

## Test plan
- [x] Tab from page load — first focusable element shows "Saltar al contenido principal"
- [x] Enter on the link → focus jumps to `<main>`
- [x] Routes covered: `/`, `/p/[rubro]`, `/precios`, `/demo`, `/comparacion`, `/blog`, `/blog/[slug]`, `/c`, `/c/[ciudad]`, `/c/[ciudad]/[rubro]`, `/casos`, `/casos/[cliente]`, `/p`
- [x] Pre-existing typecheck errors in `app/page.tsx:671` are unrelated (confirmed by stash baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)