### PR TITLE
perf(fonts): remove dead preconnects (closes #472)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 67 | see closure log below |
+| ✅ Closed | 68 | see closure log below |
 | 🟡 In progress | 0 | — |
-| 🔴 Open | 433 | the rest |
+| 🔴 Open | 432 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -87,6 +87,10 @@ Closure log:
 - **#475** — cron tests for `leads-digest` (5 tests: 403, skipped, send-per-recipient,
   malformed-referrer, supabase-error) and `sitemap-ping` (4 tests: 403, all-targets-pinged,
   per-target-error-captured, GET=POST). 9/9 passing.
+- **#472** — FOIT verified absent. Marketing landing uses no custom fonts
+  (system-ui sans-serif). Tenant sites load Google Fonts via
+  `resolve-site-tokens.ts:190` which appends `&display=swap` (FOUT, no FOIT).
+  Removed unused `fonts.googleapis.com` preconnect from root layout.
 
 ## Blocked on user input
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -36,8 +36,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="es">
       <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Summary
- Marketing landing uses no custom fonts → removed `fonts.googleapis.com` and `fonts.gstatic.com` preconnects from root layout
- Tenant sites already load Google Fonts with `&display=swap` appended (verified at `resolve-site-tokens.ts:190`) → FOIT was never possible
- Closes BUG_HUNT_500 #472

## Test plan
- [x] Landing renders identically (system-ui was already the active font)
- [x] No regression on tenant sites (their per-tenant googleFontsUrl link tag is unaffected)
- [ ] After deploy: re-run Lighthouse on landing — expect no `font-display` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)