### PR TITLE
test(cron): integration tests for leads-digest + sitemap-ping

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 66 | see closure log below |
+| ✅ Closed | 67 | see closure log below |
 | 🟡 In progress | 0 | — |
-| 🔴 Open | 434 | the rest |
+| 🔴 Open | 433 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -84,6 +84,9 @@ Closure log:
   dead "Próximamente" branch in `app/page.tsx:667-680` (every TEMPLATE in
   the local list has demoSlug, so else branch was unreachable and TS
   narrowed `template` to `never`). `npx tsc --noEmit` in `web/` now exits 0.
+- **#475** — cron tests for `leads-digest` (5 tests: 403, skipped, send-per-recipient,
+  malformed-referrer, supabase-error) and `sitemap-ping` (4 tests: 403, all-targets-pinged,
+  per-target-error-captured, GET=POST). 9/9 passing.
 
 ## Blocked on user input
 

--- a/web/tests/integration/cron-leads-digest.test.ts
+++ b/web/tests/integration/cron-leads-digest.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Cron route tests for /api/cron/leads-digest.
+ * Closes BUG_HUNT_500 #475.
+ *
+ * Coverage:
+ *   - 403 when x-cron-secret mismatch
+ *   - skipped:true when required env missing
+ *   - sends one email per recipient when events exist
+ *   - filters analytics_events by metadata.source = 'demo_qualifier'
+ *   - tolerates a malformed referrer URL (no crash)
+ *   - 500 path when supabase read errors
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mockSendTransactional = vi.fn()
+const mockSelect = vi.fn()
+const mockFrom = vi.fn(() => ({ select: mockSelect }))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(async () => ({ from: mockFrom })),
+}))
+
+vi.mock('@/lib/integrations/email/resend', () => ({
+  resendAdapter: { sendTransactional: mockSendTransactional },
+}))
+
+vi.mock('@/lib/landing/marketing-data', () => ({
+  TEMPLATES: [
+    { id: 'peluqueria', name: 'Peluquería' },
+    { id: 'gimnasio', name: 'Gimnasio' },
+  ],
+}))
+
+// Build the chained query mock that route code uses.
+function chainable(rows: unknown[], error: unknown = null) {
+  const final = { data: rows, error }
+  const limit = vi.fn(() => final)
+  const order = vi.fn(() => ({ limit }))
+  const gte = vi.fn(() => ({ order }))
+  const eq = vi.fn(() => ({ gte }))
+  return { eq }
+}
+
+describe('/api/cron/leads-digest POST', () => {
+  const ORIGINAL_ENV = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('returns 403 when x-cron-secret mismatches', async () => {
+    process.env.CRON_SECRET = 'expected-secret'
+    const { POST } = await import('@/app/api/cron/leads-digest/route')
+    const req = new Request('http://localhost/api/cron/leads-digest', {
+      method: 'POST',
+      headers: { 'x-cron-secret': 'wrong' },
+    })
+    const res = await POST(req, {} as never)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns skipped when required env missing', async () => {
+    process.env.CRON_SECRET = 's'
+    delete process.env.RESEND_API_KEY
+    delete process.env.LEADS_DIGEST_FROM
+    delete process.env.LEADS_DIGEST_TO
+    const { POST } = await import('@/app/api/cron/leads-digest/route')
+    const req = new Request('http://localhost/api/cron/leads-digest', {
+      method: 'POST',
+      headers: { 'x-cron-secret': 's' },
+    })
+    const res = await POST(req, {} as never)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({ skipped: true })
+  })
+
+  it('sends one email per recipient when events exist', async () => {
+    process.env.CRON_SECRET = 's'
+    process.env.RESEND_API_KEY = 're_test'
+    process.env.LEADS_DIGEST_FROM = 'leads@paragu-ai.com'
+    process.env.LEADS_DIGEST_TO = 'a@example.com, b@example.com'
+
+    mockFrom.mockReturnValue({
+      select: vi.fn(() =>
+        chainable([
+          {
+            id: '1',
+            lead_id: 'lead-1',
+            created_at: new Date().toISOString(),
+            metadata: { source: 'demo_qualifier', rubro: 'peluqueria', size: 'small', presence: 'none' },
+            referrer: 'https://paragu-ai.com/demo',
+          },
+          {
+            id: '2',
+            lead_id: 'lead-2',
+            created_at: new Date().toISOString(),
+            metadata: { source: 'organic_form' }, // should be filtered out
+            referrer: null,
+          },
+        ]),
+      ),
+    } as never)
+
+    mockSendTransactional.mockResolvedValue({ ok: true })
+
+    const { POST } = await import('@/app/api/cron/leads-digest/route')
+    const req = new Request('http://localhost/api/cron/leads-digest', {
+      method: 'POST',
+      headers: { 'x-cron-secret': 's' },
+    })
+    const res = await POST(req, {} as never)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    // Only the demo_qualifier row should be counted.
+    expect(body.leads).toBe(1)
+    // One send per recipient.
+    expect(mockSendTransactional).toHaveBeenCalledTimes(2)
+  })
+
+  it('tolerates malformed referrer URLs', async () => {
+    process.env.CRON_SECRET = 's'
+    process.env.RESEND_API_KEY = 're_test'
+    process.env.LEADS_DIGEST_FROM = 'leads@paragu-ai.com'
+    process.env.LEADS_DIGEST_TO = 'a@example.com'
+
+    mockFrom.mockReturnValue({
+      select: vi.fn(() =>
+        chainable([
+          {
+            id: '1',
+            lead_id: 'lead-1',
+            created_at: new Date().toISOString(),
+            metadata: { source: 'demo_qualifier' },
+            referrer: 'not-a-valid-url at all', // would throw `new URL(...)`
+          },
+        ]),
+      ),
+    } as never)
+    mockSendTransactional.mockResolvedValue({ ok: true })
+
+    const { POST } = await import('@/app/api/cron/leads-digest/route')
+    const req = new Request('http://localhost/api/cron/leads-digest', {
+      method: 'POST',
+      headers: { 'x-cron-secret': 's' },
+    })
+    const res = await POST(req, {} as never)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.leads).toBe(1)
+  })
+
+  it('returns 500 when supabase read fails', async () => {
+    process.env.CRON_SECRET = 's'
+    process.env.RESEND_API_KEY = 're_test'
+    process.env.LEADS_DIGEST_FROM = 'leads@paragu-ai.com'
+    process.env.LEADS_DIGEST_TO = 'a@example.com'
+
+    mockFrom.mockReturnValue({
+      select: vi.fn(() => chainable([], { message: 'connection refused' })),
+    } as never)
+
+    const { POST } = await import('@/app/api/cron/leads-digest/route')
+    const req = new Request('http://localhost/api/cron/leads-digest', {
+      method: 'POST',
+      headers: { 'x-cron-secret': 's' },
+    })
+    const res = await POST(req, {} as never)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toBe('read_failed')
+    expect(mockSendTransactional).not.toHaveBeenCalled()
+  })
+})

--- a/web/tests/integration/cron-sitemap-ping.test.ts
+++ b/web/tests/integration/cron-sitemap-ping.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Cron route tests for /api/cron/sitemap-ping.
+ * Closes BUG_HUNT_500 #475 (companion to leads-digest tests).
+ *
+ * Coverage:
+ *   - 403 when x-cron-secret mismatch
+ *   - GET aliases POST
+ *   - 200 + per-target results when fetch succeeds
+ *   - per-target error captured (no throw) when one fetch rejects
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+describe('/api/cron/sitemap-ping POST', () => {
+  const ORIGINAL_ENV = { ...process.env }
+  const ORIGINAL_FETCH = global.fetch
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+    global.fetch = ORIGINAL_FETCH
+  })
+
+  it('returns 403 when x-cron-secret mismatches', async () => {
+    process.env.CRON_SECRET = 'expected'
+    const { POST } = await import('@/app/api/cron/sitemap-ping/route')
+    const req = new Request('http://localhost/api/cron/sitemap-ping', {
+      method: 'POST',
+      headers: { 'x-cron-secret': 'wrong' },
+    })
+    const res = await POST(req, {} as never)
+    expect(res.status).toBe(403)
+  })
+
+  it('pings all targets when secret matches', async () => {
+    process.env.CRON_SECRET = 's'
+    global.fetch = vi.fn(async () => new Response(null, { status: 200 })) as typeof global.fetch
+
+    const { POST } = await import('@/app/api/cron/sitemap-ping/route')
+    const req = new Request('http://localhost/api/cron/sitemap-ping', {
+      method: 'POST',
+      headers: { 'x-cron-secret': 's' },
+    })
+    const res = await POST(req, {} as never)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.results).toHaveLength(2)
+    expect(body.results.every((r: { ok: boolean }) => r.ok)).toBe(true)
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('captures per-target failure without throwing', async () => {
+    process.env.CRON_SECRET = 's'
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockRejectedValueOnce(new Error('DNS failure')) as typeof global.fetch
+
+    const { POST } = await import('@/app/api/cron/sitemap-ping/route')
+    const req = new Request('http://localhost/api/cron/sitemap-ping', {
+      method: 'POST',
+      headers: { 'x-cron-secret': 's' },
+    })
+    const res = await POST(req, {} as never)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.results).toHaveLength(2)
+    const failed = body.results.find((r: { ok: boolean }) => !r.ok)
+    expect(failed).toBeDefined()
+    expect(failed.error).toMatch(/DNS failure/)
+  })
+
+  it('GET is the same handler as POST', async () => {
+    const mod = await import('@/app/api/cron/sitemap-ping/route')
+    expect(mod.GET).toBe(mod.POST)
+  })
+})


### PR DESCRIPTION
## Summary
- 9 new integration tests covering both cron routes
- `leads-digest`: 403, skipped, send-per-recipient, malformed-referrer (regression test for the actual bug we just fixed in prod), supabase-error
- `sitemap-ping`: 403, all-targets-pinged, per-target-error-captured (one bad fetch doesn't tank the rest), GET=POST aliasing
- Closes BUG_HUNT_500 #475

## Test plan
- [x] `npx vitest run tests/integration/cron-*.test.ts` → 9/9 passing locally in 1.2s
- [ ] CI runs them on next push

🤖 Generated with [Claude Code](https://claude.com/claude-code)