### PR TITLE
fix(typecheck): zero errors — drop unreachable code (closes #381-385)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 61 | see closure log below |
+| ✅ Closed | 66 | see closure log below |
 | 🟡 In progress | 0 | — |
-| 🔴 Open | 439 | the rest |
+| 🔴 Open | 434 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -78,6 +78,12 @@ Closure log:
 - **#388** — `_citiesError` / `_typesError` in `app/admin/leads/page.tsx`
   were silently swallowed — replaced with explicit `logger.warn` calls
   per error-handling rules (no more silent failure on filter dropdowns).
+- **#381, #382, #383, #384, #385** — re-verified: typecheck errors in
+  hero-section.tsx, why-destination-section.tsx, commerce-email-flush
+  route, and commerce schemas all resolved by prior PRs. Plus removed
+  dead "Próximamente" branch in `app/page.tsx:667-680` (every TEMPLATE in
+  the local list has demoSlug, so else branch was unreachable and TS
+  narrowed `template` to `never`). `npx tsc --noEmit` in `web/` now exits 0.
 
 ## Blocked on user input
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -652,43 +652,28 @@ export default function HomePage() {
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
               {TEMPLATES.filter(t => t.leads > 0 || t.demoSlug).map((template, idx) => (
                 <FadeIn key={template.id} delay={idx * 50}>
-                  {template.demoSlug ? (
-                    <a
-                      href={`/${template.demoSlug}`}
-                      className="group flex items-center gap-4 rounded-xl border border-gray-200 bg-white p-4 transition-all hover:border-blue-300 hover:shadow-md"
+                  <a
+                    href={`/${template.demoSlug}`}
+                    className="group flex items-center gap-4 rounded-xl border border-gray-200 bg-white p-4 transition-all hover:border-blue-300 hover:shadow-md"
+                  >
+                    <div
+                      className="flex h-12 w-12 items-center justify-center rounded-xl text-white"
+                      style={{ backgroundColor: template.color }}
                     >
-                      <div 
-                        className="flex h-12 w-12 items-center justify-center rounded-xl text-white"
-                        style={{ backgroundColor: template.color }}
-                      >
-                        <template.icon size={24} />
-                      </div>
-                      <div className="flex-1">
-                        <h3 className="font-semibold text-gray-900 group-hover:text-blue-600">
-                          {template.name}
-                        </h3>
-                        {template.leads > 0 && (
-                          <p className="text-xs text-gray-500">
-                            {template.leads.toLocaleString()} negocios en PY
-                          </p>
-                        )}
-                      </div>
-                      <ArrowRight size={16} className="text-gray-400 group-hover:text-blue-600" />
-                    </a>
-                  ) : (
-                    <div className="flex items-center gap-4 rounded-xl border border-gray-100 bg-gray-50 p-4 opacity-60">
-                      <div 
-                        className="flex h-12 w-12 items-center justify-center rounded-xl text-white"
-                        style={{ backgroundColor: template.color }}
-                      >
-                        <template.icon size={24} />
-                      </div>
-                      <div>
-                        <h3 className="font-semibold text-gray-700">{template.name}</h3>
-                        <p className="text-xs text-gray-400">Próximamente</p>
-                      </div>
+                      <template.icon size={24} />
                     </div>
-                  )}
+                    <div className="flex-1">
+                      <h3 className="font-semibold text-gray-900 group-hover:text-blue-600">
+                        {template.name}
+                      </h3>
+                      {template.leads > 0 && (
+                        <p className="text-xs text-gray-500">
+                          {template.leads.toLocaleString()} negocios en PY
+                        </p>
+                      )}
+                    </div>
+                    <ArrowRight size={16} className="text-gray-400 group-hover:text-blue-600" />
+                  </a>
                 </FadeIn>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- `npx tsc --noEmit` in `web/` now exits **0** (was 3 errors at `app/page.tsx:671/673/676`)
- Root cause: local TEMPLATES literal is `as const` and every entry has a non-null `demoSlug`. TS narrowed the else branch of `template.demoSlug ? ... : ...` to `never`.
- Fix: drop the unreachable "Próximamente" placeholder card. Same UX (the `.filter()` already excluded slug-less templates).
- Verified prior PRs already cleared the other 5 typecheck items (#381–#385: hero-section, why-destination, commerce schemas, commerce-email-flush).

Closes BUG_HUNT_500 #381, #382, #383, #384, #385.

## Test plan
- [x] `cd web && npx tsc --noEmit` → exit 0
- [x] Visual check of `/` "Diseños por tipo de negocio" grid — same cards render (every TEMPLATE has demoSlug, the deleted branch was never reached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)