### PR TITLE
docs+chore: LOG_FORMAT doc + log swallowed errors (#391, #388)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 59 | see closure log below |
+| ✅ Closed | 61 | see closure log below |
 | 🟡 In progress | 0 | — |
-| 🔴 Open | 441 | the rest |
+| 🔴 Open | 439 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -72,6 +72,12 @@ Closure log:
 - **#414** — `react/jsx-no-target-blank` rule enabled as ERROR in
   `eslint.config.mjs` (next preset turned it off, we override). Codebase
   already clean — zero violations. Prevents reverse-tabnabbing regressions.
+- **#391** — `LOG_LEVEL` and `LOG_FORMAT` env vars documented in
+  `docs/runbooks/ENV_VARS.md` with values, defaults, and where in the
+  code they're read (`web/lib/obs/logger.ts:106,111`).
+- **#388** — `_citiesError` / `_typesError` in `app/admin/leads/page.tsx`
+  were silently swallowed — replaced with explicit `logger.warn` calls
+  per error-handling rules (no more silent failure on filter dropdowns).
 
 ## Blocked on user input
 

--- a/docs/runbooks/ENV_VARS.md
+++ b/docs/runbooks/ENV_VARS.md
@@ -60,6 +60,21 @@
 > `https://paragu-ai.com/googleb5b0b1b9be89eed8.html` resolves and Google
 > verifies.
 
+### Logging
+
+| Var | Values | Default | Notes |
+|---|---|---|---|
+| `LOG_LEVEL` | `debug` \| `info` \| `warn` \| `error` | `info` in prod, `debug` elsewhere | Read by `web/lib/obs/logger.ts:106`. Lower-cased before lookup. Anything unknown falls back to the default. |
+| `LOG_FORMAT` | `json` \| `pretty` | `json` in prod, `pretty` elsewhere | Read by `web/lib/obs/logger.ts:111`. `pretty` is colored single-line for terminals; `json` is one structured object per line for log aggregators (Axiom, Datadog, Loki). |
+
+Set both to `debug` + `pretty` on your laptop for readable local development.
+Leave both unset on the VPS — the production default is `info` + `json` which is what
+Cloudflare/Axiom expects.
+
+If you change `LOG_FORMAT=pretty` on the VPS for one-off debugging, remember
+that `docker service logs` will keep showing colorized output until you set
+it back. The diagnostics route at `/api/diagnostics` reflects current values.
+
 ### Mailchimp (deferred per Q8.2)
 
 Skip until the newsletter flow becomes a priority. When you wire it:

--- a/web/app/admin/leads/page.tsx
+++ b/web/app/admin/leads/page.tsx
@@ -174,18 +174,18 @@ async function getStats(): Promise<Stats> {
 
 async function getFilterOptions() {
   const supabase = await createClient()
-  
-  // Get unique cities
-  const { data: cities, error: _citiesError } = await supabase
+
+  const { data: cities, error: citiesError } = await supabase
     .from('leads')
     .select('city')
     .order('city')
-  
-  // Get unique business types
-  const { data: types, error: _typesError } = await supabase
+  if (citiesError) logger.warn('Admin leads cities filter fetch failed', { error: citiesError.message })
+
+  const { data: types, error: typesError } = await supabase
     .from('leads')
     .select('business_type')
     .order('business_type')
+  if (typesError) logger.warn('Admin leads types filter fetch failed', { error: typesError.message })
   
   return {
     cities: [...new Set((cities || []).map(c => c.city))].filter(Boolean),


### PR DESCRIPTION
## Summary
- **#391**: New "Logging" section in `docs/runbooks/ENV_VARS.md` documenting `LOG_LEVEL` and `LOG_FORMAT` (values, defaults, where they're read in `web/lib/obs/logger.ts`)
- **#388**: `_citiesError` / `_typesError` in `app/admin/leads/page.tsx` were destructured-then-discarded to silence the lint warning — silent error swallow. Replaced with explicit `logger.warn` calls. Filter dropdowns still degrade gracefully (`|| []` fallback) but failures now surface in observability.

## Test plan
- [x] ENV_VARS.md renders cleanly with the new section
- [x] `app/admin/leads/page.tsx` still type-checks (no behavior change beyond the new warns)
- [ ] After deploy: trigger the unhappy path (e.g., temporary RLS deny) and confirm the warn appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)