### PR TITLE
chore(lint): enforce react/jsx-no-target-blank as error (#414)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 58 | see closure log below |
+| ✅ Closed | 59 | see closure log below |
 | 🟡 In progress | 0 | — |
-| 🔴 Open | 442 | the rest |
+| 🔴 Open | 441 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -69,6 +69,9 @@ Closure log:
   with the Asunción mapping called out, plus a pointer to the canonical
   table in `docs/runbooks/CRON_STRATEGY.md`. No more guessing what
   timezone "0 9 * * *" is in. (5 cron routes updated.)
+- **#414** — `react/jsx-no-target-blank` rule enabled as ERROR in
+  `eslint.config.mjs` (next preset turned it off, we override). Codebase
+  already clean — zero violations. Prevents reverse-tabnabbing regressions.
 
 ## Blocked on user input
 

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -30,6 +30,16 @@ const eslintConfig = [
     },
   },
 
+  // Every <a target="_blank"> must include rel="noopener noreferrer" to
+  // prevent the target page from accessing window.opener (reverse-tabnabbing).
+  // The next-config preset turns this off; we override back to error.
+  {
+    files: ['app/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}'],
+    rules: {
+      'react/jsx-no-target-blank': ['error', { allowReferrer: false, enforceDynamicLinks: 'always' }],
+    },
+  },
+
   // Legacy CommonJS scripts under web/scripts/**.js are dev-only utilities
   // (image optimization, content generation, etc.) — they are not part of the
   // shipped runtime and predate the move to ESM. Allow require() there.


### PR DESCRIPTION
## Summary
- `react/jsx-no-target-blank` rule was off (next-config preset turned it off) → reverse-tabnabbing risk for any future `<a target="_blank">` without `rel`
- Override to `error` in `eslint.config.mjs`, scoped to `app/**` and `components/**`
- Codebase already clean: zero violations on enable
- Closes BUG_HUNT_500 #414

## Test plan
- [x] `npx eslint app components | grep jsx-no-target-blank` → empty (no violations)
- [x] Other 20 pre-existing lint errors are unrelated (no-unescaped-entities, no-html-link-for-pages — separate cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)