### PR TITLE
docs(cron): every cron route states UTC schedule + Asuncion mapping (#457)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 57 | see closure log below |
+| ✅ Closed | 58 | see closure log below |
 | 🟡 In progress | 0 | — |
-| 🔴 Open | 443 | the rest |
+| 🔴 Open | 442 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -64,7 +64,11 @@ Closure log:
 - **#463, #470** — Lighthouse baseline run on 4 prod URLs; report saved to
   `docs/LIGHTHOUSE_BASELINE.md` with action items. Landing now 81/100 perf.
 - **#270** — "Esta es una demostración" banner — covered by `<DemoBadge>`.
-- **#485** — `docs/runbooks/ADD_NEW_VERTICAL.md` runbook published. Branch `docs/add-new-vertical`.
+- **#485** — `docs/runbooks/ADD_NEW_VERTICAL.md` runbook published.
+- **#457** — every cron route header now declares its schedule in UTC
+  with the Asunción mapping called out, plus a pointer to the canonical
+  table in `docs/runbooks/CRON_STRATEGY.md`. No more guessing what
+  timezone "0 9 * * *" is in. (5 cron routes updated.)
 
 ## Blocked on user input
 

--- a/web/app/api/cron/commerce-abandoned-cart/route.ts
+++ b/web/app/api/cron/commerce-abandoned-cart/route.ts
@@ -9,6 +9,9 @@ export const runtime = 'nodejs'
  * Identifies open carts older than the per-step threshold with a customer
  * email attached (via guest checkout attempts or signed-in users) and
  * enqueues a recovery email. Three touches: 24h, 72h, 7d.
+ *
+ * Schedule (UTC): every 4 hours. See docs/runbooks/CRON_STRATEGY.md
+ * for the canonical table. Protected by CRON_SECRET header.
  */
 const STEPS = [
   { step: 1, hoursAgo: 24 },

--- a/web/app/api/cron/commerce-email-flush/route.ts
+++ b/web/app/api/cron/commerce-email-flush/route.ts
@@ -10,7 +10,8 @@ export const runtime = 'nodejs'
  * Resend. Failures bump `attempts` and write `last_error`; after 5 attempts
  * rows are marked `failed` so they stop consuming cron cycles.
  *
- * Protected by CRON_SECRET header (set in hosting provider cron config).
+ * Schedule (UTC): every 5 minutes. See docs/runbooks/CRON_STRATEGY.md
+ * for the canonical table. Protected by CRON_SECRET header.
  */
 export const POST = withRequestLog(async (request, { log }) => {
   const cronSecret = process.env.CRON_SECRET

--- a/web/app/api/cron/commerce-reconcile-pending/route.ts
+++ b/web/app/api/cron/commerce-reconcile-pending/route.ts
@@ -9,6 +9,9 @@ export const runtime = 'nodejs'
  * Catches orders stuck in awaiting_payment > 6 hours and re-queries the
  * payment provider to drive them to a terminal state. Webhooks are usually
  * reliable; this is the safety net.
+ *
+ * Schedule (UTC): hourly. See docs/runbooks/CRON_STRATEGY.md for the
+ * canonical table. Protected by CRON_SECRET header.
  */
 export const POST = withRequestLog(async (request, { log }) => {
   if (process.env.CRON_SECRET && request.headers.get('x-cron-secret') !== process.env.CRON_SECRET) {

--- a/web/app/api/cron/leads-digest/route.ts
+++ b/web/app/api/cron/leads-digest/route.ts
@@ -14,7 +14,12 @@ export const runtime = 'nodejs'
  * Configure on the hosting cron with:
  *   POST https://paragu-ai.com/api/cron/leads-digest
  *   x-cron-secret: <CRON_SECRET>
- *   Schedule: 0 9 * * *  (9am Asunción time)
+ *   Crontab: 0 12 * * *  (12:00 UTC = 9:00 Asunción standard time)
+ *
+ * All schedules in this codebase are expressed in UTC. The Asunción mapping
+ * above assumes UTC-3 (standard time); during DST the local hour shifts by
+ * one. See docs/runbooks/CRON_STRATEGY.md for the canonical table and the
+ * "schedule in UTC, ignore DST" rationale.
  *
  * Required env:
  *   - CRON_SECRET                — header guard

--- a/web/app/api/cron/sitemap-ping/route.ts
+++ b/web/app/api/cron/sitemap-ping/route.ts
@@ -17,10 +17,11 @@ export const runtime = 'nodejs'
  * on their schedule. We keep the Google ping for completeness; it's a
  * no-op but doesn't hurt.
  *
- * Schedule:
+
+ * Schedule (UTC — see docs/runbooks/CRON_STRATEGY.md for the canonical table):
  *   POST https://paragu-ai.com/api/cron/sitemap-ping
  *   x-cron-secret: <CRON_SECRET>
- *   Cron: 0 8 * * 1   (Mondays 8am)
+ *   Crontab: 0 11 * * 1   (Mondays 11:00 UTC = 8:00 Asunción standard time)
  */
 
 const SITEMAP_URL = 'https://paragu-ai.com/sitemap.xml'


### PR DESCRIPTION
## Summary
- Each of the 5 cron route file headers now explicitly declares its schedule in UTC, maps to Asunción local time, and points to `docs/runbooks/CRON_STRATEGY.md` as the canonical table
- Closes BUG_HUNT_500 #457

Routes touched:
- `leads-digest` (12:00 UTC = 9:00 Asunción)
- `sitemap-ping` (Mon 11:00 UTC = 8:00 Asunción)
- `commerce-email-flush` (every 5 min UTC)
- `commerce-abandoned-cart` (every 4 h UTC)
- `commerce-reconcile-pending` (hourly UTC)

## Test plan
- [x] Behavior unchanged — comment-only edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)