### PR TITLE
chore(api): wrap /api/activity + audit unwrapped routes (#392 partial)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -10,7 +10,7 @@
 | Status | Count | Items |
 |---|---|---|
 | ✅ Closed | 73 | see closure log below |
-| 🟡 In progress | 0 | — |
+| 🟡 In progress | 1 | #392 (5 routes still unwrapped — audit in REQUEST_LOG_AUDIT.md) |
 | 🔴 Open | 427 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 

--- a/docs/REQUEST_LOG_AUDIT.md
+++ b/docs/REQUEST_LOG_AUDIT.md
@@ -1,0 +1,78 @@
+# Request-log middleware audit · 2026-04-21
+
+> Closes part of BUG_HUNT_500 #392. Tracks which API routes still need
+> `withRequestLog` wrapping. Update as routes are migrated.
+
+## Why this matters
+
+`withRequestLog` (defined in `web/lib/api/with-request-log.ts`) gives
+every request:
+
+- a request-scoped logger (`log.requestId`, contextual `trace.id` /
+  `span.id` / `http.method` / `url.path`)
+- a perf tracker
+- automatic `x-request-id` response header (so logs can be correlated
+  with a complaint or an Axiom search)
+- structured 500 fallback if the handler throws
+
+Routes that bypass the wrapper:
+- silently swallow exceptions or return Next.js defaults
+- have no `x-request-id` header → impossible to correlate with logs
+- log without trace context → harder to follow flows
+
+## Status
+
+Total API routes: ~50.
+
+| Status | Count |
+|---|---|
+| ✅ Wrapped | most (everything not listed below) |
+| ⚠️ Unwrapped | 5 |
+
+## Unwrapped routes (audit list)
+
+Verify with: `find web/app/api -name 'route.ts' | xargs grep -L withRequestLog`
+
+| Route | Lines | Methods | Why it matters |
+|---|---:|---|---|
+| `app/api/analytics/track/route.ts` | 223 | POST | High-traffic — every page view fires this. Cold-start latency was flagged in #423; wrapping gives request-id for diagnosing. |
+| `app/api/admin/daily-metrics/route.ts` | 397 | GET | Admin-only metrics dashboard. Failure modes are silent; needs structured logs. |
+| `app/api/reminders/route.ts` | 332 | GET, POST | Internal scheduling — needs trace context to debug stale reminders. |
+| `app/api/leads/bulk-update/route.ts` | 207 | POST | Bulk write path. A failure in the middle of the batch is currently un-correlatable with the upstream request. |
+| `app/api/leads/[id]/notes/route.ts` | 234 | GET, POST, PATCH, DELETE | Multi-method admin route. Each method should be wrapped individually. |
+
+## Recently wrapped
+
+| Route | Wrapped in |
+|---|---|
+| `app/api/activity/route.ts` | This audit's PR |
+
+## Wrapping pattern
+
+```ts
+// before
+export async function GET() {
+  return NextResponse.json({ ok: true })
+}
+
+// after
+export const GET = withRequestLog(async () => {
+  return NextResponse.json({ ok: true })
+})
+
+// for dynamic routes:
+export const GET = withRequestLog<{ id: string }>(async (req, ctx, { id }) => {
+  ctx.log.info('Fetched', { id })
+  return NextResponse.json({ id })
+})
+```
+
+`ctx` gives you `log`, `perf`, `requestId`. Replace any inline
+`logger.info(...)` calls with `ctx.log.info(...)` so they inherit the
+request's trace context.
+
+## Verification
+
+After wrapping a route, add a smoke test that asserts
+`response.headers.get('x-request-id')` is truthy. See
+`web/tests/integration/api-activity.test.ts` for the pattern.

--- a/web/app/api/activity/route.ts
+++ b/web/app/api/activity/route.ts
@@ -10,6 +10,7 @@
  * launches, never sub-minute.
  */
 import { NextResponse } from 'next/server'
+import { withRequestLog } from '@/lib/api/with-request-log'
 import { REAL_CLIENTS } from '@/lib/landing/marketing-data'
 
 export const runtime = 'nodejs'
@@ -25,7 +26,7 @@ export type ActivityEntry = {
   ago?: string
 }
 
-export async function GET() {
+export const GET = withRequestLog(async () => {
   const entries: ActivityEntry[] = REAL_CLIENTS.map((c, i) => ({
     slug: c.slug,
     name: c.name,
@@ -36,4 +37,4 @@ export async function GET() {
   }))
 
   return NextResponse.json({ entries })
-}
+})

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -4,8 +4,8 @@ import { useState, useEffect } from 'react'
 import {
   Scissors, Dumbbell, Flower2, Hand, PenTool, User, Sparkles,
   Palette, Zap, Eye, Globe, Smartphone, Search, MessageCircle,
-  ArrowRight, BarChart3, Layers, Wand2, Star,
-  MapPin, Users, TrendingUp, ShoppingCart, Check,
+  ArrowRight, Layers, Wand2, Star,
+  ShoppingCart, Check,
   Menu, X as XIcon, PlayCircle,
   UtensilsCrossed, Fish, CircleDot,
   RotateCcw, Activity, Unlock,
@@ -16,7 +16,6 @@ import { Container } from '@/components/ui/container'
 import { FadeIn } from '@/components/landing/fade-in'
 import { FAQItem } from '@/components/landing/faq-item'
 import { LogoStrip } from '@/components/landing/logo-strip'
-import { PressStrip } from '@/components/landing/press-strip'
 import { FloatingShape } from '@/components/landing/chrome'
 
 /* ── Schema.org Structured Data ────────────────────────────────── */
@@ -370,7 +369,6 @@ const FAQS = [
   { question: '¿Qué pasa si no me gusta el sitio?', answer: 'Tenés 30 días de garantía. Si no te convence, te devolvemos el 100% del setup. Sin preguntas ni letra chica.' },
 ]
 
-const SECTIONS = ['clientes', 'rubros', 'como-funciona', 'precios', 'faq']
 
 /* ── Helper Functions ───────────────────────────────────────────── */
 
@@ -710,7 +708,7 @@ export default function HomePage() {
 
             <FadeIn delay={500}>
               <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-                {GUARANTEES.map((g, idx) => (
+                {GUARANTEES.map((g) => (
                   <div key={g.title} className="flex items-start gap-3 rounded-xl bg-white p-4">
                     <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
                       <g.icon size={20} />

--- a/web/tests/integration/api-activity.test.ts
+++ b/web/tests/integration/api-activity.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Smoke test for /api/activity — verifies the route is wrapped in
+ * withRequestLog (gets x-request-id stamped) and returns the expected shape.
+ * Closes part of #392.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/lib/landing/marketing-data', () => ({
+  REAL_CLIENTS: [
+    { slug: 'a', name: 'A', href: '/casos/a', vertical: 'V1' },
+    { slug: 'b', name: 'B', href: '/casos/b', vertical: 'V2' },
+  ],
+}))
+
+describe('/api/activity GET', () => {
+  it('returns entries with the expected shape', async () => {
+    const { GET } = await import('@/app/api/activity/route')
+    const req = new Request('http://localhost/api/activity', { method: 'GET' })
+    const res = await GET(req, {} as never)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.entries).toHaveLength(2)
+    expect(body.entries[0]).toMatchObject({
+      slug: 'a',
+      name: 'A',
+      href: '/casos/a',
+      context: 'V1',
+      ago: 'hoy',
+    })
+  })
+
+  it('stamps x-request-id (proof withRequestLog is active)', async () => {
+    const { GET } = await import('@/app/api/activity/route')
+    const req = new Request('http://localhost/api/activity', { method: 'GET' })
+    const res = await GET(req, {} as never)
+    expect(res.headers.get('x-request-id')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- `/api/activity` GET handler now wrapped in `withRequestLog` → gains `x-request-id` stamping, trace context, structured 500 fallback
- New `tests/integration/api-activity.test.ts` (2 tests, both passing) — asserts response shape AND that the `x-request-id` header is set (proof the wrapper fired)
- New `docs/REQUEST_LOG_AUDIT.md` catalogs the 5 remaining unwrapped routes with LOC counts and why each matters, plus the wrapping pattern and verification idiom for follow-up PRs

#392 in-progress in BUG_HUNT_500 — 1/6 routes wrapped. Remaining: `analytics/track` (223 LOC), `admin/daily-metrics` (397), `reminders` (332), `leads/bulk-update` (207), `leads/[id]/notes` (234).

## Test plan
- [x] `npx vitest run tests/integration/api-activity.test.ts` → 2/2 passing
- [x] Audit doc accurately reflects current state per `find … xargs grep -L`

🤖 Generated with [Claude Code](https://claude.com/claude-code)