### PR TITLE
feat(commerce): discounts admin + reconciliation + cart-recovery + multi-currency + CSV import

### DIFF
--- a/supabase/migrations/20260422000400_commerce_email_outbox_cart_recovery.sql
+++ b/supabase/migrations/20260422000400_commerce_email_outbox_cart_recovery.sql
@@ -1,0 +1,19 @@
+-- Allow the abandoned-cart cron to enqueue recovery emails into the outbox.
+-- Each of the 3 touch steps (24h / 72h / 7d) gets its own template id so
+-- downstream analytics + unsubscribe logic can distinguish them.
+
+ALTER TABLE commerce_email_outbox
+  DROP CONSTRAINT IF EXISTS commerce_email_outbox_template_check;
+
+ALTER TABLE commerce_email_outbox
+  ADD CONSTRAINT commerce_email_outbox_template_check
+    CHECK (template IN (
+      'order_confirmation',
+      'order_paid',
+      'order_shipped',
+      'order_refunded',
+      'low_stock_digest',
+      'cart_recovery_24h',
+      'cart_recovery_72h',
+      'cart_recovery_7d'
+    ));

--- a/web/app/admin/commerce/[businessId]/discounts/page.tsx
+++ b/web/app/admin/commerce/[businessId]/discounts/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+import { listDiscounts } from '@/lib/commerce/discounts-admin'
+import { DiscountsManager } from '@/components/admin/commerce/discounts-manager'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export default async function DiscountsPage({
+  params,
+}: {
+  params: Promise<{ businessId: string }>
+}) {
+  const { businessId } = await params
+  const discounts = await listDiscounts(businessId)
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <Link href={`/admin/commerce/${businessId}/products`} className="mb-4 inline-block text-sm text-[color:var(--primary,#111)] underline">
+        ← Volver a productos
+      </Link>
+      <h1 className="mb-1 text-2xl font-bold">Códigos de descuento</h1>
+      <p className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">
+        Creá cupones que el shopper aplica en el checkout. Podés ser porcentuales, monto fijo, o envío gratis.
+      </p>
+      <DiscountsManager businessId={businessId} initialDiscounts={discounts} />
+    </div>
+  )
+}

--- a/web/app/admin/commerce/[businessId]/products/import/page.tsx
+++ b/web/app/admin/commerce/[businessId]/products/import/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+import { CsvImporter } from '@/components/admin/commerce/csv-importer'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export default async function ImportProductsPage({
+  params,
+}: {
+  params: Promise<{ businessId: string }>
+}) {
+  const { businessId } = await params
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <Link
+        href={`/admin/commerce/${businessId}/products`}
+        className="mb-4 inline-block text-sm text-[color:var(--primary,#111)] underline"
+      >
+        ← Volver a productos
+      </Link>
+      <h1 className="mb-1 text-2xl font-bold">Importar productos (CSV)</h1>
+      <p className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">
+        Subí un archivo CSV exportado de Excel o Google Sheets. Te mostramos una vista previa antes de guardar.
+      </p>
+      <CsvImporter businessId={businessId} />
+    </div>
+  )
+}

--- a/web/app/admin/commerce/[businessId]/products/page.tsx
+++ b/web/app/admin/commerce/[businessId]/products/page.tsx
@@ -31,6 +31,26 @@ export default async function AdminProductsPage({ params }: { params: Promise<{ 
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">
+      <nav className="mb-4 flex flex-wrap items-center gap-3 text-sm text-[color:var(--text-muted,#6b7280)]">
+        <Link href={`/admin/commerce/${businessId}/products`} className="font-semibold text-[color:var(--text,#111)] underline">
+          Productos
+        </Link>
+        <Link href={`/admin/commerce/${businessId}/products/import`} className="hover:underline">
+          Importar CSV
+        </Link>
+        <Link href={`/admin/commerce/${businessId}/discounts`} className="hover:underline">
+          Descuentos
+        </Link>
+        <Link href={`/admin/commerce/${businessId}/shipping`} className="hover:underline">
+          Envíos
+        </Link>
+        <Link href={`/admin/commerce/${businessId}/orders`} className="hover:underline">
+          Pedidos
+        </Link>
+        <Link href={`/admin/commerce/${businessId}/reconciliation`} className="hover:underline">
+          Conciliación
+        </Link>
+      </nav>
       <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-2xl font-bold">Productos</h1>
         <div className="flex items-center gap-2">

--- a/web/app/admin/commerce/[businessId]/reconciliation/page.tsx
+++ b/web/app/admin/commerce/[businessId]/reconciliation/page.tsx
@@ -1,0 +1,226 @@
+import Link from 'next/link'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { scopedQueries } from '@/lib/supabase/scoped'
+import { formatCents } from '@/lib/commerce/compute-totals'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+interface DailyAggregate {
+  day: string
+  orders: number
+  paidCount: number
+  paidGmvCents: number
+  failedCount: number
+  refundedCount: number
+}
+
+interface TxAggregate {
+  day: string
+  approved: number
+  rejected: number
+  pending: number
+  refunded: number
+  approvedCents: number
+}
+
+/**
+ * Naive daily reconciliation: aggregate orders by day + status and
+ * storefront_transactions by day + status, put them side-by-side. The
+ * diff in the rightmost column is the quick eyeball check: if your
+ * orders say paid-N but Pagopar-tx says approved-M and N != M, that's
+ * a reconciliation gap to dig into.
+ *
+ * For v1 we slice by day/14d in the app rather than via the
+ * commerce_daily_metrics materialized view — less DB surface to
+ * maintain and the data volume is tiny right now.
+ */
+async function loadAggregates(businessId: string) {
+  const supabase = await createAdminClient()
+  const scoped = scopedQueries(supabase, businessId)
+  const sinceIso = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString()
+
+  type OrderRow = { created_at: string; status: string; total_cents: number; currency: string }
+  type TxRow = { created_at: string; status: string; amount_cents: number }
+
+  const { data: orderRowsRaw } = await scoped.select<OrderRow>('orders', 'created_at, status, total_cents, currency', {
+    filter: (q) => q.gt('created_at', sinceIso),
+  })
+  const { data: txRowsRaw } = await scoped.select<TxRow>('storefront_transactions', 'created_at, status, amount_cents', {
+    filter: (q) => q.gt('created_at', sinceIso),
+  })
+
+  const orderRows = Array.isArray(orderRowsRaw) ? orderRowsRaw : []
+  const txRows = Array.isArray(txRowsRaw) ? txRowsRaw : []
+
+  const byDay: Record<string, DailyAggregate> = {}
+  for (const o of orderRows) {
+    const day = o.created_at.slice(0, 10)
+    const cur = byDay[day] ?? {
+      day,
+      orders: 0,
+      paidCount: 0,
+      paidGmvCents: 0,
+      failedCount: 0,
+      refundedCount: 0,
+    }
+    cur.orders++
+    if (['paid', 'fulfilled', 'shipped', 'delivered'].includes(o.status)) {
+      cur.paidCount++
+      cur.paidGmvCents += o.total_cents
+    }
+    if (o.status === 'failed') cur.failedCount++
+    if (o.status === 'refunded') cur.refundedCount++
+    byDay[day] = cur
+  }
+
+  const txByDay: Record<string, TxAggregate> = {}
+  for (const t of txRows) {
+    const day = t.created_at.slice(0, 10)
+    const cur = txByDay[day] ?? { day, approved: 0, rejected: 0, pending: 0, refunded: 0, approvedCents: 0 }
+    if (t.status === 'approved') {
+      cur.approved++
+      cur.approvedCents += t.amount_cents
+    } else if (t.status === 'rejected' || t.status === 'failed') cur.rejected++
+    else if (t.status === 'refunded') cur.refunded++
+    else cur.pending++
+    txByDay[day] = cur
+  }
+
+  const days = new Set([...Object.keys(byDay), ...Object.keys(txByDay)])
+  return [...days].sort().reverse().map((day) => ({
+    day,
+    orders: byDay[day] ?? { day, orders: 0, paidCount: 0, paidGmvCents: 0, failedCount: 0, refundedCount: 0 },
+    tx: txByDay[day] ?? { day, approved: 0, rejected: 0, pending: 0, refunded: 0, approvedCents: 0 },
+  }))
+}
+
+export default async function ReconciliationPage({
+  params,
+}: {
+  params: Promise<{ businessId: string }>
+}) {
+  const { businessId } = await params
+  const rows = await loadAggregates(businessId)
+
+  const totals = rows.reduce(
+    (acc, r) => {
+      acc.orders += r.orders.orders
+      acc.paidOrders += r.orders.paidCount
+      acc.paidGmvCents += r.orders.paidGmvCents
+      acc.pagoparApproved += r.tx.approved
+      acc.pagoparApprovedCents += r.tx.approvedCents
+      return acc
+    },
+    { orders: 0, paidOrders: 0, paidGmvCents: 0, pagoparApproved: 0, pagoparApprovedCents: 0 },
+  )
+
+  const gmvDiff = totals.paidGmvCents - totals.pagoparApprovedCents
+  const countDiff = totals.paidOrders - totals.pagoparApproved
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <Link href={`/admin/commerce/${businessId}/orders`} className="mb-4 inline-block text-sm text-[color:var(--primary,#111)] underline">
+        ← Volver a órdenes
+      </Link>
+      <h1 className="mb-1 text-2xl font-bold">Conciliación — últimos 14 días</h1>
+      <p className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">
+        Compara tus órdenes (fuente: nuestra DB) con las transacciones de Pagopar del mismo día.
+        Si los totales no cuadran, es momento de revisar manualmente.
+      </p>
+
+      <div className="mb-6 grid gap-3 sm:grid-cols-3">
+        <SummaryCard
+          label="Órdenes pagadas (14 d)"
+          value={String(totals.paidOrders)}
+          sub={formatCents(totals.paidGmvCents)}
+        />
+        <SummaryCard
+          label="Pagopar aprobadas"
+          value={String(totals.pagoparApproved)}
+          sub={formatCents(totals.pagoparApprovedCents)}
+        />
+        <SummaryCard
+          label="Diferencia"
+          value={countDiff === 0 ? '✓ OK' : `${countDiff > 0 ? '+' : ''}${countDiff}`}
+          sub={gmvDiff === 0 ? 'totales coinciden' : formatCents(gmvDiff)}
+          tone={countDiff === 0 && gmvDiff === 0 ? 'good' : 'warn'}
+        />
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-[color:var(--border,#e5e7eb)] p-8 text-center text-sm text-[color:var(--text-muted,#6b7280)]">
+          Sin datos en los últimos 14 días.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)]">
+          <table className="w-full text-sm">
+            <thead className="bg-[color:var(--surface-muted,#f9fafb)] text-left">
+              <tr>
+                <th className="px-3 py-2 font-semibold">Día</th>
+                <th className="px-3 py-2 text-right font-semibold">Órdenes</th>
+                <th className="px-3 py-2 text-right font-semibold">Pagadas</th>
+                <th className="px-3 py-2 text-right font-semibold">GMV</th>
+                <th className="px-3 py-2 text-right font-semibold">Pagopar aprob.</th>
+                <th className="px-3 py-2 text-right font-semibold">Pagopar $</th>
+                <th className="px-3 py-2 text-right font-semibold">Δ $</th>
+                <th className="px-3 py-2 text-right font-semibold">Rechazadas</th>
+                <th className="px-3 py-2 text-right font-semibold">Reembolsadas</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => {
+                const diff = r.orders.paidGmvCents - r.tx.approvedCents
+                return (
+                  <tr key={r.day} className="border-t border-[color:var(--border,#e5e7eb)]">
+                    <td className="px-3 py-2 font-mono text-xs">{r.day}</td>
+                    <td className="px-3 py-2 text-right">{r.orders.orders}</td>
+                    <td className="px-3 py-2 text-right">{r.orders.paidCount}</td>
+                    <td className="px-3 py-2 text-right">{formatCents(r.orders.paidGmvCents)}</td>
+                    <td className="px-3 py-2 text-right">{r.tx.approved}</td>
+                    <td className="px-3 py-2 text-right">{formatCents(r.tx.approvedCents)}</td>
+                    <td className={`px-3 py-2 text-right ${diff === 0 ? '' : 'bg-yellow-50 text-yellow-900'}`}>
+                      {diff === 0 ? '—' : formatCents(diff)}
+                    </td>
+                    <td className="px-3 py-2 text-right text-[color:var(--text-muted,#6b7280)]">
+                      {r.orders.failedCount + r.tx.rejected}
+                    </td>
+                    <td className="px-3 py-2 text-right text-[color:var(--text-muted,#6b7280)]">
+                      {r.orders.refundedCount}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SummaryCard({
+  label,
+  value,
+  sub,
+  tone = 'default',
+}: {
+  label: string
+  value: string
+  sub: string
+  tone?: 'default' | 'good' | 'warn'
+}) {
+  const toneClass =
+    tone === 'good'
+      ? 'bg-green-50 text-green-800'
+      : tone === 'warn'
+      ? 'bg-yellow-50 text-yellow-800'
+      : 'bg-[color:var(--surface,#fff)]'
+  return (
+    <div className={`rounded-lg border border-[color:var(--border,#e5e7eb)] p-4 ${toneClass}`}>
+      <p className="text-xs font-semibold uppercase opacity-70">{label}</p>
+      <p className="mt-1 text-2xl font-bold">{value}</p>
+      <p className="text-xs opacity-70">{sub}</p>
+    </div>
+  )
+}

--- a/web/app/api/admin/commerce/[businessId]/discounts/[id]/route.ts
+++ b/web/app/api/admin/commerce/[businessId]/discounts/[id]/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { requireAdminUser } from '@/lib/commerce/admin-auth'
+import { updateDiscount, deleteDiscount, DiscountInputSchema } from '@/lib/commerce/discounts-admin'
+
+export const runtime = 'nodejs'
+
+const PatchSchema = DiscountInputSchema.partial()
+
+export const PATCH = withRequestLog<{ businessId: string; id: string }>(async (req, { log }, { businessId, id }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+  const parsed = PatchSchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+  }
+  try {
+    const discount = await updateDiscount(businessId, id, parsed.data)
+    log.info('admin.commerce.discount.updated', { businessId, id })
+    return NextResponse.json({ discount })
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'update_failed' },
+      { status: 500 },
+    )
+  }
+})
+
+export const DELETE = withRequestLog<{ businessId: string; id: string }>(async (_req, { log }, { businessId, id }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  try {
+    await deleteDiscount(businessId, id)
+    log.info('admin.commerce.discount.deleted', { businessId, id })
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'delete_failed' },
+      { status: 500 },
+    )
+  }
+})

--- a/web/app/api/admin/commerce/[businessId]/discounts/[id]/route.ts
+++ b/web/app/api/admin/commerce/[businessId]/discounts/[id]/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from 'next/server'
 import { withRequestLog } from '@/lib/api/with-request-log'
 import { requireAdminUser } from '@/lib/commerce/admin-auth'
-import { updateDiscount, deleteDiscount, DiscountInputSchema } from '@/lib/commerce/discounts-admin'
+import { updateDiscount, deleteDiscount, DiscountInputShape } from '@/lib/commerce/discounts-admin'
 
 export const runtime = 'nodejs'
 
-const PatchSchema = DiscountInputSchema.partial()
+const PatchSchema = DiscountInputShape.partial()
 
 export const PATCH = withRequestLog<{ businessId: string; id: string }>(async (req, { log }, { businessId, id }) => {
   const admin = await requireAdminUser()

--- a/web/app/api/admin/commerce/[businessId]/discounts/route.ts
+++ b/web/app/api/admin/commerce/[businessId]/discounts/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { requireAdminUser } from '@/lib/commerce/admin-auth'
+import {
+  listDiscounts,
+  createDiscount,
+  DiscountInputSchema,
+} from '@/lib/commerce/discounts-admin'
+
+export const runtime = 'nodejs'
+
+export const GET = withRequestLog<{ businessId: string }>(async (_req, _ctx, { businessId }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const discounts = await listDiscounts(businessId)
+  return NextResponse.json({ discounts })
+})
+
+export const POST = withRequestLog<{ businessId: string }>(async (req, { log }, { businessId }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+  const parsed = DiscountInputSchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+  }
+  try {
+    const discount = await createDiscount(businessId, parsed.data)
+    log.info('admin.commerce.discount.created', { businessId, code: discount.code })
+    return NextResponse.json({ discount })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'create_failed'
+    const status = message === 'code_already_exists' ? 409 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+})

--- a/web/app/api/admin/commerce/[businessId]/products/import/route.ts
+++ b/web/app/api/admin/commerce/[businessId]/products/import/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from 'next/server'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { requireAdminUser } from '@/lib/commerce/admin-auth'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { parseProductCsv } from '@/lib/commerce/csv-import'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST multipart/form-data { file, mode } — bulk product import.
+ *   mode = "preview" → parse + validate only, return per-row results
+ *   mode = "commit"  → parse + validate + batch-insert valid rows
+ * Conflict handling: (business_id, slug) is unique, so duplicate rows
+ * return a per-row error in the preview and are skipped on commit.
+ */
+export const POST = withRequestLog<{ businessId: string }>(async (req, { log }, { businessId }) => {
+  const admin = await requireAdminUser()
+  if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  let form: FormData
+  try {
+    form = await req.formData()
+  } catch {
+    return NextResponse.json({ error: 'invalid_multipart' }, { status: 400 })
+  }
+  const file = form.get('file')
+  const mode = String(form.get('mode') ?? 'preview')
+  if (!(file instanceof File)) return NextResponse.json({ error: 'missing_file' }, { status: 400 })
+  if (file.size > 2 * 1024 * 1024) return NextResponse.json({ error: 'file_too_large' }, { status: 413 })
+
+  const text = new TextDecoder('utf-8').decode(new Uint8Array(await file.arrayBuffer()))
+  const { rows, headerWarnings } = parseProductCsv(text)
+
+  const valid = rows.filter((r) => r.ok)
+  const invalid = rows.filter((r) => !r.ok)
+
+  const summary = {
+    total: rows.length,
+    valid: valid.length,
+    invalid: invalid.length,
+    headerWarnings,
+  }
+
+  if (mode === 'preview') {
+    return NextResponse.json({ mode, summary, rows })
+  }
+
+  // Commit — batch insert via upsert on (business_id, slug) so re-runs
+  // update instead of failing. ON CONFLICT uses the existing UNIQUE index.
+  if (valid.length === 0) {
+    return NextResponse.json({ mode: 'commit', summary, rows })
+  }
+
+  const supabase = await createAdminClient()
+  const records = valid.map((r) => ({
+    business_id: businessId,
+    slug: r.data!.slug,
+    name: r.data!.name,
+    description: r.data!.description,
+    category: r.data!.category,
+    price_cents: r.data!.priceCents,
+    compare_at_price_cents: r.data!.compareAtPriceCents,
+    currency: 'PYG',
+    sku: r.data!.sku,
+    inventory_qty: r.data!.inventoryQty,
+    inventory_policy: 'deny',
+    images: r.data!.imageUrl
+      ? [{ url: r.data!.imageUrl, alt: r.data!.name, isCover: true }]
+      : [],
+    status: r.data!.status,
+    is_seed: false,
+    metadata: {},
+  }))
+
+  const { data, error } = await supabase
+    .from('products')
+    .upsert(records, { onConflict: 'business_id,slug' })
+    .select('id, slug')
+
+  if (error) {
+    log.error('admin.commerce.csv.upsert_failed', new Error(error.message))
+    return NextResponse.json(
+      { error: 'upsert_failed', message: error.message, summary },
+      { status: 500 },
+    )
+  }
+
+  log.info('admin.commerce.csv.imported', { businessId, count: data?.length ?? 0 })
+  return NextResponse.json({
+    mode: 'commit',
+    summary: { ...summary, inserted: data?.length ?? 0 },
+    rows,
+  })
+})

--- a/web/app/api/cron/commerce-abandoned-cart/route.ts
+++ b/web/app/api/cron/commerce-abandoned-cart/route.ts
@@ -2,21 +2,27 @@ import { NextResponse } from 'next/server'
 import { randomBytes } from 'crypto'
 import { withRequestLog } from '@/lib/api/with-request-log'
 import { createAdminClient } from '@/lib/supabase/admin'
+import { cartRecoveryEmail } from '@/lib/commerce/email-templates'
 
 export const runtime = 'nodejs'
 
 /**
  * Identifies open carts older than the per-step threshold with a customer
- * email attached (via guest checkout attempts or signed-in users) and
- * enqueues a recovery email. Three touches: 24h, 72h, 7d.
+ * email attached (via guest checkout attempts or signed-in users), writes
+ * a recovery touch row, and enqueues a recovery email into the email
+ * outbox (the commerce-email-flush cron sends them on the next tick).
  *
- * Schedule (UTC): every 4 hours. See docs/runbooks/CRON_STRATEGY.md
- * for the canonical table. Protected by CRON_SECRET header.
+ * Three touches: 24h, 72h, 7d. Each cart gets exactly one email per step
+ * — the (cart_id, step) UNIQUE constraint on cart_recovery_touches
+ * prevents re-sending.
+ *
+ * Schedule (UTC): every 4 hours. See docs/runbooks/CRON_STRATEGY.md for
+ * the canonical table. Protected by CRON_SECRET header.
  */
 const STEPS = [
-  { step: 1, hoursAgo: 24 },
-  { step: 2, hoursAgo: 72 },
-  { step: 3, hoursAgo: 168 },
+  { step: 1 as const, hoursAgo: 24 },
+  { step: 2 as const, hoursAgo: 72 },
+  { step: 3 as const, hoursAgo: 168 },
 ]
 
 export const POST = withRequestLog(async (request, { log }) => {
@@ -25,13 +31,14 @@ export const POST = withRequestLog(async (request, { log }) => {
   }
 
   const supabase = await createAdminClient()
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXT_PUBLIC_BASE_URL ?? 'https://paragu-ai.com'
   let touched = 0
+  let enqueued = 0
+  let skippedNoEmail = 0
 
   for (const { step, hoursAgo } of STEPS) {
     const cutoff = new Date(Date.now() - hoursAgo * 60 * 60 * 1000).toISOString()
 
-    // Carts with an associated user_id (we have an email) that haven't been
-    // touched since cutoff and haven't already been sent this step's email.
     const { data: carts } = await supabase
       .from('carts')
       .select('id, business_id, user_id, updated_at')
@@ -42,7 +49,7 @@ export const POST = withRequestLog(async (request, { log }) => {
 
     const rows = Array.isArray(carts) ? carts : []
     for (const cart of rows) {
-      // Skip if we've already sent this step
+      // Skip if we've already sent this step for this cart.
       const { count } = await supabase
         .from('cart_recovery_touches')
         .select('*', { count: 'exact', head: true })
@@ -58,12 +65,45 @@ export const POST = withRequestLog(async (request, { log }) => {
         recovery_token: token,
       })
       touched++
-      // Email enqueueing is intentionally minimal here — in production, we'd
-      // look up the user's email via auth and queue to commerce_email_outbox.
-      // Stub left for Phase 3 polish.
+
+      // Look up business + customer email for the enqueue.
+      // Supabase Auth stores email on auth.users; we query via the service
+      // role which can read the auth schema.
+      const [{ data: biz }, { data: user }] = await Promise.all([
+        supabase.from('businesses').select('name, slug').eq('id', cart.business_id).maybeSingle(),
+        supabase.schema('auth').from('users').select('email, raw_user_meta_data').eq('id', cart.user_id).maybeSingle(),
+      ])
+
+      const customerEmail = (user as { email?: string } | null)?.email
+      if (!customerEmail || !biz) {
+        skippedNoEmail++
+        continue
+      }
+
+      const meta = (user as { raw_user_meta_data?: { name?: string; full_name?: string } } | null)?.raw_user_meta_data
+      const customerName = meta?.name ?? meta?.full_name ?? customerEmail.split('@')[0] ?? 'cliente'
+
+      const recoveryUrl = `${appUrl}/s/es/${biz.slug}/carrito?recover=${token}`
+      const { subject, html } = cartRecoveryEmail({
+        customerName,
+        businessName: biz.name,
+        recoveryUrl,
+        step,
+      })
+
+      const { error: outboxError } = await supabase.from('commerce_email_outbox').insert({
+        business_id: cart.business_id,
+        order_id: null,
+        template:
+          step === 1 ? 'cart_recovery_24h' : step === 2 ? 'cart_recovery_72h' : 'cart_recovery_7d',
+        recipient_email: customerEmail,
+        subject,
+        html_body: html,
+      })
+      if (!outboxError) enqueued++
     }
   }
 
-  log.info('commerce.cron.abandoned_cart.done', { touched })
-  return NextResponse.json({ touched })
+  log.info('commerce.cron.abandoned_cart.done', { touched, enqueued, skippedNoEmail })
+  return NextResponse.json({ touched, enqueued, skippedNoEmail })
 })

--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -9,7 +9,7 @@ import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { formatCents } from '@/lib/commerce/compute-totals'
 import { ProductDetailActions } from '@/components/commerce/product-detail-actions'
 import { PriceDisplay } from '@/components/commerce/price-display'
-import { loadPygRates } from '@/lib/commerce/currency'
+import { loadPygRates } from '@/lib/commerce/currency-server'
 
 export const runtime = 'nodejs'
 export const revalidate = 300

--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -8,6 +8,8 @@ import { ProductImage } from '@/components/commerce/product-image'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { formatCents } from '@/lib/commerce/compute-totals'
 import { ProductDetailActions } from '@/components/commerce/product-detail-actions'
+import { PriceDisplay } from '@/components/commerce/price-display'
+import { loadPygRates } from '@/lib/commerce/currency'
 
 export const runtime = 'nodejs'
 export const revalidate = 300
@@ -39,6 +41,7 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
   if (!product || product.status !== 'active') notFound()
 
   const cover = product.images.find((i) => i.isCover) ?? product.images[0]
+  const rates = await loadPygRates()
 
   const structuredData = {
     '@context': 'https://schema.org',
@@ -79,11 +82,23 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
 
         <div>
           <h1 className="text-3xl font-bold text-[color:var(--text,#111)]">{product.name}</h1>
-          <p className="mt-2 text-2xl font-semibold">{formatCents(product.priceCents, product.currency)}</p>
+          {product.currency === 'PYG' ? (
+            <PriceDisplay className="mt-2 block text-2xl font-semibold" pygCents={product.priceCents} rates={rates} />
+          ) : (
+            <p className="mt-2 text-2xl font-semibold">{formatCents(product.priceCents, product.currency)}</p>
+          )}
           {product.compareAtPriceCents && product.compareAtPriceCents > product.priceCents ? (
-            <p className="mt-1 text-sm text-[color:var(--text-muted,#9ca3af)] line-through">
-              {formatCents(product.compareAtPriceCents, product.currency)}
-            </p>
+            product.currency === 'PYG' ? (
+              <PriceDisplay
+                className="mt-1 block text-sm text-[color:var(--text-muted,#9ca3af)] line-through"
+                pygCents={product.compareAtPriceCents}
+                rates={rates}
+              />
+            ) : (
+              <p className="mt-1 text-sm text-[color:var(--text-muted,#9ca3af)] line-through">
+                {formatCents(product.compareAtPriceCents, product.currency)}
+              </p>
+            )
           ) : null}
 
           {product.description ? (

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -5,7 +5,7 @@ import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { ProductCard } from '@/components/commerce/product-card'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
-import { loadPygRates } from '@/lib/commerce/currency'
+import { loadPygRates } from '@/lib/commerce/currency-server'
 
 export const runtime = 'nodejs'
 export const revalidate = 300

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -5,6 +5,7 @@ import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { ProductCard } from '@/components/commerce/product-card'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
+import { loadPygRates } from '@/lib/commerce/currency'
 
 export const runtime = 'nodejs'
 export const revalidate = 300
@@ -14,7 +15,7 @@ export default async function StorePage({ params }: { params: Promise<{ site: st
   const business = await resolveBusinessBySlug(site)
   if (!business || !(await isCommerceEnabled(business.type))) notFound()
 
-  const products = await listActiveProducts(business.id, { limit: 48 })
+  const [products, rates] = await Promise.all([listActiveProducts(business.id, { limit: 48 }), loadPygRates()])
 
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
@@ -31,7 +32,7 @@ export default async function StorePage({ params }: { params: Promise<{ site: st
         ) : (
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 lg:gap-6">
             {products.map((product, idx) => (
-              <ProductCard key={product.id} siteSlug={site} product={product} priority={idx < 4} />
+              <ProductCard key={product.id} siteSlug={site} product={product} priority={idx < 4} rates={rates} />
             ))}
           </div>
         )}

--- a/web/components/admin/commerce/csv-importer.tsx
+++ b/web/components/admin/commerce/csv-importer.tsx
@@ -1,0 +1,213 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface PreviewRow {
+  rowIndex: number
+  ok: boolean
+  error?: string
+  data?: {
+    slug: string
+    name: string
+    priceCents: number
+    inventoryQty: number
+    status: string
+  }
+}
+
+interface PreviewResponse {
+  mode: 'preview' | 'commit'
+  summary: {
+    total: number
+    valid: number
+    invalid: number
+    inserted?: number
+    headerWarnings: string[]
+  }
+  rows: PreviewRow[]
+}
+
+const TEMPLATE_CSV = `slug,name,description,category,price,compare_at_price,sku,stock,status,image_url
+remera-basica-blanca,Remera Básica Blanca,100% algodón premium,ropa,85000,,REM-001,10,active,
+jean-recto-azul,Jean Recto Azul,Calce recto clásico,ropa,180000,220000,JEAN-002,8,active,https://example.com/jean.jpg`
+
+export function CsvImporter({ businessId }: { businessId: string }) {
+  const router = useRouter()
+  const [file, setFile] = useState<File | null>(null)
+  const [preview, setPreview] = useState<PreviewResponse | null>(null)
+  const [loading, setLoading] = useState<'idle' | 'previewing' | 'committing'>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  async function run(mode: 'preview' | 'commit') {
+    if (!file) return
+    setError(null)
+    setLoading(mode === 'preview' ? 'previewing' : 'committing')
+    try {
+      const form = new FormData()
+      form.append('file', file)
+      form.append('mode', mode)
+      const res = await fetch(`/api/admin/commerce/${businessId}/products/import`, {
+        method: 'POST',
+        body: form,
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.message ?? data.error ?? 'Error')
+      setPreview(data as PreviewResponse)
+      if (mode === 'commit' && (data as PreviewResponse).summary.inserted) {
+        router.refresh()
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al procesar')
+    } finally {
+      setLoading('idle')
+    }
+  }
+
+  function downloadTemplate() {
+    const blob = new Blob([TEMPLATE_CSV], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'paragu-productos-plantilla.csv'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4">
+        <h2 className="mb-2 text-sm font-semibold">1. Preparar el CSV</h2>
+        <p className="mb-3 text-xs text-[color:var(--text-muted,#6b7280)]">
+          Columnas obligatorias: <code>slug</code>, <code>name</code>, <code>price</code>. Opcionales:{' '}
+          <code>description</code>, <code>category</code>, <code>compare_at_price</code>, <code>sku</code>,{' '}
+          <code>stock</code>, <code>status</code> (active/draft/archived), <code>image_url</code>.
+        </p>
+        <button
+          type="button"
+          onClick={downloadTemplate}
+          className="rounded border border-[color:var(--border,#e5e7eb)] px-3 py-1 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+        >
+          Descargar plantilla CSV
+        </button>
+      </section>
+
+      <section className="rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4">
+        <h2 className="mb-3 text-sm font-semibold">2. Subir archivo</h2>
+        <div className="flex flex-wrap items-center gap-3">
+          <input
+            type="file"
+            accept=".csv,text/csv"
+            onChange={(e) => {
+              setFile(e.target.files?.[0] ?? null)
+              setPreview(null)
+            }}
+            className="text-sm"
+          />
+          <button
+            type="button"
+            onClick={() => run('preview')}
+            disabled={!file || loading !== 'idle'}
+            className="rounded border border-[color:var(--border,#e5e7eb)] px-3 py-1 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)] disabled:opacity-50"
+          >
+            {loading === 'previewing' ? 'Procesando…' : 'Vista previa'}
+          </button>
+        </div>
+        {file && (
+          <p className="mt-2 text-xs text-[color:var(--text-muted,#6b7280)]">
+            {file.name} · {(file.size / 1024).toFixed(1)} KB
+          </p>
+        )}
+      </section>
+
+      {error && <p role="alert" className="rounded bg-red-50 p-3 text-sm text-red-700">{error}</p>}
+
+      {preview && (
+        <section className="rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4">
+          <h2 className="mb-3 text-sm font-semibold">3. Vista previa</h2>
+
+          {preview.summary.headerWarnings.length > 0 ? (
+            <div className="mb-3 rounded bg-red-50 p-3 text-xs text-red-800">
+              {preview.summary.headerWarnings.map((w) => (
+                <p key={w}>{w}</p>
+              ))}
+            </div>
+          ) : null}
+
+          <div className="mb-3 grid grid-cols-3 gap-3 text-center text-sm">
+            <div className="rounded bg-[color:var(--surface-muted,#f9fafb)] p-3">
+              <p className="text-2xl font-bold">{preview.summary.total}</p>
+              <p className="text-xs text-[color:var(--text-muted,#6b7280)]">Filas</p>
+            </div>
+            <div className="rounded bg-green-50 p-3 text-green-800">
+              <p className="text-2xl font-bold">{preview.summary.valid}</p>
+              <p className="text-xs">Válidas</p>
+            </div>
+            <div className="rounded bg-red-50 p-3 text-red-800">
+              <p className="text-2xl font-bold">{preview.summary.invalid}</p>
+              <p className="text-xs">Con errores</p>
+            </div>
+          </div>
+
+          {preview.mode === 'commit' && preview.summary.inserted !== undefined ? (
+            <p className="mb-3 rounded bg-green-50 p-3 text-sm text-green-800">
+              ✓ {preview.summary.inserted} productos guardados (upsert por slug — existentes fueron actualizados).
+            </p>
+          ) : null}
+
+          {preview.rows.length > 0 && (
+            <div className="mb-3 max-h-80 overflow-y-auto rounded border border-[color:var(--border,#e5e7eb)]">
+              <table className="w-full text-xs">
+                <thead className="sticky top-0 bg-[color:var(--surface-muted,#f9fafb)]">
+                  <tr>
+                    <th className="px-2 py-1 text-left">Fila</th>
+                    <th className="px-2 py-1 text-left">Estado</th>
+                    <th className="px-2 py-1 text-left">Slug</th>
+                    <th className="px-2 py-1 text-left">Nombre</th>
+                    <th className="px-2 py-1 text-right">Precio</th>
+                    <th className="px-2 py-1 text-right">Stock</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.rows.map((r) => (
+                    <tr key={r.rowIndex} className="border-t border-[color:var(--border,#e5e7eb)]">
+                      <td className="px-2 py-1 font-mono">{r.rowIndex}</td>
+                      <td className="px-2 py-1">
+                        {r.ok ? (
+                          <span className="text-green-700">✓</span>
+                        ) : (
+                          <span className="text-red-700" title={r.error}>
+                            ✗ {r.error?.slice(0, 60)}
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-2 py-1 font-mono">{r.data?.slug ?? '—'}</td>
+                      <td className="px-2 py-1">{r.data?.name ?? '—'}</td>
+                      <td className="px-2 py-1 text-right">
+                        {r.data ? `Gs ${r.data.priceCents.toLocaleString('es-PY')}` : '—'}
+                      </td>
+                      <td className="px-2 py-1 text-right">{r.data?.inventoryQty ?? '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {preview.mode === 'preview' && preview.summary.valid > 0 && (
+            <button
+              type="button"
+              onClick={() => run('commit')}
+              disabled={loading !== 'idle'}
+              className="rounded-lg bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+            >
+              {loading === 'committing'
+                ? 'Guardando…'
+                : `Guardar ${preview.summary.valid} producto${preview.summary.valid === 1 ? '' : 's'}`}
+            </button>
+          )}
+        </section>
+      )}
+    </div>
+  )
+}

--- a/web/components/admin/commerce/discounts-manager.tsx
+++ b/web/components/admin/commerce/discounts-manager.tsx
@@ -1,0 +1,313 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type { DiscountRecord, DiscountType } from '@/lib/commerce/discounts-admin'
+
+function formatGs(cents: number | null): string {
+  if (cents === null) return '—'
+  return `Gs ${cents.toLocaleString('es-PY')}`
+}
+
+function summariseValue(d: DiscountRecord): string {
+  if (d.type === 'percent') return `${d.valuePercent}%`
+  if (d.type === 'fixed_amount') return formatGs(d.valueCents)
+  return 'Envío gratis'
+}
+
+export function DiscountsManager({
+  businessId,
+  initialDiscounts,
+}: {
+  businessId: string
+  initialDiscounts: DiscountRecord[]
+}) {
+  const router = useRouter()
+  const [discounts, setDiscounts] = useState(initialDiscounts)
+  const [showForm, setShowForm] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function create(payload: {
+    code: string
+    type: DiscountType
+    valuePercent?: number
+    valueCents?: number
+    minSubtotalCents: number
+    endsAt?: string
+    maxUses?: number
+  }) {
+    setError(null)
+    const res = await fetch(`/api/admin/commerce/${businessId}/discounts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    const data = await res.json()
+    if (!res.ok) {
+      setError(
+        data.error === 'code_already_exists'
+          ? 'Ya existe un código con ese nombre.'
+          : data.error ?? 'Error al crear',
+      )
+      return false
+    }
+    setDiscounts((prev) => [data.discount, ...prev])
+    setShowForm(false)
+    router.refresh()
+    return true
+  }
+
+  async function pauseToggle(id: string, current: DiscountRecord['status']) {
+    const nextStatus = current === 'active' ? 'paused' : 'active'
+    const res = await fetch(`/api/admin/commerce/${businessId}/discounts/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: nextStatus }),
+    })
+    if (res.ok) {
+      const { discount } = await res.json()
+      setDiscounts((prev) => prev.map((d) => (d.id === id ? discount : d)))
+    }
+  }
+
+  async function deleteDiscount(id: string) {
+    if (!confirm('¿Eliminar este código? Esta acción no se puede deshacer.')) return
+    const res = await fetch(`/api/admin/commerce/${businessId}/discounts/${id}`, { method: 'DELETE' })
+    if (res.ok) {
+      setDiscounts((prev) => prev.filter((d) => d.id !== id))
+      router.refresh()
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {!showForm && (
+        <button
+          type="button"
+          onClick={() => setShowForm(true)}
+          className="rounded-lg bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-semibold text-white"
+        >
+          + Nuevo código
+        </button>
+      )}
+
+      {showForm && <NewDiscountForm onCreate={create} onCancel={() => setShowForm(false)} />}
+
+      {error && <p role="alert" className="rounded bg-red-50 p-2 text-sm text-red-700">{error}</p>}
+
+      {discounts.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-[color:var(--border,#e5e7eb)] p-6 text-center text-sm text-[color:var(--text-muted,#6b7280)]">
+          Sin códigos todavía. Creá el primero — promociones típicas: <code>BIENVENIDO10</code>, <code>ENVIOGRATIS</code>.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)]">
+          <table className="w-full text-sm">
+            <thead className="bg-[color:var(--surface-muted,#f9fafb)] text-left">
+              <tr>
+                <th className="px-4 py-2 font-semibold">Código</th>
+                <th className="px-4 py-2 font-semibold">Tipo</th>
+                <th className="px-4 py-2 font-semibold">Mínimo</th>
+                <th className="px-4 py-2 font-semibold">Usos</th>
+                <th className="px-4 py-2 font-semibold">Estado</th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {discounts.map((d) => (
+                <tr key={d.id} className="border-t border-[color:var(--border,#e5e7eb)]">
+                  <td className="px-4 py-2 font-mono font-semibold">{d.code}</td>
+                  <td className="px-4 py-2">{summariseValue(d)}</td>
+                  <td className="px-4 py-2 text-[color:var(--text-muted,#6b7280)]">
+                    {d.minSubtotalCents > 0 ? formatGs(d.minSubtotalCents) : '—'}
+                  </td>
+                  <td className="px-4 py-2 text-[color:var(--text-muted,#6b7280)]">
+                    {d.usesCount}
+                    {d.maxUses ? ` / ${d.maxUses}` : ''}
+                  </td>
+                  <td className="px-4 py-2">
+                    <span
+                      className={`rounded px-2 py-0.5 text-xs ${
+                        d.status === 'active'
+                          ? 'bg-green-100 text-green-800'
+                          : d.status === 'paused'
+                          ? 'bg-yellow-100 text-yellow-800'
+                          : 'bg-gray-100 text-gray-700'
+                      }`}
+                    >
+                      {d.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <div className="flex justify-end gap-3">
+                      <button
+                        type="button"
+                        onClick={() => pauseToggle(d.id, d.status)}
+                        className="text-xs text-[color:var(--primary,#111)] underline"
+                      >
+                        {d.status === 'active' ? 'Pausar' : 'Activar'}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => deleteDiscount(d.id)}
+                        className="text-xs text-red-700 underline"
+                      >
+                        Borrar
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function NewDiscountForm({
+  onCreate,
+  onCancel,
+}: {
+  onCreate: (payload: {
+    code: string
+    type: DiscountType
+    valuePercent?: number
+    valueCents?: number
+    minSubtotalCents: number
+    endsAt?: string
+    maxUses?: number
+  }) => Promise<boolean>
+  onCancel: () => void
+}) {
+  const [type, setType] = useState<DiscountType>('percent')
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setSubmitting(true)
+    const f = new FormData(event.currentTarget)
+    const code = String(f.get('code') ?? '').trim()
+    const minSubtotalCents = parseInt(String(f.get('minSubtotalCents') ?? '0').replace(/[^0-9]/g, ''), 10) || 0
+    const endsAt = String(f.get('endsAt') ?? '')
+    const maxUsesRaw = parseInt(String(f.get('maxUses') ?? ''), 10)
+
+    const payload = {
+      code,
+      type,
+      minSubtotalCents,
+      endsAt: endsAt ? new Date(endsAt).toISOString() : undefined,
+      maxUses: Number.isFinite(maxUsesRaw) && maxUsesRaw > 0 ? maxUsesRaw : undefined,
+      valuePercent:
+        type === 'percent'
+          ? parseFloat(String(f.get('valuePercent') ?? '0')) || undefined
+          : undefined,
+      valueCents:
+        type === 'fixed_amount'
+          ? parseInt(String(f.get('valueCents') ?? '0').replace(/[^0-9]/g, ''), 10) || undefined
+          : undefined,
+    }
+    await onCreate(payload)
+    setSubmitting(false)
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4"
+    >
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">Código (se guarda en mayúsculas)</span>
+          <input
+            name="code"
+            required
+            maxLength={80}
+            placeholder="LANZAMIENTO20"
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm uppercase"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">Tipo</span>
+          <select
+            value={type}
+            onChange={(e) => setType(e.target.value as DiscountType)}
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+          >
+            <option value="percent">Porcentaje</option>
+            <option value="fixed_amount">Monto fijo (Gs)</option>
+            <option value="free_shipping">Envío gratis</option>
+          </select>
+        </label>
+        {type === 'percent' && (
+          <label className="block">
+            <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">Porcentaje de descuento</span>
+            <input
+              name="valuePercent"
+              type="number"
+              min={1}
+              max={100}
+              step={0.5}
+              required
+              placeholder="20"
+              className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+            />
+          </label>
+        )}
+        {type === 'fixed_amount' && (
+          <label className="block">
+            <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">Monto descontado (Gs)</span>
+            <input
+              name="valueCents"
+              required
+              placeholder="20000"
+              className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+            />
+          </label>
+        )}
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">Subtotal mínimo (Gs, opcional)</span>
+          <input
+            name="minSubtotalCents"
+            placeholder="0"
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">Vence (opcional)</span>
+          <input
+            name="endsAt"
+            type="datetime-local"
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">Usos máximos (opcional)</span>
+          <input
+            name="maxUses"
+            type="number"
+            min={1}
+            placeholder="100"
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+          />
+        </label>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded-lg bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+        >
+          {submitting ? 'Creando…' : 'Crear código'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded border border-[color:var(--border,#e5e7eb)] px-4 py-2 text-sm hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+        >
+          Cancelar
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/web/components/commerce/commerce-header.tsx
+++ b/web/components/commerce/commerce-header.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { MiniCartBadge } from './mini-cart-badge'
 import { CartDrawer } from './cart-drawer'
+import { CurrencyToggle } from './currency-toggle'
 
 export function CommerceHeader({ siteSlug, businessName }: { siteSlug: string; businessName: string }) {
   const [open, setOpen] = useState(false)
@@ -18,6 +19,7 @@ export function CommerceHeader({ siteSlug, businessName }: { siteSlug: string; b
             <Link href={`/s/es/${siteSlug}/tienda`} className="hover:underline">
               Tienda
             </Link>
+            <CurrencyToggle />
             <MiniCartBadge onClick={() => setOpen(true)} />
           </nav>
         </div>

--- a/web/components/commerce/currency-toggle.tsx
+++ b/web/components/commerce/currency-toggle.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { DISPLAY_CURRENCIES, isDisplayCurrency, type DisplayCurrency } from '@/lib/commerce/currency'
+
+const STORAGE_KEY = 'paragu_storefront_currency'
+export const CURRENCY_CHANGE_EVENT = 'paragu:currency-change'
+
+export function getStoredCurrency(): DisplayCurrency {
+  if (typeof window === 'undefined') return 'PYG'
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  return stored && isDisplayCurrency(stored) ? stored : 'PYG'
+}
+
+function subscribe(cb: () => void) {
+  window.addEventListener(CURRENCY_CHANGE_EVENT, cb)
+  return () => window.removeEventListener(CURRENCY_CHANGE_EVENT, cb)
+}
+
+function getServerSnapshot(): DisplayCurrency {
+  return 'PYG'
+}
+
+/**
+ * Shopper-side currency selector. Persists choice in localStorage + fires
+ * a window event so every <PriceDisplay> on the page re-renders without a
+ * round trip to the server. Prices never leave PYG on the wire; this is
+ * purely a display convenience for cross-border visitors (Argentine
+ * expats, Brazilian tourists, etc.).
+ */
+export function CurrencyToggle({ availableCurrencies }: { availableCurrencies?: DisplayCurrency[] }) {
+  const options = availableCurrencies ?? DISPLAY_CURRENCIES
+  const currency = useSyncExternalStore(subscribe, getStoredCurrency, getServerSnapshot)
+
+  function change(next: DisplayCurrency) {
+    window.localStorage.setItem(STORAGE_KEY, next)
+    window.dispatchEvent(new CustomEvent(CURRENCY_CHANGE_EVENT, { detail: next }))
+  }
+
+  return (
+    <label className="inline-flex items-center gap-1 text-xs text-[color:var(--text-muted,#6b7280)]">
+      <span className="sr-only">Moneda</span>
+      <select
+        value={currency}
+        onChange={(e) => change(e.target.value as DisplayCurrency)}
+        className="rounded border border-[color:var(--border,#e5e7eb)] bg-white px-2 py-1 text-xs"
+        aria-label="Moneda de visualización"
+      >
+        {options.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}

--- a/web/components/commerce/price-display.tsx
+++ b/web/components/commerce/price-display.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { convertPygAmount, formatDisplay, type DisplayCurrency } from '@/lib/commerce/currency'
+import { CURRENCY_CHANGE_EVENT, getStoredCurrency } from './currency-toggle'
+
+interface Props {
+  pygCents: number
+  /** Optional fallback when rates are missing (e.g., zero value). */
+  rates: Record<string, number>
+  className?: string
+}
+
+function subscribe(cb: () => void) {
+  window.addEventListener(CURRENCY_CHANGE_EVENT, cb)
+  return () => window.removeEventListener(CURRENCY_CHANGE_EVENT, cb)
+}
+
+function getServerSnapshot(): DisplayCurrency {
+  return 'PYG'
+}
+
+/**
+ * Renders a PYG amount, re-rendering in the shopper's selected currency.
+ * Server renders PYG on first paint (no client JS needed if the shopper
+ * never toggles); client side swaps when the event fires.
+ */
+export function PriceDisplay({ pygCents, rates, className }: Props) {
+  const currency = useSyncExternalStore(subscribe, getStoredCurrency, getServerSnapshot)
+  const { amount, currency: finalCurrency } = convertPygAmount(pygCents, currency, rates)
+  return <span className={className}>{formatDisplay(amount, finalCurrency)}</span>
+}

--- a/web/components/commerce/product-card.tsx
+++ b/web/components/commerce/product-card.tsx
@@ -6,14 +6,16 @@ import type { Product } from '@/lib/schemas/commerce/product'
 import { ProductImage } from './product-image'
 import { formatCents } from '@/lib/commerce/compute-totals'
 import { useCartStore } from '@/lib/stores/cart-store'
+import { PriceDisplay } from './price-display'
 
 interface Props {
   siteSlug: string
   product: Product
   priority?: boolean
+  rates?: Record<string, number>
 }
 
-export function ProductCard({ siteSlug, product, priority }: Props) {
+export function ProductCard({ siteSlug, product, priority, rates }: Props) {
   const addItem = useCartStore((s) => s.addItem)
   const [adding, setAdding] = useState(false)
   const cover = product.images.find((i) => i.isCover) ?? product.images[0] ?? null
@@ -54,9 +56,17 @@ export function ProductCard({ siteSlug, product, priority }: Props) {
       <div className="mt-3 flex flex-1 flex-col">
         <h3 className="text-sm font-medium text-[color:var(--text,#111)] line-clamp-2">{product.name}</h3>
         <div className="mt-1 flex items-baseline gap-2">
-          <p className="text-base font-semibold text-[color:var(--text,#111)]">{formatCents(product.priceCents, product.currency)}</p>
+          {rates && product.currency === 'PYG' ? (
+            <PriceDisplay className="text-base font-semibold text-[color:var(--text,#111)]" pygCents={product.priceCents} rates={rates} />
+          ) : (
+            <p className="text-base font-semibold text-[color:var(--text,#111)]">{formatCents(product.priceCents, product.currency)}</p>
+          )}
           {product.compareAtPriceCents && product.compareAtPriceCents > product.priceCents ? (
-            <p className="text-xs text-[color:var(--text-muted,#9ca3af)] line-through">{formatCents(product.compareAtPriceCents, product.currency)}</p>
+            rates && product.currency === 'PYG' ? (
+              <PriceDisplay className="text-xs text-[color:var(--text-muted,#9ca3af)] line-through" pygCents={product.compareAtPriceCents} rates={rates} />
+            ) : (
+              <p className="text-xs text-[color:var(--text-muted,#9ca3af)] line-through">{formatCents(product.compareAtPriceCents, product.currency)}</p>
+            )
           ) : null}
         </div>
 

--- a/web/lib/commerce/csv-import.ts
+++ b/web/lib/commerce/csv-import.ts
@@ -1,0 +1,179 @@
+import { z } from 'zod'
+
+/**
+ * Minimal CSV parser — RFC 4180 subset covering the shapes merchants
+ * actually produce (Google Sheets / Excel exports with quoted commas +
+ * optional BOM). Single-file so we don't pull in papaparse for ~30 lines
+ * of logic.
+ *
+ * Assumes UTF-8. Strips BOM if present. Supports:
+ *   - comma-separated (default) or semicolon-separated (Latin-America
+ *     Excel default) — auto-detected from the header row
+ *   - double-quoted fields with embedded commas / newlines / "" escapes
+ *   - \r\n or \n row terminators
+ */
+export function parseCsv(raw: string): string[][] {
+  const text = raw.replace(/^﻿/, '')
+  const headerLine = text.slice(0, text.indexOf('\n'))
+  const delimiter = (headerLine.match(/;/g)?.length ?? 0) > (headerLine.match(/,/g)?.length ?? 0) ? ';' : ','
+
+  const rows: string[][] = []
+  let row: string[] = []
+  let field = ''
+  let inQuotes = false
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    const next = text[i + 1]
+    if (inQuotes) {
+      if (ch === '"' && next === '"') {
+        field += '"'
+        i++
+      } else if (ch === '"') {
+        inQuotes = false
+      } else {
+        field += ch
+      }
+    } else {
+      if (ch === '"') inQuotes = true
+      else if (ch === delimiter) {
+        row.push(field)
+        field = ''
+      } else if (ch === '\n' || ch === '\r') {
+        if (ch === '\r' && next === '\n') i++
+        row.push(field)
+        field = ''
+        if (row.length > 1 || row[0] !== '') rows.push(row)
+        row = []
+      } else {
+        field += ch
+      }
+    }
+  }
+  if (field !== '' || row.length > 0) {
+    row.push(field)
+    rows.push(row)
+  }
+  return rows
+}
+
+/**
+ * The "shape" we accept from merchants. Column names are lowercased +
+ * trimmed on header parse so case/whitespace differences don't cause
+ * pointless rejections.
+ */
+export const CsvProductRowSchema = z
+  .object({
+    slug: z.string().trim().min(1).max(120),
+    name: z.string().trim().min(1).max(200),
+    description: z.string().trim().max(5000).optional().default(''),
+    category: z.string().trim().max(80).optional().default(''),
+    price: z.union([z.string(), z.number()]),
+    compare_at_price: z.union([z.string(), z.number()]).optional().default(''),
+    sku: z.string().trim().max(80).optional().default(''),
+    stock: z.union([z.string(), z.number()]).optional().default('0'),
+    status: z.enum(['active', 'draft', 'archived']).optional().default('active'),
+    image_url: z.string().trim().max(500).optional().default(''),
+  })
+  .passthrough() // extra columns are ignored rather than rejected
+
+export type CsvProductRow = z.infer<typeof CsvProductRowSchema>
+
+/**
+ * Parses a PY-friendly price string: accepts "150000", "150.000", "Gs 150000",
+ * "150,000" etc. Returns integer PYG.
+ */
+export function parsePygPrice(raw: string | number): number {
+  if (typeof raw === 'number') return Math.round(raw)
+  const stripped = raw.replace(/[^\d-]/g, '')
+  const n = parseInt(stripped || '0', 10)
+  return Number.isFinite(n) && n >= 0 ? n : 0
+}
+
+export interface ParsedRow {
+  rowIndex: number // 1-based including header for error messages
+  ok: boolean
+  error?: string
+  data?: {
+    slug: string
+    name: string
+    description: string | null
+    category: string | null
+    priceCents: number
+    compareAtPriceCents: number | null
+    sku: string | null
+    inventoryQty: number
+    status: 'active' | 'draft' | 'archived'
+    imageUrl: string | null
+  }
+}
+
+export function normaliseHeader(h: string): string {
+  return h
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '_')
+    .replace(/[^\w]/g, '')
+}
+
+export function parseProductCsv(raw: string): { rows: ParsedRow[]; headerWarnings: string[] } {
+  const grid = parseCsv(raw)
+  if (grid.length === 0) return { rows: [], headerWarnings: [] }
+
+  const rawHeaders = grid[0].map(normaliseHeader)
+  const REQUIRED = ['slug', 'name', 'price']
+  const missing = REQUIRED.filter((h) => !rawHeaders.includes(h))
+  if (missing.length > 0) {
+    return {
+      rows: [],
+      headerWarnings: [`Faltan columnas obligatorias: ${missing.join(', ')}`],
+    }
+  }
+
+  const rows: ParsedRow[] = []
+  for (let i = 1; i < grid.length; i++) {
+    const line = grid[i]
+    // Skip fully-empty rows — Excel exports often add trailing blank lines.
+    if (line.every((cell) => !cell || !cell.trim())) continue
+
+    const record: Record<string, unknown> = {}
+    rawHeaders.forEach((h, colIdx) => {
+      record[h] = line[colIdx] ?? ''
+    })
+    const parsed = CsvProductRowSchema.safeParse(record)
+    if (!parsed.success) {
+      rows.push({
+        rowIndex: i + 1,
+        ok: false,
+        error: parsed.error.issues.map((x) => `${x.path.join('.')}: ${x.message}`).join('; '),
+      })
+      continue
+    }
+    const d = parsed.data
+    const priceCents = parsePygPrice(d.price)
+    if (priceCents <= 0) {
+      rows.push({ rowIndex: i + 1, ok: false, error: 'Precio inválido o <= 0' })
+      continue
+    }
+    rows.push({
+      rowIndex: i + 1,
+      ok: true,
+      data: {
+        slug: d.slug,
+        name: d.name,
+        description: d.description?.trim() || null,
+        category: d.category?.trim() || null,
+        priceCents,
+        compareAtPriceCents:
+          d.compare_at_price && String(d.compare_at_price).trim() !== ''
+            ? parsePygPrice(d.compare_at_price)
+            : null,
+        sku: d.sku?.trim() || null,
+        inventoryQty: parseInt(String(d.stock ?? '0').replace(/[^\d-]/g, ''), 10) || 0,
+        status: d.status,
+        imageUrl: d.image_url?.trim() || null,
+      },
+    })
+  }
+  return { rows, headerWarnings: [] }
+}

--- a/web/lib/commerce/currency-server.ts
+++ b/web/lib/commerce/currency-server.ts
@@ -1,0 +1,30 @@
+import 'server-only'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+/**
+ * Load the most recent rate for each PYG→X pair. Small enough (≤3 pairs)
+ * that caching in Next fetch cache is sufficient — no dedicated Redis
+ * layer needed at this volume.
+ *
+ * Lives in a separate file from `currency.ts` so the pure conversion
+ * helpers stay importable from client components without dragging
+ * `next/headers` into the browser bundle.
+ */
+export async function loadPygRates(): Promise<Record<string, number>> {
+  const supabase = await createAdminClient()
+  const pairs: Record<string, number> = { PYG: 1 }
+
+  const { data } = await supabase
+    .from('exchange_rates')
+    .select('from_currency, to_currency, rate, as_of')
+    .eq('from_currency', 'PYG')
+    .in('to_currency', ['USD', 'ARS', 'BRL'])
+    .order('as_of', { ascending: false })
+
+  const rows = Array.isArray(data) ? data : []
+  for (const row of rows) {
+    const key = row.to_currency as string
+    if (pairs[key] === undefined) pairs[key] = Number(row.rate)
+  }
+  return pairs
+}

--- a/web/lib/commerce/currency.ts
+++ b/web/lib/commerce/currency.ts
@@ -1,0 +1,78 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+
+/**
+ * Supported display currencies. Base currency stays PYG — we only convert
+ * at RENDER time for shopper display. Actual charges still go through
+ * Pagopar in PYG. Full multi-currency settlement is a future dLocal PR.
+ */
+export const DISPLAY_CURRENCIES = ['PYG', 'USD', 'ARS', 'BRL'] as const
+export type DisplayCurrency = (typeof DISPLAY_CURRENCIES)[number]
+
+export function isDisplayCurrency(value: string): value is DisplayCurrency {
+  return (DISPLAY_CURRENCIES as readonly string[]).includes(value)
+}
+
+export interface ExchangeRate {
+  from: string
+  to: string
+  rate: number
+  asOf: string
+}
+
+/**
+ * Load the most recent rate for each PYG→X pair. Small enough (≤3 pairs)
+ * that caching in Next fetch cache is sufficient — no dedicated Redis
+ * layer needed at this volume.
+ */
+export async function loadPygRates(): Promise<Record<string, number>> {
+  const supabase = await createAdminClient()
+  const pairs: Record<string, number> = { PYG: 1 }
+
+  const { data } = await supabase
+    .from('exchange_rates')
+    .select('from_currency, to_currency, rate, as_of')
+    .eq('from_currency', 'PYG')
+    .in('to_currency', ['USD', 'ARS', 'BRL'])
+    .order('as_of', { ascending: false })
+
+  const rows = Array.isArray(data) ? data : []
+  for (const row of rows) {
+    const key = row.to_currency as string
+    // Each target currency's first row (most recent as_of) wins.
+    if (pairs[key] === undefined) pairs[key] = Number(row.rate)
+  }
+  return pairs
+}
+
+/**
+ * Convert PYG integer amount to a display currency. Rounds to integer
+ * cents for USD/ARS/BRL (they have 2 subunits so we multiply by 100 and
+ * round). PYG has no subunit so the display is integer guaraníes.
+ *
+ * Returns zero-padded to safe precision; the UI chooses how to format.
+ */
+export function convertPygAmount(
+  pygAmount: number,
+  target: DisplayCurrency,
+  rates: Record<string, number>,
+): { amount: number; currency: DisplayCurrency } {
+  if (target === 'PYG') return { amount: pygAmount, currency: 'PYG' }
+  const rate = rates[target]
+  if (!rate || rate <= 0) return { amount: pygAmount, currency: 'PYG' } // graceful fallback
+  return { amount: pygAmount * rate, currency: target }
+}
+
+/**
+ * Format a display amount with locale + currency symbol. USD/ARS/BRL get
+ * 2 decimals; PYG gets none.
+ */
+export function formatDisplay(amount: number, currency: DisplayCurrency): string {
+  const locale = currency === 'BRL' ? 'pt-BR' : currency === 'ARS' ? 'es-AR' : currency === 'USD' ? 'en-US' : 'es-PY'
+  const options: Intl.NumberFormatOptions =
+    currency === 'PYG'
+      ? { style: 'decimal', maximumFractionDigits: 0 }
+      : { style: 'currency', currency, maximumFractionDigits: 2 }
+  const formatter = new Intl.NumberFormat(locale, options)
+  const formatted = formatter.format(Math.round(amount * 100) / 100)
+  return currency === 'PYG' ? `Gs ${formatted}` : formatted
+}

--- a/web/lib/commerce/currency.ts
+++ b/web/lib/commerce/currency.ts
@@ -1,6 +1,9 @@
-import { createAdminClient } from '@/lib/supabase/admin'
-
 /**
+ * Pure, client-safe currency helpers. Do NOT import server-only modules
+ * here — <PriceDisplay> is a client component and transitively loads this
+ * file, so any next/headers dependency would poison the client bundle.
+ * Server-only rate loading lives in `currency-server.ts`.
+ *
  * Supported display currencies. Base currency stays PYG — we only convert
  * at RENDER time for shopper display. Actual charges still go through
  * Pagopar in PYG. Full multi-currency settlement is a future dLocal PR.
@@ -17,31 +20,6 @@ export interface ExchangeRate {
   to: string
   rate: number
   asOf: string
-}
-
-/**
- * Load the most recent rate for each PYG→X pair. Small enough (≤3 pairs)
- * that caching in Next fetch cache is sufficient — no dedicated Redis
- * layer needed at this volume.
- */
-export async function loadPygRates(): Promise<Record<string, number>> {
-  const supabase = await createAdminClient()
-  const pairs: Record<string, number> = { PYG: 1 }
-
-  const { data } = await supabase
-    .from('exchange_rates')
-    .select('from_currency, to_currency, rate, as_of')
-    .eq('from_currency', 'PYG')
-    .in('to_currency', ['USD', 'ARS', 'BRL'])
-    .order('as_of', { ascending: false })
-
-  const rows = Array.isArray(data) ? data : []
-  for (const row of rows) {
-    const key = row.to_currency as string
-    // Each target currency's first row (most recent as_of) wins.
-    if (pairs[key] === undefined) pairs[key] = Number(row.rate)
-  }
-  return pairs
 }
 
 /**

--- a/web/lib/commerce/discounts-admin.ts
+++ b/web/lib/commerce/discounts-admin.ts
@@ -1,0 +1,149 @@
+import { z } from 'zod'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { scopedQueries } from '@/lib/supabase/scoped'
+
+/**
+ * Admin CRUD over the discounts table. The shopper-side applyDiscount lives
+ * in /lib/commerce/discounts.ts; this module is the merchant-facing surface.
+ */
+
+export const DiscountTypeSchema = z.enum(['percent', 'fixed_amount', 'free_shipping'])
+export type DiscountType = z.infer<typeof DiscountTypeSchema>
+
+export const DiscountInputSchema = z
+  .object({
+    code: z.string().trim().min(1).max(80).transform((s) => s.toUpperCase()),
+    type: DiscountTypeSchema,
+    valuePercent: z.number().min(0).max(100).nullable().optional(),
+    valueCents: z.number().int().min(0).nullable().optional(),
+    minSubtotalCents: z.number().int().min(0).default(0),
+    currency: z.string().length(3).default('PYG'),
+    startsAt: z.string().datetime().nullable().optional(),
+    endsAt: z.string().datetime().nullable().optional(),
+    maxUses: z.number().int().min(1).nullable().optional(),
+    maxUsesPerCustomer: z.number().int().min(1).default(1),
+    status: z.enum(['active', 'paused', 'archived']).default('active'),
+  })
+  .refine(
+    (d) => {
+      if (d.type === 'percent') return typeof d.valuePercent === 'number' && d.valuePercent > 0
+      if (d.type === 'fixed_amount') return typeof d.valueCents === 'number' && d.valueCents > 0
+      return true // free_shipping needs no amount
+    },
+    { message: 'percent requires valuePercent; fixed_amount requires valueCents' },
+  )
+export type DiscountInput = z.infer<typeof DiscountInputSchema>
+
+export interface DiscountRecord {
+  id: string
+  businessId: string
+  code: string
+  type: DiscountType
+  valuePercent: number | null
+  valueCents: number | null
+  minSubtotalCents: number
+  currency: string
+  startsAt: string | null
+  endsAt: string | null
+  maxUses: number | null
+  maxUsesPerCustomer: number | null
+  usesCount: number
+  status: 'active' | 'paused' | 'archived'
+  createdAt: string
+  updatedAt: string
+}
+
+function rowToRecord(row: Record<string, unknown>): DiscountRecord {
+  return {
+    id: row.id as string,
+    businessId: row.business_id as string,
+    code: row.code as string,
+    type: row.type as DiscountType,
+    valuePercent: (row.value_percent as number | null) ?? null,
+    valueCents: (row.value_cents as number | null) ?? null,
+    minSubtotalCents: (row.min_subtotal_cents as number) ?? 0,
+    currency: row.currency as string,
+    startsAt: (row.starts_at as string | null) ?? null,
+    endsAt: (row.ends_at as string | null) ?? null,
+    maxUses: (row.max_uses as number | null) ?? null,
+    maxUsesPerCustomer: (row.max_uses_per_customer as number | null) ?? null,
+    usesCount: (row.uses_count as number) ?? 0,
+    status: row.status as DiscountRecord['status'],
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+  }
+}
+
+export async function listDiscounts(businessId: string): Promise<DiscountRecord[]> {
+  const supabase = await createAdminClient()
+  const scoped = scopedQueries(supabase, businessId)
+  const { data } = await scoped.select<Record<string, unknown>>('discounts', '*', {
+    filter: (q) => q.order('created_at', { ascending: false }),
+  })
+  return (Array.isArray(data) ? data : []).map(rowToRecord)
+}
+
+export async function createDiscount(businessId: string, input: DiscountInput): Promise<DiscountRecord> {
+  const supabase = await createAdminClient()
+  const scoped = scopedQueries(supabase, businessId)
+  const { data, error } = await scoped.insert<Record<string, unknown>>('discounts', {
+    code: input.code,
+    type: input.type,
+    value_percent: input.valuePercent ?? null,
+    value_cents: input.valueCents ?? null,
+    min_subtotal_cents: input.minSubtotalCents,
+    currency: input.currency,
+    starts_at: input.startsAt ?? null,
+    ends_at: input.endsAt ?? null,
+    max_uses: input.maxUses ?? null,
+    max_uses_per_customer: input.maxUsesPerCustomer,
+    status: input.status,
+  })
+  if (error || !data?.[0]) {
+    const pgCode = (error as { code?: string } | null)?.code
+    if (pgCode === '23505' || (error?.message ?? '').includes('duplicate')) {
+      throw new Error('code_already_exists')
+    }
+    throw new Error(error?.message ?? 'discount_create_failed')
+  }
+  return rowToRecord(data[0])
+}
+
+export async function updateDiscount(
+  businessId: string,
+  id: string,
+  patch: Partial<DiscountInput>,
+): Promise<DiscountRecord> {
+  const supabase = await createAdminClient()
+  const scoped = scopedQueries(supabase, businessId)
+  const dbPatch: Record<string, unknown> = {}
+  if (patch.code !== undefined) dbPatch.code = patch.code.toUpperCase()
+  if (patch.type !== undefined) dbPatch.type = patch.type
+  if (patch.valuePercent !== undefined) dbPatch.value_percent = patch.valuePercent
+  if (patch.valueCents !== undefined) dbPatch.value_cents = patch.valueCents
+  if (patch.minSubtotalCents !== undefined) dbPatch.min_subtotal_cents = patch.minSubtotalCents
+  if (patch.currency !== undefined) dbPatch.currency = patch.currency
+  if (patch.startsAt !== undefined) dbPatch.starts_at = patch.startsAt
+  if (patch.endsAt !== undefined) dbPatch.ends_at = patch.endsAt
+  if (patch.maxUses !== undefined) dbPatch.max_uses = patch.maxUses
+  if (patch.maxUsesPerCustomer !== undefined) dbPatch.max_uses_per_customer = patch.maxUsesPerCustomer
+  if (patch.status !== undefined) dbPatch.status = patch.status
+
+  const { data, error } = await scoped.update<Record<string, unknown>>(
+    'discounts',
+    dbPatch,
+    (q) => q.eq('id', id),
+  )
+  if (error || !data?.[0]) throw new Error(error?.message ?? 'discount_update_failed')
+  return rowToRecord(data[0])
+}
+
+export async function deleteDiscount(businessId: string, id: string): Promise<void> {
+  const supabase = await createAdminClient()
+  const { error } = await supabase
+    .from('discounts')
+    .delete()
+    .eq('id', id)
+    .eq('business_id', businessId)
+  if (error) throw new Error(error.message)
+}

--- a/web/lib/commerce/discounts-admin.ts
+++ b/web/lib/commerce/discounts-admin.ts
@@ -10,28 +10,34 @@ import { scopedQueries } from '@/lib/supabase/scoped'
 export const DiscountTypeSchema = z.enum(['percent', 'fixed_amount', 'free_shipping'])
 export type DiscountType = z.infer<typeof DiscountTypeSchema>
 
-export const DiscountInputSchema = z
-  .object({
-    code: z.string().trim().min(1).max(80).transform((s) => s.toUpperCase()),
-    type: DiscountTypeSchema,
-    valuePercent: z.number().min(0).max(100).nullable().optional(),
-    valueCents: z.number().int().min(0).nullable().optional(),
-    minSubtotalCents: z.number().int().min(0).default(0),
-    currency: z.string().length(3).default('PYG'),
-    startsAt: z.string().datetime().nullable().optional(),
-    endsAt: z.string().datetime().nullable().optional(),
-    maxUses: z.number().int().min(1).nullable().optional(),
-    maxUsesPerCustomer: z.number().int().min(1).default(1),
-    status: z.enum(['active', 'paused', 'archived']).default('active'),
-  })
-  .refine(
-    (d) => {
-      if (d.type === 'percent') return typeof d.valuePercent === 'number' && d.valuePercent > 0
-      if (d.type === 'fixed_amount') return typeof d.valueCents === 'number' && d.valueCents > 0
-      return true // free_shipping needs no amount
-    },
-    { message: 'percent requires valuePercent; fixed_amount requires valueCents' },
-  )
+/**
+ * Raw object schema without refinement — exported so callers that need
+ * `.partial()` (PATCH routes) can derive a patch schema. Zod v4 rejects
+ * `.partial()` on schemas that carry refinements, so we keep the refine
+ * on DiscountInputSchema only (used for create/full-body validation).
+ */
+export const DiscountInputShape = z.object({
+  code: z.string().trim().min(1).max(80).transform((s) => s.toUpperCase()),
+  type: DiscountTypeSchema,
+  valuePercent: z.number().min(0).max(100).nullable().optional(),
+  valueCents: z.number().int().min(0).nullable().optional(),
+  minSubtotalCents: z.number().int().min(0).default(0),
+  currency: z.string().length(3).default('PYG'),
+  startsAt: z.string().datetime().nullable().optional(),
+  endsAt: z.string().datetime().nullable().optional(),
+  maxUses: z.number().int().min(1).nullable().optional(),
+  maxUsesPerCustomer: z.number().int().min(1).default(1),
+  status: z.enum(['active', 'paused', 'archived']).default('active'),
+})
+
+export const DiscountInputSchema = DiscountInputShape.refine(
+  (d) => {
+    if (d.type === 'percent') return typeof d.valuePercent === 'number' && d.valuePercent > 0
+    if (d.type === 'fixed_amount') return typeof d.valueCents === 'number' && d.valueCents > 0
+    return true // free_shipping needs no amount
+  },
+  { message: 'percent requires valuePercent; fixed_amount requires valueCents' },
+)
 export type DiscountInput = z.infer<typeof DiscountInputSchema>
 
 export interface DiscountRecord {

--- a/web/lib/commerce/email-templates.ts
+++ b/web/lib/commerce/email-templates.ts
@@ -60,6 +60,38 @@ export function orderShippedEmail({ order, businessName, storeUrl }: Context) {
   }
 }
 
+interface CartRecoveryContext {
+  customerName: string
+  businessName: string
+  recoveryUrl: string
+  /** 1 = 24 h touch ("still thinking?"), 2 = 72 h, 3 = 7 d ("last chance"). */
+  step: 1 | 2 | 3
+}
+
+export function cartRecoveryEmail(ctx: CartRecoveryContext) {
+  const subjects: Record<1 | 2 | 3, string> = {
+    1: `¿Seguís pensándolo? — ${ctx.businessName}`,
+    2: `Tu carrito sigue esperando en ${ctx.businessName}`,
+    3: `Última oportunidad — tu carrito en ${ctx.businessName}`,
+  }
+  const bodies: Record<1 | 2 | 3, string> = {
+    1: 'Vimos que dejaste algunos productos en tu carrito. ¿Querés volver a revisarlos?',
+    2: 'Tus productos siguen guardados. Si necesitás ayuda para decidir, escribinos por WhatsApp.',
+    3: 'Tu carrito se va a vaciar pronto. Si te interesa algún producto, te conviene volver ahora.',
+  }
+  return {
+    subject: subjects[ctx.step],
+    html: `
+<!doctype html><html><body style="font-family:system-ui,-apple-system,sans-serif;color:#111;max-width:600px;margin:0 auto;padding:24px;">
+  <h1 style="font-size:20px;">Hola ${escape(ctx.customerName)},</h1>
+  <p>${escape(bodies[ctx.step])}</p>
+  <p style="margin:24px 0;"><a href="${ctx.recoveryUrl}" style="display:inline-block;background:#111;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Volver a mi carrito</a></p>
+  <p style="color:#666;font-size:12px;margin-top:24px;">Si ya compraste o no te interesa más, ignorá este mensaje. El link solo funciona por 7 días.</p>
+  <p style="color:#666;font-size:12px;">${escape(ctx.businessName)} · enviado desde Paragu-AI</p>
+</body></html>`.trim(),
+  }
+}
+
 function escape(s: string): string {
   return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!))
 }


### PR DESCRIPTION
## Summary

Five polish features closing out the commerce path for nexaparaguay + future tenants:

1. **Discount admin UI** — `/admin/commerce/[id]/discounts`. CRUD for percent / fixed_amount / free_shipping codes with min-subtotal, expiry, max-uses controls. Duplicate code → `code_already_exists` on 23505.
2. **Reconciliation dashboard** — `/admin/commerce/[id]/reconciliation`. 14-day orders-by-status vs storefront_transactions-by-status side-by-side; highlights any per-day count or GMV drift so the operator can spot missing webhooks.
3. **Cart-recovery email bodies** — 24h / 72h / 7d Spanish templates wired into the `commerce-abandoned-cart` cron. New CHECK on `commerce_email_outbox.template` allows the three new values.
4. **Multi-currency storefront display** — PYG/USD/ARS/BRL via `loadPygRates()` + `CurrencyToggle` + `PriceDisplay`. Server renders PYG; client swaps via `useSyncExternalStore`. Charges stay PYG on the wire — this is display-only for Argentine expats / Brazilian tourists. Exchange rates seeded in `exchange_rates`.
5. **Bulk CSV product import** — `/admin/commerce/[id]/products/import`. Single-file RFC-4180-subset parser (auto-detects `,` vs `;`, strips BOM, handles quoted commas). Preview → commit with per-row validation. Upsert on `(business_id, slug)` so re-imports update.

Admin products page gains a tab-style nav bar linking to Productos / Importar CSV / Descuentos / Envíos / Pedidos / Conciliación.

## Migrations
- `20260422000400_commerce_email_outbox_cart_recovery.sql` — extend template CHECK constraint

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (only unrelated warnings)
- [x] `npm run test:unit` — 426 pass / 11 skipped
- [ ] Manual: create discount code in admin, apply at checkout, confirm redemption
- [ ] Manual: upload 10-row CSV, preview, commit, confirm upsert on re-run
- [ ] Manual: toggle PYG→USD in header, verify all prices reformat
- [ ] Manual: trigger cron `/api/cron/commerce-abandoned-cart`, confirm outbox enqueues `cart_recovery_24h`

🤖 Generated with [Claude Code](https://claude.com/claude-code)