### PR TITLE
perf(analytics): memoize Supabase client + fix salt bug (#423)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 73 | see closure log below |
+| ✅ Closed | 74 | see closure log below |
 | 🟡 In progress | 1 | #392 (5 routes still unwrapped — audit in REQUEST_LOG_AUDIT.md) |
-| 🔴 Open | 427 | the rest |
+| 🔴 Open | 426 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -98,6 +98,11 @@ Closure log:
 - **#482** — per-route Cache-Control headers in `next.config.mjs`:
   admin/auth/login → `no-store`; sitemap/robots → 1d browser, 1w CDN;
   OG images + favicon → 1d browser, 1w CDN, 30d SWR.
+- **#423** — `/api/analytics/track` Supabase client now memoized at module
+  scope (was created fresh per request, was the cold-start cause). Test
+  asserts `createClient` is called exactly once across 5 POSTs. Also fixed
+  a real `hashIp` operator-precedence bug where `ip + process.env.SALT || 'fallback'`
+  always took the first operand, making the salt fallback dead.
 - **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
   added id to `<main>` on landing + 11 high-traffic marketing routes.
 - **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).

--- a/web/app/api/analytics/track/route.ts
+++ b/web/app/api/analytics/track/route.ts
@@ -3,19 +3,28 @@
  * Win 68: Page view tracking API
  */
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 
-// Lazy client: creating it at request time (not module top-level) lets
-// `next build` collect page data without Supabase env vars being set.
-// The runtime error only fires when a real request hits without config.
-function getSupabase() {
+// Module-scoped, memoized client. First request pays the init cost (~tens
+// of ms — just wrapper construction, no network); every subsequent request
+// reuses the same instance. Previous implementation created a fresh client
+// per request, which shows up as cold-start latency on the first POST
+// after a container restart.
+//
+// Not memoized at module top-level because `next build` page-data collection
+// runs without Supabase env vars — would throw there.
+let cachedClient: SupabaseClient | null = null
+
+function getSupabase(): SupabaseClient {
+  if (cachedClient) return cachedClient
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY
   if (!url || !key) throw new Error('Missing Supabase credentials')
-  return createClient(url, key, {
+  cachedClient = createClient(url, key, {
     auth: { autoRefreshToken: false, persistSession: false },
   })
+  return cachedClient
 }
 
 // Valid event types
@@ -210,9 +219,12 @@ export async function GET(request: NextRequest) {
 
 // Helper functions
 async function hashIp(ip: string): Promise<string> {
-  // Simple hash for privacy
+  // Salt for k-anonymity. Operator precedence: + binds tighter than ||,
+  // so the previous `ip + process.env.SALT || 'paragu-ai'` always took
+  // the first operand (a non-empty string), making the fallback dead.
+  const salt = process.env.ANALYTICS_SALT || 'paragu-ai'
   const encoder = new TextEncoder()
-  const data = encoder.encode(ip + process.env.ANALYTICS_SALT || 'paragu-ai')
+  const data = encoder.encode(ip + salt)
   const hashBuffer = await crypto.subtle.digest('SHA-256', data)
   const hashArray = Array.from(new Uint8Array(hashBuffer))
   return hashArray.map(b => b.toString(16).padStart(2, '0')).join('').slice(0, 16)

--- a/web/tests/integration/api-analytics-track.test.ts
+++ b/web/tests/integration/api-analytics-track.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for /api/analytics/track. Closes BUG_HUNT_500 #423.
+ *
+ * Coverage:
+ *   - 400 on missing/invalid event type
+ *   - 200 happy path returns event id + session id
+ *   - supabase client is created exactly once across N requests (proves
+ *     the module-scoped cache works — was the cold-start bug)
+ *   - 401 on GET without bearer token
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mockInsert = vi.fn()
+const mockSelect = vi.fn(() => ({
+  single: vi.fn(async () => ({ data: { id: 'evt-1' }, error: null })),
+}))
+const mockFrom = vi.fn(() => ({
+  insert: () => ({ select: mockSelect }),
+}))
+const createClientSpy = vi.fn(() => ({ from: mockFrom }))
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: (...args: unknown[]) => createClientSpy(...args),
+}))
+
+const ORIGINAL_ENV = { ...process.env }
+
+describe('/api/analytics/track POST', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = {
+      ...ORIGINAL_ENV,
+      NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-test',
+    }
+    // Reset module cache so each test gets a fresh module-scoped client.
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('returns 400 when eventType is missing', async () => {
+    const { POST } = await import('@/app/api/analytics/track/route')
+    const req = new Request('http://localhost/api/analytics/track', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    })
+    const res = await POST(req as never)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for invalid event type', async () => {
+    const { POST } = await import('@/app/api/analytics/track/route')
+    const req = new Request('http://localhost/api/analytics/track', {
+      method: 'POST',
+      body: JSON.stringify({ eventType: 'definitely-not-a-real-event' }),
+    })
+    const res = await POST(req as never)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 + event id on the happy path', async () => {
+    const { POST } = await import('@/app/api/analytics/track/route')
+    const req = new Request('http://localhost/api/analytics/track', {
+      method: 'POST',
+      body: JSON.stringify({ eventType: 'page_view', pageUrl: '/' }),
+    })
+    const res = await POST(req as never)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.eventId).toBe('evt-1')
+    expect(body.sessionId).toMatch(/^sess_/)
+  })
+
+  it('creates the Supabase client exactly once across many requests (cache works)', async () => {
+    const { POST } = await import('@/app/api/analytics/track/route')
+    for (let i = 0; i < 5; i++) {
+      const req = new Request('http://localhost/api/analytics/track', {
+        method: 'POST',
+        body: JSON.stringify({ eventType: 'page_view' }),
+      })
+      await POST(req as never)
+    }
+    // 5 POSTs, only 1 createClient call — module-scoped cache hits 4 times.
+    expect(createClientSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('/api/analytics/track GET', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    process.env = {
+      ...ORIGINAL_ENV,
+      NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-test',
+    }
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('returns 401 without bearer token', async () => {
+    const { GET } = await import('@/app/api/analytics/track/route')
+    const req = new Request('http://localhost/api/analytics/track', { method: 'GET' })
+    const res = await GET(req as never)
+    expect(res.status).toBe(401)
+  })
+})


### PR DESCRIPTION
## Summary
- `/api/analytics/track` Supabase client is now memoized at module scope (was created fresh per request — cold-start cause). New test asserts `createClient` is called exactly once across 5 sequential POSTs.
- Bonus fix: `hashIp` had a real operator-precedence bug. `ip + process.env.SALT || 'paragu-ai'` always took the first operand (a non-empty string is truthy), so the salt fallback was dead code. Salt now applied correctly.
- Closes BUG_HUNT_500 #423.

## Test plan
- [x] `npx vitest run tests/integration/api-analytics-track.test.ts` → 5/5 passing
- [x] `npx tsc --noEmit` → 0 errors
- [ ] After deploy: hit `/api/analytics/track` after container restart, then again — second request should not show the same latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)