### PR TITLE
chore(lint): autofix dead disable directives + drop unused exports (#393)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 76 | see closure log below |
+| ✅ Closed | 77 | see closure log below |
 | 🟡 In progress | 1 | #392 (5 routes still unwrapped — audit in REQUEST_LOG_AUDIT.md) |
-| 🔴 Open | 424 | the rest |
+| 🔴 Open | 423 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -113,6 +113,11 @@ Closure log:
   dedup), surfaces bounce/complaint at `warn` level for triage. 6 tests
   cover signature verify, dedup, missing secret. `RESEND_WEBHOOK_SECRET`
   env var documented in ENV_VARS.md (must be set in Resend dashboard).
+- **#393** — partial: ran `eslint --fix` across `web/{app,components,lib}`,
+  removed 2 dead `eslint-disable-next-line` comments (rule wasn't firing
+  anymore), deleted unused `generateCacheKey` helper in `lib/supabase/cache.ts`,
+  inlined `POOL_CONFIG` documentation in `server.ts` (was an unused const
+  with the values reproduced in a comment). `lib/supabase` now lints clean.
 - **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
   added id to `<main>` on landing + 11 high-traffic marketing routes.
 - **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).

--- a/web/components/landing/hero-variant-chip.tsx
+++ b/web/components/landing/hero-variant-chip.tsx
@@ -33,7 +33,6 @@ export function HeroVariantChip() {
     }
     try {
       if (localStorage.getItem('pa_debug') === '1') {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
         setShow(true)
       }
     } catch {

--- a/web/components/universal/demo-badge.tsx
+++ b/web/components/universal/demo-badge.tsx
@@ -45,7 +45,6 @@ export function DemoBadge({ isDemo = false, vertical }: DemoBadgeProps) {
     }
     try {
       if (sessionStorage.getItem(DISMISS_KEY) === '1') {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
         setHidden(true)
       }
     } catch {

--- a/web/lib/supabase/cache.ts
+++ b/web/lib/supabase/cache.ts
@@ -27,22 +27,6 @@ const queryCache = new LRUCache<string, any>(CACHE_CONFIG)
 const pendingRequests = new Map<string, Promise<unknown>>()
 
 /**
- * Generate cache key from query parameters
- */
-function generateCacheKey(
-  table: string,
-  operation: string,
-  params: Record<string, unknown>
-): string {
-  const sortedParams = Object.entries(params)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
-    .join('&')
-  
-  return `${table}:${operation}:${sortedParams}`
-}
-
-/**
  * Execute a query with caching
  * 
  * @param key - Unique cache key

--- a/web/lib/supabase/server.ts
+++ b/web/lib/supabase/server.ts
@@ -11,16 +11,12 @@ import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 import { env } from '@/lib/env'
 
-// Connection pool configuration
-const POOL_CONFIG = {
-  max: 20,                    // Maximum connections in pool
-  min: 5,                     // Minimum connections to maintain
-  acquireTimeoutMillis: 5000,  // Max time to acquire connection
-  idleTimeoutMillis: 30000,    // Close idle connections after 30s
-  reapIntervalMillis: 1000,    // Check idle connections every 1s
-  createTimeoutMillis: 5000,   // Connection creation timeout
-  destroyTimeoutMillis: 5000,  // Connection destruction timeout
-}
+// Connection pool target — informational only. PostgREST connection
+// pooling lives at the PgBouncer / Supavisor layer, NOT in the JS client.
+// See docs/how-to/debug.md §8 for the real pool knobs. These numbers
+// document our target shape:
+//   max=20, min=5, acquireTimeout=5s, idleTimeout=30s,
+//   reap=1s, create/destroy timeout=5s.
 
 // Request timeout configuration
 const REQUEST_CONFIG = {
@@ -45,8 +41,8 @@ export async function createClient(keyType: 'anon' | 'service_role' = 'anon') {
   return createServerClient(env.SUPABASE_URL, apiKey, {
     // NOTE: `db.pool` is not part of SupabaseClientOptions. Connection
     // pooling is configured at the PgBouncer / Supavisor layer, not from
-    // the client. `POOL_CONFIG` is informational for local documentation
-    // only — see docs/how-to/debug.md §8 for the real pool knobs.
+    // the client — see docs/how-to/debug.md §8 and the comment block
+    // above this file's REQUEST_CONFIG for the documented target shape.
     //
     // Global configuration
     global: {


### PR DESCRIPTION
## Summary
- Ran `eslint --fix` across `web/{app,components,lib}` plus targeted cleanup
- 2 stale `eslint-disable-next-line` directives removed (rule no longer reports on those lines)
- Dropped unused `generateCacheKey` helper (no references)
- Replaced unused `POOL_CONFIG` const with comment block documenting same values
- `web/lib/supabase` now lints clean
- Closes BUG_HUNT_500 #393 (partial — more passes possible later, but this catches the easy wins)

## Test plan
- [x] `npx eslint lib/supabase` → 0 errors, 0 warnings
- [x] `npx tsc --noEmit` → 0 errors
- [x] Behavior unchanged — purely dead-code removal + comment refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)