### PR TITLE
docs: refresh README + close #400, #469, #483

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Demo tenants (salon-maria, gymfit-py, spa-serenidad, etc.) live alongside real t
 - **New to the repo?** → [ARCHITECTURE.md](./ARCHITECTURE.md) (the 5-minute system tour)
 - **Contributing code?** → [CONTRIBUTING.md](./CONTRIBUTING.md) (branch, commit, PR, quality gates)
 - **Looking for something specific?** → [docs/README.md](./docs/README.md) (docs hub — every reference, how-to, and explainer)
-- **Adding a new tenant?** → [docs/how-to/add-tenant.md](./docs/how-to/add-tenant.md) _(planned — see [consolidation plan](./docs/DOCS_CONSOLIDATION_PLAN.md))_
+- **Adding a new tenant?** → [docs/runbooks/ADD_NEW_TENANT.md](./docs/runbooks/ADD_NEW_TENANT.md)
+- **Adding a new vertical?** → [docs/runbooks/ADD_NEW_VERTICAL.md](./docs/runbooks/ADD_NEW_VERTICAL.md)
+- **Rotating a secret / env vars?** → [docs/runbooks/ENV_VARS.md](./docs/runbooks/ENV_VARS.md)
+- **Last deploy broke?** → [docs/runbooks/ROLLBACK.md](./docs/runbooks/ROLLBACK.md)
 - **AI-agent-oriented context?** → [CLAUDE.md](./CLAUDE.md) (the instructions LLMs read)
 
 ## Quick start
@@ -86,9 +89,9 @@ web/                  Application layer (Next.js)
     [business]/             flat-pattern legacy tenant routes
     s/[locale]/[siteSlug]/  locale-prefixed modern tenant routes
     admin/                  protected dashboard
-    api/                    21 REST routes
+    api/                    52 REST routes (incl. cron, webhooks, admin, storefront)
   components/
-    sections/               83 reusable section components
+    sections/               82 reusable section components
     ui/                     primitives (Button, Card, Badge via CVA)
   lib/
     engine/                 composition pipeline

--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 77 | see closure log below |
+| ✅ Closed | 80 | see closure log below |
 | 🟡 In progress | 1 | #392 (5 routes still unwrapped — audit in REQUEST_LOG_AUDIT.md) |
-| 🔴 Open | 423 | the rest |
+| 🔴 Open | 420 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -118,6 +118,17 @@ Closure log:
   anymore), deleted unused `generateCacheKey` helper in `lib/supabase/cache.ts`,
   inlined `POOL_CONFIG` documentation in `server.ts` (was an unused const
   with the values reproduced in a comment). `lib/supabase` now lints clean.
+- **#400** — verified: zero JSX `class=` violations across `web/{app,components}`.
+  Remaining `class=` instances are inside HTML email templates (e.g.
+  `app/api/admin/daily-metrics/route.ts:303`) which are correct as-is.
+- **#469** — verified: only one `tabIndex={-1}` in app code, on the spam-honeypot
+  field at `lead-form-section.tsx:158` (intentional — hidden input, not a CTA).
+  All real CTAs are reachable via Tab.
+- **#483** — README.md updated: API route count `21 → 52` (cron + webhooks +
+  admin + storefront added since first count); section count `83 → 82`; "Adding
+  a new tenant" pointer fixed to actual `docs/runbooks/ADD_NEW_TENANT.md` (was
+  pointing to a "planned" file that already exists), plus links to ADD_NEW_VERTICAL,
+  ENV_VARS, and ROLLBACK runbooks.
 - **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
   added id to `<main>` on landing + 11 high-traffic marketing routes.
 - **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).


### PR DESCRIPTION
## Summary
- README.md API route count 21 → 52, section count 83 → 82
- "Adding a new tenant" link fixed (was "planned", now points to actual `docs/runbooks/ADD_NEW_TENANT.md`)
- Added pointers to ADD_NEW_VERTICAL, ENV_VARS, ROLLBACK runbooks
- Closes BUG_HUNT_500 #400 (no JSX `class=` violations), #469 (CTAs Tab-reachable), #483 (README current)

## Test plan
- [x] `grep -rE '<[a-z]+[^>]*\sclass=' web/{app,components} --include="*.tsx" | grep -v className` → empty
- [x] `grep -rnE 'tabIndex={?-1' web/{app,components} --include="*.tsx"` → only the honeypot
- [x] README counts verified: `find web/app/api -name route.ts | wc -l` = 52, `ls web/components/sections | wc -l` = 82

🤖 Generated with [Claude Code](https://claude.com/claude-code)