### PR TITLE
docs(decisions): seed ADR log with 6 locked-in choices (#489)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 80 | see closure log below |
+| ✅ Closed | 81 | see closure log below |
 | 🟡 In progress | 1 | #392 (5 routes still unwrapped — audit in REQUEST_LOG_AUDIT.md) |
-| 🔴 Open | 420 | the rest |
+| 🔴 Open | 419 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -129,6 +129,12 @@ Closure log:
   a new tenant" pointer fixed to actual `docs/runbooks/ADD_NEW_TENANT.md` (was
   pointing to a "planned" file that already exists), plus links to ADD_NEW_VERTICAL,
   ENV_VARS, and ROLLBACK runbooks.
+- **#489** — `docs/decisions/` ADR log seeded with 6 records: Tailwind 3.4.19
+  pin (#0001), Hostinger crontab (#0002), env-allowlist admin (#0003), Pagopar
+  primary (#0004), defer next/image (#0005), Supabase client cache (#0006).
+  README + format documented at `docs/decisions/README.md`. Indexed from
+  `docs/README.md` so future "why did we pick X?" questions land at the ADRs
+  instead of grep through commit history.
 - **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
   added id to `<main>` on landing + 11 high-traffic marketing routes.
 - **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ The [docs consolidation plan](./DOCS_CONSOLIDATION_PLAN.md) tracked the migratio
 | Debugging a live issue | [how-to/debug.md](./how-to/debug.md) + [observability/](./observability/) |
 | Understanding why the system is built this way | [explanation/](./explanation/) |
 | Responding to an alert | [runbooks/](./runbooks/) _(one file per alert, added as alerts are defined)_ |
+| Asking "why did we pick X?" | [decisions/](./decisions/) — ADR log of locked-in technical choices |
 
 ## Canonical layout
 
@@ -69,6 +70,9 @@ docs/
 │
 ├── runbooks/                         one file per pageable alert
 │   └── README.md                     convention (no runbooks yet — populated as alerts are defined)
+│
+├── decisions/                        ADRs — "why we picked X over Y"
+│   └── README.md                     index + format
 │
 └── archive/                          superseded/completed — preserved for audit
     └── 2026-04/                      39 files archived during the consolidation

--- a/docs/decisions/0001-tailwind-3-not-4.md
+++ b/docs/decisions/0001-tailwind-3-not-4.md
@@ -1,0 +1,42 @@
+# 0001 · Tailwind 3.4.19 (do not upgrade to v4)
+
+**Status:** Accepted · 2026-04-15
+**Deciders:** Ivan
+
+## Context
+
+We composed tenant themes as JSON token files (`src/tokens/<vertical>.tokens.json`)
+that the build pipeline reads to generate per-tenant CSS variables. Tailwind v4
+introduced a new content-scanner that aggressively parses every JSON in the
+working tree, treating our token files as class candidates. That broke the
+build with cryptic "unknown class" errors.
+
+## Options considered
+
+- **Tailwind v4 + ignore globs** — patch the v4 scanner config to exclude
+  `src/tokens/**`. Risk: scanner internals are moving target; future v4 minor
+  may re-break the workaround.
+- **Tailwind v4 + rename token files** — move tokens out of `src/` so the
+  scanner doesn't see them. Forces a wide structural change for a tooling fix.
+- **Stay on Tailwind 3.4.19** — last version before the scanner change. Loses
+  v4's perf gains (color-mix(), variants engine).
+
+## Decision
+
+Pin `tailwindcss@3.4.19` until the v4 scanner is configurable enough to ignore
+JSON content directories without per-release maintenance.
+
+## Consequences
+
+- Pre-commit and CI pin the version explicitly; dependabot PRs that try to bump
+  Tailwind get rejected.
+- We forgo v4's CSS-only build mode and the new variants. Acceptable trade for
+  build stability.
+- `CLAUDE.md` highlights this as a "DO NOT" rule so contributors don't waste
+  time chasing the upgrade.
+
+## Revisit if
+
+- Tailwind v4 ships an explicit "ignore JSON" config knob, OR
+- Our token format moves to TypeScript (which v4 wouldn't scan), OR
+- A future build-perf bottleneck makes v4's gains worth the maintenance.

--- a/docs/decisions/0002-hostinger-cron.md
+++ b/docs/decisions/0002-hostinger-cron.md
@@ -1,0 +1,48 @@
+# 0002 · Hostinger VPS crontab over external cron services
+
+**Status:** Accepted · 2026-04-21
+**Deciders:** Ivan
+
+## Context
+
+Five recurring jobs need scheduling: leads-digest (daily), sitemap-ping (weekly),
+commerce-email-flush (every 5 min), commerce-abandoned-cart (every 4 h),
+commerce-reconcile-pending (hourly). The launch questionnaire asked: "i think
+all should be in hostinger what do yopu suggest analyze and choose the best
+option".
+
+## Options considered
+
+- **Hostinger crontab on the VPS** — same box that runs the app. Curl to
+  `localhost`. No extra infra. Pros: zero coupling cost, zero auth round-trip
+  to a third-party. Cons: single point of failure (but if the VPS is down, the
+  app is down too — wash).
+- **GitHub Actions scheduled workflows** — already managing deploys. Free.
+  Cons: 5-minute minimum interval (overkill for daily/weekly), repo-visibility
+  caveats if the repo goes private, auth from rotating GitHub IPs.
+- **Vercel Cron** — best DX but we don't host on Vercel.
+- **Cloudflare Cron Triggers** — cheap, global. Cons: Workers code path was
+  removed in a pre-merge cleanup, would need to ship app to CF first.
+- **External services (cron-job.org etc.)** — easy GUI, yet another vendor,
+  CRON_SECRET leaves our perimeter.
+
+## Decision
+
+Hostinger crontab on the VPS. Curl-to-localhost. CRON_SECRET in env. Logs to
+`/var/log/paragu-ai-crons.log` with logrotate.
+
+## Consequences
+
+- All schedules live in one place (VPS crontab) and one doc
+  (`docs/runbooks/CRON_STRATEGY.md`).
+- CRON_SECRET stays inside our perimeter — never sent to third parties.
+- VPS reboots break the schedule until re-applied via `crontab -e`. Mitigated
+  by storing the canonical schedule in CRON_STRATEGY.md.
+- No retry-on-fail at the cron layer (cron just logs the curl exit code).
+  See ADR or follow-up for #445 cron retry policy.
+
+## Revisit if
+
+- We migrate the app off the VPS (e.g. to Vercel or Cloudflare Pages), at
+  which point the platform's native scheduler is the obvious choice.
+- Reliability needs cross-region redundancy.

--- a/docs/decisions/0003-env-allowlist-admin.md
+++ b/docs/decisions/0003-env-allowlist-admin.md
@@ -1,0 +1,45 @@
+# 0003 · Env-allowlist for admin auth (vs `profiles.role` table)
+
+**Status:** Accepted · 2026-04-21
+**Deciders:** Ivan
+
+## Context
+
+Admin pages were originally gated on `profiles.role = 'admin'`, but the
+`profiles` table doesn't exist in this Supabase project (verified against
+project `qyvokpribmbrosafntqa` on 2026-04-21). The check was silently failing
+and every authenticated user was being redirected to `/unauthorized`.
+
+## Options considered
+
+- **Create the `profiles` table + role column** — proper RBAC, supports many
+  admins. Requires a migration, RLS policies, an admin-management UI for
+  inviting users, and a backfill for the one existing admin email.
+- **Env-allowlist (`ADMIN_EMAILS=a@x.com,b@y.com`)** — Just compare
+  `user.email` against a comma-separated env var. Zero database round-trips,
+  no schema, version-controlled per environment.
+- **Supabase JWT custom claims** — set `app_metadata.role` server-side, check
+  the claim. Requires a webhook or edge function to set the claim on signup.
+
+## Decision
+
+Env-allowlist (`ADMIN_EMAILS`). Implemented in `web/lib/auth/admin.ts` with
+two helpers: `requireAdmin()` (Server Component, redirects) and `checkAdmin()`
+(route handler, returns discriminated result).
+
+## Consequences
+
+- Adding/removing an admin = setting an env var on the VPS + redeploying.
+  Reasonable for a 1-2 person team; would be friction past ~5 admins.
+- No database round-trip per admin request — measurably faster than the
+  prior failing check.
+- Removes a class of "table missing" / "RLS policy wrong" failure modes.
+- Call sites unchanged when we eventually move to RBAC: `requireAdmin()` keeps
+  the same signature.
+
+## Revisit if
+
+- Team grows past ~5 admins (env list becomes unwieldy).
+- We need per-tenant admin scopes (env can't express scoping).
+- Audit requirements demand per-action attribution (env says "Ivan can do
+  things"; RBAC tables say "Ivan did X at T").

--- a/docs/decisions/0004-payments-pagopar-first.md
+++ b/docs/decisions/0004-payments-pagopar-first.md
@@ -1,0 +1,48 @@
+# 0004 · Pagopar primary, Mercado Pago removed, dLocal Phase 2
+
+**Status:** Accepted · 2026-04
+**Deciders:** Ivan
+
+## Context
+
+Paraguay SMB checkout needs a payment provider that supports local methods
+(Bancard cards, Tigo Money, transfers) without forcing the merchant onto a
+foreign processor. We initially scaffolded both Mercado Pago and Pagopar
+adapters before going to market.
+
+## Options considered
+
+- **Mercado Pago as primary** — strong brand recognition, mature SDK. Cons:
+  weaker on local PY methods (no Tigo Money in default flow), MERCOSUR-wide
+  fee structure that disadvantages PY merchants.
+- **Pagopar as primary** — Paraguay-native. Supports Bancard, Tigo Money, all
+  local rails. Direct merchant relationships. Webhook-based, well documented.
+- **Stripe** — best DX, no PY local rails. Non-starter for the target customer.
+- **Build everything custom against Bancard 3DS** — too much PCI scope for our
+  size.
+
+## Decision
+
+- **Phase 1 (now):** Pagopar is the only integrated provider. Mercado Pago
+  adapter code was removed from the codebase to stop misleading the engine
+  and admin UI into thinking it's a viable choice.
+- **Phase 2 (later):** dLocal as a secondary provider for international cards
+  (relocation tenants need this). Reuses the same `payments` adapter
+  interface — no engine refactor.
+- **Facilitator Lite legal model:** ParaguAI takes payment on behalf of the
+  merchant, settles minus our commission. Avoids per-merchant Pagopar onboarding
+  friction at this scale.
+
+## Consequences
+
+- Only one provider in the production code path → smaller surface, easier ops.
+- Webhook handling (`/api/webhooks/pagopar`) is the canonical pattern for
+  payment events; future adapters (dLocal) will mirror its shape.
+- No "select your provider" UX needed for merchants — we abstract it.
+- Dropping MP means we can't claim "MP supported" in marketing copy.
+
+## Revisit if
+
+- A specific large customer demands MP for brand reasons.
+- Pagopar fee structure or reliability degrades.
+- Phase 2 (international cards) needs to ship — implement dLocal adapter then.

--- a/docs/decisions/0005-defer-next-image.md
+++ b/docs/decisions/0005-defer-next-image.md
@@ -1,0 +1,51 @@
+# 0005 · `<img>` over `next/image` until tenant-content dimensions exist
+
+**Status:** Accepted · 2026-04-21
+**Deciders:** Ivan
+
+## Context
+
+`next/image` would give us automatic WebP/AVIF negotiation, responsive
+srcset, and lazy loading. The audit (#471, full report in
+`docs/IMAGE_OPTIMIZATION_AUDIT.md`) found 12 raw `<img>` tags across
+`web/components/`, all rendering tenant-supplied images (Supabase Storage
+URLs or external CDNs) where dimensions aren't known at build time.
+
+## Options considered
+
+- **Use `<Image>` with `fill` + sized parent containers** — current containers
+  already use `aspect-square` / `aspect-video`, so this is the cleanest path.
+  Requires auditing every container.
+- **Server-side dimension lookup at build/render** — adds a network round-trip
+  per image, slows SSG.
+- **Store dimensions in the content schema** — best long-term. Requires
+  authoring tooling + migration of existing tenant content.
+
+## Decision
+
+Stay on `<img>` for now. Apply `loading="lazy"` + `decoding="async"` + explicit
+`width`/`height` everywhere we can infer them. Defer the `next/image` migration
+to a dedicated epic that includes the schema change.
+
+Cloudflare Polish (zone-level setting, already enabled) handles WebP/AVIF
+negotiation server-side, so the loss vs `next/image` is smaller than it appears.
+
+## Consequences
+
+- Lighthouse perf scores didn't flag image issues on any of the 4 audited URLs
+  (the bottleneck was JS execution, fixed via `next/dynamic` in PR #114).
+- We forgo `next/image`'s built-in srcset generation — Cloudflare's auto
+  width-by-DPR is the closest analogue, and it ships today without code changes.
+- When the schema migration lands, swapping `<img>` → `<Image>` is mechanical
+  per-component.
+
+## Revisit if
+
+- We add a new image-heavy section (e.g. portfolio with 50+ images) where
+  bandwidth becomes the dominant cost.
+- We move off Cloudflare (Polish goes away).
+- Tenant content authoring tool gains a "set dimensions" step.
+
+## See also
+
+- `docs/IMAGE_OPTIMIZATION_AUDIT.md`

--- a/docs/decisions/0006-supabase-client-cache.md
+++ b/docs/decisions/0006-supabase-client-cache.md
@@ -1,0 +1,52 @@
+# 0006 · Module-scoped Supabase client cache for cold-start fix
+
+**Status:** Accepted · 2026-04-21
+**Deciders:** Ivan
+
+## Context
+
+`/api/analytics/track` was timing out with 504 on the first POST after a
+container restart (BUG_HUNT_500 #423). The route created a fresh Supabase
+client per request via `createClient()` inside the handler. The client itself
+is cheap (a wrapper object), but the first network handshake plus first-call
+SDK lazy init had visible latency on a cold container.
+
+## Options considered
+
+- **Cache the client at module scope** — initialize once on first use, reuse
+  forever. Tested: `createClient` is called exactly once across N sequential
+  requests. Risk: no risk on a long-running Docker container; mild risk on
+  serverless platforms where module scope can be reset between invocations
+  (we don't deploy serverless).
+- **Migrate the route to Edge runtime** — fast cold-start (~50ms) but our
+  hosting is a long-running Node container, not serverless. Edge runtime
+  buys us nothing here, and `crypto.subtle.digest` (used for IP hashing)
+  would still work but Supabase JS adds compatibility overhead.
+- **Fire-and-forget the insert** — return 200 immediately, do the DB write
+  in the background. Hides errors from the caller; analytics correctness
+  drops.
+- **Module-level top-level init** — would crash `next build` page-data
+  collection where Supabase env vars aren't set.
+
+## Decision
+
+Cache the Supabase client at module scope behind a memoized getter. First
+request initializes; all subsequent requests reuse the same instance.
+Lazy init avoids the build-time crash.
+
+## Consequences
+
+- Cold-start cost is paid once per container lifetime (after restart or
+  deploy), not once per request.
+- Test asserts `createClient` is called exactly once across 5 sequential
+  POSTs — regression-proof.
+- Pattern can be lifted into a shared helper if more routes need it. For now,
+  inline at each call site is clearer.
+
+## Revisit if
+
+- We move to Cloudflare Workers / serverless where module-scoped caches don't
+  persist across invocations. (At that point, switch to a request-scoped
+  cache OR rely on the platform's connection pooling.)
+- Supabase JS client gains a meaningful per-request init cost (currently
+  near-zero after the first call).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,55 @@
+# Decision log (ADRs)
+
+> **What:** lightweight Architecture Decision Records.
+> **Why:** answer "why did we pick X over Y?" without grepping commit history.
+> **When to add:** any time a non-obvious technical choice gets locked in
+> (framework, tool, library, schema shape, naming convention, deploy target).
+
+## Format
+
+One file per decision. Filename: `NNNN-short-title.md` (4-digit zero-padded
+sequence). Body:
+
+```markdown
+# NNNN · <Decision title>
+
+**Status:** Accepted · YYYY-MM-DD
+**Deciders:** <names or roles>
+
+## Context
+<What's the problem? What were the constraints?>
+
+## Options considered
+- **Option A** — pros / cons
+- **Option B** — pros / cons
+- **Option C** — pros / cons
+
+## Decision
+<What did we pick? In one sentence.>
+
+## Consequences
+<What does this make easier / harder going forward?
+What load-bearing assumptions does this rest on?>
+
+## Revisit if
+<Trigger conditions that should make us reopen this. e.g.
+"Tailwind v4 ships JSON support", "Supabase adds edge-region replication",
+"team grows past 5 admins".>
+```
+
+Keep ADRs **immutable once accepted** — if the decision changes, write a new
+ADR that supersedes the old one (and link both ways).
+
+## Index
+
+- [0001 — Tailwind 3.4.19 (do not upgrade to v4)](./0001-tailwind-3-not-4.md)
+- [0002 — Hostinger VPS crontab over external cron services](./0002-hostinger-cron.md)
+- [0003 — Env-allowlist for admin auth (vs `profiles.role` table)](./0003-env-allowlist-admin.md)
+- [0004 — Pagopar primary, MP removed, dLocal Phase 2](./0004-payments-pagopar-first.md)
+- [0005 — `<img>` over `next/image` until tenant-content dimensions exist](./0005-defer-next-image.md)
+- [0006 — Module-scoped Supabase client cache for cold-start fix](./0006-supabase-client-cache.md)
+
+## See also
+
+- `docs/runbooks/` — what to do when something breaks
+- `CLAUDE.md` — current state of all conventions (decisions get summarized here)


### PR DESCRIPTION
## Summary
- New `docs/decisions/` folder following the lightweight ADR pattern
- 6 ADRs capture the most-asked "why did we pick X?" technical choices
- Format documented in `docs/decisions/README.md`
- Indexed from `docs/README.md` so future questions land at ADRs instead of grepping commit history
- Closes BUG_HUNT_500 #489

## ADRs added
- **0001** Tailwind 3.4.19 pin (do not upgrade to v4)
- **0002** Hostinger VPS crontab over external cron services
- **0003** Env-allowlist admin auth (vs missing `profiles.role` table)
- **0004** Pagopar primary, MP removed, dLocal Phase 2
- **0005** Defer `next/image` until tenant-content dimension schema exists
- **0006** Module-scoped Supabase client cache (cold-start fix from #423)

## Test plan
- [x] All 8 new files render as valid markdown
- [x] Index links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)