### PR TITLE
fix(api): leads/notes — wrap + auth + drop hardcoded admin (#392, #460)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -10,7 +10,7 @@
 | Status | Count | Items |
 |---|---|---|
 | ✅ Closed | 81 | see closure log below |
-| 🟡 In progress | 1 | #392 (5 routes still unwrapped — audit in REQUEST_LOG_AUDIT.md) |
+| 🟡 In progress | 1 | #392 (4 routes still unwrapped — audit in REQUEST_LOG_AUDIT.md) |
 | 🔴 Open | 419 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
@@ -135,6 +135,10 @@ Closure log:
   README + format documented at `docs/decisions/README.md`. Indexed from
   `docs/README.md` so future "why did we pick X?" questions land at the ADRs
   instead of grep through commit history.
+- **#392 partial #2** — `/api/leads/[id]/notes` (GET/POST/PATCH/DELETE) wrapped
+  in `withRequestLog` AND gained `checkAdmin()` on every method (was completely
+  unauthenticated). Replaced hardcoded `createdBy: 'admin'` with the
+  authenticated user's email — TODO closed. Audit doc count 5 → 4 routes.
 - **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
   added id to `<main>` on landing + 11 high-traffic marketing routes.
 - **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).

--- a/docs/REQUEST_LOG_AUDIT.md
+++ b/docs/REQUEST_LOG_AUDIT.md
@@ -27,7 +27,7 @@ Total API routes: ~50.
 | Status | Count |
 |---|---|
 | ✅ Wrapped | most (everything not listed below) |
-| ⚠️ Unwrapped | 5 |
+| ⚠️ Unwrapped | 4 |
 
 ## Unwrapped routes (audit list)
 
@@ -39,13 +39,13 @@ Verify with: `find web/app/api -name 'route.ts' | xargs grep -L withRequestLog`
 | `app/api/admin/daily-metrics/route.ts` | 397 | GET | Admin-only metrics dashboard. Failure modes are silent; needs structured logs. |
 | `app/api/reminders/route.ts` | 332 | GET, POST | Internal scheduling — needs trace context to debug stale reminders. |
 | `app/api/leads/bulk-update/route.ts` | 207 | POST | Bulk write path. A failure in the middle of the batch is currently un-correlatable with the upstream request. |
-| `app/api/leads/[id]/notes/route.ts` | 234 | GET, POST, PATCH, DELETE | Multi-method admin route. Each method should be wrapped individually. |
 
 ## Recently wrapped
 
 | Route | Wrapped in |
 |---|---|
-| `app/api/activity/route.ts` | This audit's PR |
+| `app/api/activity/route.ts` | PR #131 |
+| `app/api/leads/[id]/notes/route.ts` | This PR — also added `checkAdmin` to all 4 methods + replaced hardcoded `createdBy: 'admin'` with the authenticated user's email |
 
 ## Wrapping pattern
 

--- a/web/app/api/leads/[id]/notes/route.ts
+++ b/web/app/api/leads/[id]/notes/route.ts
@@ -1,16 +1,24 @@
 /**
  * Lead Notes API
- * 
+ *
  * CRUD operations for lead notes:
  * - GET: Retrieve all notes for a lead
  * - POST: Add a new note
  * - PATCH: Update a note
  * - DELETE: Remove a note
+ *
+ * All mutations require an authenticated admin (env-allowlist via
+ * `lib/auth/admin.ts#checkAdmin`). GET is admin-only too — notes can
+ * contain customer-private intel.
+ *
+ * Storage is currently an in-memory Map keyed by leadId. This survives
+ * within a single container lifetime; restart loses notes. A real
+ * `lead_notes` table is the next iteration.
  */
-import { logger } from '@/lib/logger'
-
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 import { z } from 'zod'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { checkAdmin } from '@/lib/auth/admin'
 
 export const runtime = 'nodejs'
 
@@ -26,9 +34,7 @@ const UpdateNoteSchema = z.object({
   isPrivate: z.boolean().optional(),
 })
 
-// In-memory storage for demo (replace with database in production)
-// Key: leadId, Value: array of notes
-const notesStore = new Map<string, Array<{
+interface LeadNote {
   id: string
   leadId: string
   content: string
@@ -37,198 +43,102 @@ const notesStore = new Map<string, Array<{
   createdBy: string
   createdAt: string
   updatedAt?: string
-}>>()
+}
 
-// Generate unique ID
+const notesStore = new Map<string, LeadNote[]>()
+
 function generateId(): string {
-  return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
 }
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const { id: leadId } = await params
-    
-    if (!leadId) {
-      return NextResponse.json(
-        { error: 'Lead ID is required' },
-        { status: 400 }
-      )
-    }
+export const GET = withRequestLog<{ id: string }>(async (_request, _ctx, { id: leadId }) => {
+  const auth = await checkAdmin()
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason }, { status: auth.status })
+  }
+  if (!leadId) {
+    return NextResponse.json({ error: 'Lead ID is required' }, { status: 400 })
+  }
+  const notes = (notesStore.get(leadId) || [])
+    .slice()
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+  return NextResponse.json({ success: true, data: notes, count: notes.length })
+})
 
-    const notes = notesStore.get(leadId) || []
-    
-    // Sort by createdAt desc
-    const sortedNotes = notes.sort((a, b) => 
-      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    )
+export const POST = withRequestLog<{ id: string }>(async (request, { log }, { id: leadId }) => {
+  const auth = await checkAdmin()
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason }, { status: auth.status })
+  }
+  if (!leadId) {
+    return NextResponse.json({ error: 'Lead ID is required' }, { status: 400 })
+  }
 
-    return NextResponse.json({
-      success: true,
-      data: sortedNotes,
-      count: sortedNotes.length
-    })
-  } catch (error) {
-    logger.error('Failed to fetch lead notes', { action: 'leads.notes.list', error: error instanceof Error ? error.message : String(error) })
+  const body = await request.json().catch(() => null)
+  const validated = NoteSchema.safeParse(body)
+  if (!validated.success) {
     return NextResponse.json(
-      { error: 'Failed to fetch notes' },
-      { status: 500 }
+      { error: 'Validation failed', details: validated.error.flatten().fieldErrors },
+      { status: 400 },
     )
   }
-}
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const { id: leadId } = await params
-    
-    if (!leadId) {
-      return NextResponse.json(
-        { error: 'Lead ID is required' },
-        { status: 400 }
-      )
-    }
+  const note: LeadNote = {
+    id: generateId(),
+    leadId,
+    ...validated.data,
+    createdBy: auth.user.email ?? auth.user.id,
+    createdAt: new Date().toISOString(),
+  }
+  const existing = notesStore.get(leadId) || []
+  existing.push(note)
+  notesStore.set(leadId, existing)
+  log.info('leads.notes.created', { leadId, noteId: note.id, type: note.type })
+  return NextResponse.json({ success: true, data: note }, { status: 201 })
+})
 
-    const body = await request.json()
-    const validated = NoteSchema.safeParse(body)
-
-    if (!validated.success) {
-      return NextResponse.json(
-        { 
-          error: 'Validation failed', 
-          details: validated.error.flatten().fieldErrors 
-        },
-        { status: 400 }
-      )
-    }
-
-    const { content, type, isPrivate } = validated.data
-
-    const note = {
-      id: generateId(),
-      leadId,
-      content,
-      type,
-      isPrivate,
-      createdBy: 'admin', // TODO: Get from auth session
-      createdAt: new Date().toISOString()
-    }
-
-    const existingNotes = notesStore.get(leadId) || []
-    existingNotes.push(note)
-    notesStore.set(leadId, existingNotes)
-
-    return NextResponse.json({
-      success: true,
-      data: note,
-      message: 'Note added successfully'
-    }, { status: 201 })
-  } catch (error) {
-    logger.error('Failed to create lead note', { action: 'leads.notes.create', error: error instanceof Error ? error.message : String(error) })
+export const PATCH = withRequestLog<{ id: string }>(async (request, { log }, { id: leadId }) => {
+  const auth = await checkAdmin()
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason }, { status: auth.status })
+  }
+  const body = await request.json().catch(() => ({}))
+  const { noteId, ...updates } = body as { noteId?: string } & Record<string, unknown>
+  if (!leadId || !noteId) {
+    return NextResponse.json({ error: 'Lead ID and Note ID are required' }, { status: 400 })
+  }
+  const validated = UpdateNoteSchema.safeParse(updates)
+  if (!validated.success) {
     return NextResponse.json(
-      { error: 'Failed to create note' },
-      { status: 500 }
+      { error: 'Validation failed', details: validated.error.flatten().fieldErrors },
+      { status: 400 },
     )
   }
-}
-
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const { id: leadId } = await params
-    const { noteId, ...updates } = await request.json()
-    
-    if (!leadId || !noteId) {
-      return NextResponse.json(
-        { error: 'Lead ID and Note ID are required' },
-        { status: 400 }
-      )
-    }
-
-    const validated = UpdateNoteSchema.safeParse(updates)
-    if (!validated.success) {
-      return NextResponse.json(
-        { 
-          error: 'Validation failed', 
-          details: validated.error.flatten().fieldErrors 
-        },
-        { status: 400 }
-      )
-    }
-
-    const notes = notesStore.get(leadId) || []
-    const noteIndex = notes.findIndex(n => n.id === noteId)
-
-    if (noteIndex === -1) {
-      return NextResponse.json(
-        { error: 'Note not found' },
-        { status: 404 }
-      )
-    }
-
-    notes[noteIndex] = {
-      ...notes[noteIndex],
-      ...validated.data,
-      updatedAt: new Date().toISOString()
-    }
-
-    return NextResponse.json({
-      success: true,
-      data: notes[noteIndex],
-      message: 'Note updated successfully'
-    })
-  } catch (error) {
-    logger.error('Failed to update lead note', { action: 'leads.notes.update', error: error instanceof Error ? error.message : String(error) })
-    return NextResponse.json(
-      { error: 'Failed to update note' },
-      { status: 500 }
-    )
+  const notes = notesStore.get(leadId) || []
+  const idx = notes.findIndex((n) => n.id === noteId)
+  if (idx === -1) {
+    return NextResponse.json({ error: 'Note not found' }, { status: 404 })
   }
-}
+  notes[idx] = { ...notes[idx], ...validated.data, updatedAt: new Date().toISOString() }
+  log.info('leads.notes.updated', { leadId, noteId })
+  return NextResponse.json({ success: true, data: notes[idx] })
+})
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const { id: leadId } = await params
-    const { searchParams } = new URL(request.url)
-    const noteId = searchParams.get('noteId')
-    
-    if (!leadId || !noteId) {
-      return NextResponse.json(
-        { error: 'Lead ID and Note ID are required' },
-        { status: 400 }
-      )
-    }
-
-    const notes = notesStore.get(leadId) || []
-    const filteredNotes = notes.filter(n => n.id !== noteId)
-
-    if (filteredNotes.length === notes.length) {
-      return NextResponse.json(
-        { error: 'Note not found' },
-        { status: 404 }
-      )
-    }
-
-    notesStore.set(leadId, filteredNotes)
-
-    return NextResponse.json({
-      success: true,
-      message: 'Note deleted successfully'
-    })
-  } catch (error) {
-    logger.error('Failed to delete lead note', { action: 'leads.notes.delete', error: error instanceof Error ? error.message : String(error) })
-    return NextResponse.json(
-      { error: 'Failed to delete note' },
-      { status: 500 }
-    )
+export const DELETE = withRequestLog<{ id: string }>(async (request, { log }, { id: leadId }) => {
+  const auth = await checkAdmin()
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason }, { status: auth.status })
   }
-}
+  const noteId = new URL(request.url).searchParams.get('noteId')
+  if (!leadId || !noteId) {
+    return NextResponse.json({ error: 'Lead ID and Note ID are required' }, { status: 400 })
+  }
+  const notes = notesStore.get(leadId) || []
+  const filtered = notes.filter((n) => n.id !== noteId)
+  if (filtered.length === notes.length) {
+    return NextResponse.json({ error: 'Note not found' }, { status: 404 })
+  }
+  notesStore.set(leadId, filtered)
+  log.info('leads.notes.deleted', { leadId, noteId })
+  return NextResponse.json({ success: true })
+})


### PR DESCRIPTION
## Summary
- All 4 methods of `/api/leads/[id]/notes` now wrapped in `withRequestLog` (trace ctx + `x-request-id` + structured 500)
- All 4 methods now require admin via `checkAdmin()` — route was completely unauthenticated; anyone could read or write notes for any leadId
- Removed hardcoded `createdBy: 'admin'` → uses the authenticated user's email
- Rewritten for consistency (extracted `LeadNote` type, simplified ID gen, removed try/catch noise — `withRequestLog` handles unhandled errors)

## Closes
- #392 partial — audit count 5 → 4 unwrapped routes
- #460 partial — real CSRF/auth check on this admin POST surface
- TODO@line 117 (the `createdBy: 'admin'` placeholder)

## Notes
- Storage is still in-memory `Map`. A real `lead_notes` table is a separate PR.
- Pre-existing typecheck errors in `app/onboarding/{gimnasio,peluqueria}/` are unrelated WIP from a parallel agent.

## Test plan
- [x] `npx tsc --noEmit | grep -v onboarding` → clean (no errors I introduced)
- [ ] After deploy: hit `/api/leads/X/notes` without session → 401; with session as non-admin → 403; with admin → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)