### PR TITLE
docs: glossary + sales playbook (closes #491, #493)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 81 | see closure log below |
+| ✅ Closed | 83 | see closure log below |
 | 🟡 In progress | 1 | #392 (4 routes still unwrapped — audit in REQUEST_LOG_AUDIT.md) |
-| 🔴 Open | 419 | the rest |
+| 🔴 Open | 417 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -139,6 +139,15 @@ Closure log:
   in `withRequestLog` AND gained `checkAdmin()` on every method (was completely
   unauthenticated). Replaced hardcoded `createdBy: 'admin'` with the
   authenticated user's email — TODO closed. Audit doc count 5 → 4 routes.
+- **#491** — `docs/SALES_PLAYBOOK.md` covers universal objections (price,
+  Instagram-is-enough, technology fear, primo-makes-it-free) plus
+  per-vertical scripts (peluquería, gimnasio, spa, restaurant, relocation,
+  professional services). Includes closing techniques and disqualification
+  criteria.
+- **#493** — `docs/GLOSSARY.md` defines every recurring term: Vertical / Type /
+  Site / Section / Demo / Real tenant / Pilot / Promote / Pagopar /
+  Facilitator Lite / withRequestLog / checkAdmin / Cloudflare Polish /
+  Runbook / ADR / BUG_HUNT_500. Cross-linked from other docs.
 - **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
   added id to `<main>` on landing + 11 high-traffic marketing routes.
 - **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,85 @@
+# Glossary
+
+> Vocabulary that recurs across this repo, in code, docs, and sales
+> conversations. Read once; come back when a term confuses you.
+>
+> Closes BUG_HUNT_500 #493.
+
+## Engine concepts
+
+| Term | Definition | Where in code |
+|---|---|---|
+| **Vertical** | An industry group that shares a theme palette, allowed sections, and content shape. E.g. `beauty-personal-care`, `food-beverage`, `relocation`. About 23 verticals exist. | `src/verticals/<id>/` |
+| **Type** (a.k.a. **Business type**, **Plantilla** in Spanish UI) | A specific business inside a vertical. E.g. `peluqueria`, `barberia`, `panaderia`. About 1,960 types exist. Each declares which sections to render and what SEO to emit. | `src/registry/<id>.type.json` |
+| **Site** (a.k.a. **Tenant**) | A real or demo business with its own slug, copy, brand colors, and pages. Sites are *configured*, not *built* — they re-use the same React section components, just with different JSON. | `sites/<slug>/` |
+| **Section** | A reusable React component that renders one block of a page (hero, services, testimonials, etc.). About 82 exist. | `web/components/sections/` |
+| **Composition pipeline** | The build-time process that takes a site's JSON + the vertical's defaults + the type's section list, and emits the rendered page. | `web/lib/engine/compose-site.ts` |
+| **Token resolver** | Merges base + vertical + per-tenant token files into the CSS variables a tenant's pages read. | `web/lib/engine/resolve-site-tokens.ts` |
+| **Locale-prefixed route** | The canonical tenant URL: `/s/<locale>/<slug>` (e.g. `/s/es/nexa-paraguay`). | `web/app/s/[locale]/[site]/` |
+| **Flat-slug route** | Legacy URL: `/<slug>` redirects to the locale-prefixed canonical via the middleware rewrite. | `web/middleware.ts` |
+
+## Tenant lifecycle
+
+| Term | Definition |
+|---|---|
+| **Demo** | A site we build to show what the engine produces for a vertical. `is_demo: true` in `site.json`. WhatsApp CTAs point at the ParaguAI sales line, not at the imaginary business. Demo sites get a `<DemoBadge>` overlay and a `noindex` meta tag. |
+| **Real tenant** | A paying or pilot customer's site. `is_demo: false`. Real WhatsApp number, real address, real services. Lives at the same `sites/<slug>/` path as a demo. |
+| **Pilot** | A real tenant who isn't yet paying — our 6 current real tenants are all pilots. The model is "deliver value first, charge once they're getting leads". |
+| **Promote** | The act of turning a demo into a real tenant. Steps in `docs/runbooks/ADD_NEW_TENANT.md` § "Promote a demo to a real tenant". |
+
+## Pricing terms
+
+| Term | Definition |
+|---|---|
+| **Setup** | One-time fee at sign-up. Plan-dependent (Gs 0 / Gs 650K / Gs 1.2M / etc). |
+| **Mensualidad** | Monthly recurring fee. |
+| **Plan Starter** | Free tier — subdomain `<slug>.paragu-ai.com`, single page, WhatsApp button. Used for "let me see what it'd look like" prospects. |
+| **Plan Profesional** | Real domain `.com.py`, up to 5 pages, SEO, 2 monthly content updates included. |
+| **Plan Negocio** | Bookings, catalog, blog, priority support. |
+| **Comisión** | Our per-transaction cut on commerce sales (Pagopar split-billing). |
+
+## Provider / payment terms
+
+| Term | Definition |
+|---|---|
+| **Pagopar** | The Paraguayan payment gateway we use. Handles Bancard cards, Tigo Money, transfers. See ADR `0004`. |
+| **Bancard** | The Paraguayan card-processing utility behind every PY card. Pagopar abstracts it. |
+| **Tigo Money** | Local mobile-money wallet, very common for small purchases. |
+| **dLocal** | Future provider (Phase 2) for international cards — relocation tenants need this. |
+| **Facilitator Lite** | Our legal model: ParaguAI receives the customer payment, settles to the merchant minus our commission. Avoids per-merchant Pagopar onboarding friction. |
+
+## Operational terms
+
+| Term | Definition | Where |
+|---|---|---|
+| **CRON_SECRET** | Header (`x-cron-secret`) every cron job sends; routes 403 without it. | `web/app/api/cron/*/route.ts` |
+| **`webhook_events`** | Append-only audit table for all incoming webhooks. UNIQUE on `(provider, provider_event_id)` gives replay dedup. | `supabase/migrations/20260421000000_commerce_core.sql` |
+| **`analytics_events`** | Append-only event log. Front-end fires events into here via `/api/analytics/track`. | `supabase/migrations/20260422000300_analytics_events.sql` |
+| **withRequestLog** | Middleware wrapper for API routes. Stamps `x-request-id`, sets up trace context, catches unhandled errors. | `web/lib/api/with-request-log.ts` |
+| **checkAdmin / requireAdmin** | The two admin auth helpers. `requireAdmin()` redirects (Server Components); `checkAdmin()` returns a discriminated result (route handlers). | `web/lib/auth/admin.ts` |
+| **Cloudflare Polish** | Zone-level setting that auto-converts images to WebP/AVIF based on the request's `Accept` header. Covers our `<img>` use without `next/image`. |  Cloudflare dash |
+
+## Doc conventions
+
+| Term | Definition |
+|---|---|
+| **Runbook** | What-to-do-when-X-fires document. One file per alert. Lives in `docs/runbooks/`. |
+| **ADR** | Architecture Decision Record — "why we picked X over Y", immutable once accepted. Lives in `docs/decisions/`. |
+| **BUG_HUNT_500** | The 500-item launch-readiness backlog at `docs/BUG_HUNT_500.md`. Source of truth for what's open/closed/in-progress. |
+| **Closure log** | The append-only list at the top of `BUG_HUNT_500.md` documenting each closed item with brief context. |
+
+## Verticals catalog (for quick reference)
+
+`beauty-personal-care`, `health-wellness`, `food-beverage`, `hospitality-tourism`,
+`service-booking`, `portfolio-professional`, `trades-home-services`, `automotive`,
+`retail-local`, `education-training`, `b2b-professional`, `real-estate-relocation`,
+`trades-industrial`, `agriculture-agribusiness`, `logistics-transport`,
+`finance-insurance`, `technology-digital`, `arts-entertainment-venues`,
+`sports-recreation`, `pets-animals`, `media-publishing`, `membership-community`,
+`death-care`. Authoritative list at `src/registry/index.json#verticalsCatalog`.
+
+## See also
+
+- `docs/decisions/` — ADRs explaining *why* we picked each pattern
+- `docs/runbooks/` — what-to-do-when things break
+- `docs/reference/` — exhaustive catalogs (every section, every type)

--- a/docs/SALES_PLAYBOOK.md
+++ b/docs/SALES_PLAYBOOK.md
@@ -1,0 +1,198 @@
+# Sales playbook · objection handling
+
+> Common objections from PY SMBs when pitching ParaguAI, and the
+> short answers that work. Per-vertical specifics in the second half.
+>
+> Closes BUG_HUNT_500 #491.
+
+## Universal objections
+
+### "Ya tengo Instagram, no necesito web"
+
+**Reality:** Instagram is rented land. Algorithm changes, account hacks,
+shadow-bans cost businesses their entire customer base overnight.
+
+**Answer (1-line):** "Tu Instagram es para *encontrar* clientes; tu sitio
+es para *cerrar* la venta. Las 2 cosas se complementan, y el sitio te
+asegura que aunque IG cambie, tus clientes te encuentran en Google."
+
+**Follow-up if they push:** "¿Cuántas veces te ha bajado IG por un día?
+¿Cuánto ventaste ese día?"
+
+### "Es muy caro"
+
+**Reality:** Plan Profesional is Gs 650K setup + monthly. That's less than
+one good lead.
+
+**Answer:** "El sitio se paga solo con UN cliente nuevo por mes. ¿Cuánto
+cobrás por servicio? Si es Gs 100K, te bastan 7 clientes/mes nuevos para
+cubrirlo. ¿Cuántos te genera Instagram hoy?"
+
+**Don't:** discount immediately. Defend the price. If they're truly
+strapped, point them at Plan Starter (free) so they at least *have*
+a presence.
+
+### "No sé manejar tecnología"
+
+**Reality:** This is the #1 latent fear, often disguised as other
+objections.
+
+**Answer:** "No tenés que saber nada. Vos nos mandás info por WhatsApp,
+nosotros hacemos el sitio. Cambios futuros también — vos decís 'cambia
+el precio del corte' por WhatsApp y lo cambiamos."
+
+**Don't:** show them the admin panel in the first call. Even seeing
+"login" stresses non-technical owners.
+
+### "¿Y si no me funciona?"
+
+**Reality:** They've been burned by previous "agency" promises.
+
+**Answer:** "30 días de garantía. Si no te convence, devolvemos el 100%
+del setup. Sin preguntas, sin letra chica."
+
+**Show them:** the actual case studies (`/casos/<cliente>`) — Nexa Paraguay
+has real translations across 4 languages, Dayah has a real portfolio, etc.
+
+### "Mi primo/sobrino me hace uno gratis"
+
+**Reality:** They will get a 1-page WordPress that looks like 2014, no SEO,
+no WhatsApp, no maintenance.
+
+**Answer:** "Perfecto, ¿y quién lo va a actualizar cuando quieras subir
+precios? ¿Quién va a renovar el dominio el año que viene? ¿Tiene SEO para
+que la gente te encuentre?"
+
+**Show them:** a side-by-side of one of our demo sites vs a typical
+"primo-built" site. The professional design is undeniable.
+
+### "Necesito hablarlo con mi socio/esposo/contador"
+
+**Reality:** Stalling. Either real (legitimate decision-making delay) or
+soft no.
+
+**Answer:** "Buenísimo, ¿le mando esta noche el resumen por mail para que
+lo revisen juntos? Y armamos call para el [día específico]?"
+
+**Set the next step in the same call.** Don't leave it open-ended.
+
+## Vertical-specific objections
+
+### Peluquería / Salón de belleza
+
+**"Yo agendo todo por WhatsApp, no necesito sistema de reservas"**
+
+That's fine — Plan Profesional doesn't *require* the bookings module. The
+WhatsApp button on the sitio is the same flow they're used to. The site
+brings them new customers from Google searches; WhatsApp closes them.
+
+**"Ya tengo Booksy / Fresha"**
+
+Great, we integrate. Your sitio has a "Reservar" button that opens your
+existing booking app. You don't lose the workflow.
+
+### Gimnasio / Fitness
+
+**"Mis clases se llenan, no necesito más leads"**
+
+Two things:
+1. They lose ~30% of members per year — site keeps the lead funnel full.
+2. Site lets them upsell premium plans (personal training) without an
+   in-person pitch.
+
+**"Soy CrossFit, soy Yoga, mi audiencia es de boca-en-boca"**
+
+True for the first 50 members. Past that, Google search ("yoga en Asunción
+[barrio]") becomes the dominant intake channel. We rank you for
+neighborhood + practice.
+
+### Spa & Wellness
+
+**"Mis clientas son 35-55, no buscan en Google"**
+
+They do — for "spa Asunción día de la madre", "regalo amiga cumpleaños",
+"masajes [embarazo / pareja / corporativos]". Specific intent searches
+that convert.
+
+### Restaurant / Food & Beverage
+
+**"Tengo Mostrador / Pedidos Ya, no necesito sitio"**
+
+Mostrador = high commission. PedidosYa = high commission. Direct site +
+WhatsApp = zero commission. ROI is on the second order.
+
+**"Mi menú cambia mucho, sería un lío actualizar"**
+
+You WhatsApp us "el viernes corregimos los precios y agregamos lomo
+italiano" — done same day.
+
+### Servicios de reubicación (Nexa)
+
+**"¿Cuánto cuesta un sitio multi-idioma de 4 idiomas?"**
+
+Same Plan Profesional + Negocio. Idiomas no son un upcharge — están
+incluidos. Lo que paga es traducción humana profesional vs. auto-translate.
+
+**"Mis clientes son europeos, ¿el sitio los va a convencer?"**
+
+Show them Nexa Paraguay live. The English/Dutch/German pages aren't
+auto-translated; they're voice-matched to a relocation-services tone.
+Paraguay-specific copy. International clients land already convinced.
+
+### Servicios profesionales (legal, contadores, consultoría)
+
+**"En mi rubro, los clientes vienen por referencias, no por Google"**
+
+Half-true. Existing client referrals do come direct. NEW clients (younger
+business owners who Google before calling) come from search. You're missing
+~40% of inbound by not having a credible site.
+
+**"¿Es ético tener un sitio comercial siendo un estudio jurídico?"**
+
+It's not advertising — it's making your existence findable. Show them
+established firms (Mersán, Vouga) and ask if those sites look unethical.
+
+## Closing the call
+
+### When you sense interest
+
+"Te paso el setup hoy y empezás mañana, ¿dale? El primer borrador lo tenés
+en 24 horas." Strike while warm. Don't email a quote — get permission to
+proceed in the same call.
+
+### When they're hesitant
+
+"Te dejo el plan Starter activo en tu rubro, sin compromiso, así ves cómo
+queda. Si te gusta, lo upgradeamos. Si no, no pasa nada y se queda gratis
+viviendo." Low friction → demonstrates value → easier upgrade later.
+
+### Pricing reveal order
+
+1. Establish value (1-2 demo screens of similar businesses)
+2. Quote Plan Profesional first (Gs 650K + monthly)
+3. Mention Plan Starter as the "no-compromise way to start"
+4. Only mention Plan Negocio if they ask "¿qué más viene?"
+
+Anchoring matters. Quote middle tier first, optional tiers above and below.
+
+## Disqualification
+
+**Walk away from prospects who:**
+
+- Ask for "social media + sitio + Google ads + brand kit + ChatGPT bot"
+  for the price of the sitio. They want an agency, not a tool.
+- Want to pay only after they "see if it works for 6 months". They'll
+  treat the trial period as 6 months of free service and ghost.
+- Refuse to share their actual current numbers. Means they don't trust
+  you yet OR don't trust their own numbers — either way, friction every
+  step of the relationship.
+- Want a redesign of an existing well-performing site. Out of scope —
+  we *generate* sites, not migrate-and-tweak. Refer to a freelance
+  designer.
+
+## See also
+
+- `docs/01_VALUE_PROPOSITION.md` — what we sell, in their language
+- `docs/03_PRICING_MODEL.md` — the 4 plans + commerce commission
+- `docs/runbooks/ADD_NEW_TENANT.md` — what happens after they say yes
+- `docs/GLOSSARY.md` — terminology cheat sheet


### PR DESCRIPTION
## Summary
Two short-but-load-bearing docs:

**`docs/GLOSSARY.md`** — every recurring term in the repo and sales conversations defined once. Vertical, Type, Site, Section, Demo, Real tenant, Pilot, Promote, Pagopar, Facilitator Lite, withRequestLog, checkAdmin, Cloudflare Polish, Runbook, ADR, BUG_HUNT_500, etc. Includes the 23-vertical catalog for quick reference.

**`docs/SALES_PLAYBOOK.md`** — objection-handling for the 6 most common PY SMB resistance points (price, "Instagram is enough", "no sé tecnología", the primo-makes-it-free, "necesito hablarlo con socio") plus per-vertical scripts (peluquería, gimnasio, spa, restaurant, relocation, professional services). Closing-the-call patterns + disqualification criteria.

Closes BUG_HUNT_500 #491 (sales playbook) + #493 (glossary).

## Test plan
- [x] Both files render as valid markdown
- [x] Cross-links resolve (decisions/, runbooks/, reference/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)