### PR TITLE
feat(commerce): manual bank-transfer + WhatsApp checkout (no Pagopar required)

### DIFF
--- a/src/registry/relocation.type.json
+++ b/src/registry/relocation.type.json
@@ -169,7 +169,7 @@
     }
   },
   "commerce": {
-    "enabled": true,
+    "enabled": false,
     "launchPhase": "pilot",
     "provider": "pagopar",
     "currency": "PYG",

--- a/web/app/s/[locale]/[site]/checkout/transfer/[orderId]/page.tsx
+++ b/web/app/s/[locale]/[site]/checkout/transfer/[orderId]/page.tsx
@@ -1,0 +1,122 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
+import { getOrder, CheckoutError } from '@/lib/commerce/orders'
+import { formatCents } from '@/lib/commerce/compute-totals'
+import { listCredentialsForBusiness } from '@/lib/commerce/payment-credentials'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+interface BankInstructions {
+  bankName?: string
+  accountType?: string
+  accountNumber?: string
+  holderName?: string
+  ciOrRuc?: string
+  whatsappNumber?: string
+  instructions?: string
+}
+
+function buildWhatsappDeepLink(whatsappNumber: string, orderNumber: string, totalLabel: string): string {
+  const digits = whatsappNumber.replace(/\D/g, '')
+  const text = `Hola, adjunto el comprobante de transferencia del pedido ${orderNumber} por ${totalLabel}.`
+  return `https://wa.me/${digits}?text=${encodeURIComponent(text)}`
+}
+
+export default async function TransferInstructionsPage({
+  params,
+}: {
+  params: Promise<{ site: string; locale: string; orderId: string }>
+}) {
+  const { site, locale, orderId } = await params
+  const business = await resolveBusinessBySlug(site)
+  if (!business) notFound()
+
+  let order
+  try {
+    order = await getOrder(business.id, orderId)
+  } catch (err) {
+    if (err instanceof CheckoutError && err.code === 'order_not_found') notFound()
+    throw err
+  }
+
+  const credentials = await listCredentialsForBusiness(business.id)
+  const manualRow = credentials.find((c) => c.provider === 'manual' && c.status === 'active')
+  const bank: BankInstructions = (manualRow?.publicConfig as BankInstructions | undefined) ?? {}
+
+  const totalLabel = formatCents(order.totalCents, order.currency)
+  const whatsappUrl = bank.whatsappNumber
+    ? buildWhatsappDeepLink(bank.whatsappNumber, order.orderNumber, totalLabel)
+    : null
+
+  return (
+    <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
+      <main className="mx-auto max-w-2xl px-4 py-10">
+        <div className="rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-6 shadow-sm">
+          <h1 className="text-2xl font-bold text-[color:var(--text,#111)]">
+            Pedido {order.orderNumber} — esperando transferencia
+          </h1>
+          <p className="mt-2 text-sm text-[color:var(--text-muted,#6b7280)]">
+            Guardamos tu pedido. Para completarlo, transferí el total a la cuenta de abajo y enviá el
+            comprobante por WhatsApp.
+          </p>
+
+          <section className="mt-6 rounded-lg bg-[color:var(--surface-muted,#f9fafb)] p-4">
+            <p className="text-sm text-[color:var(--text-muted,#6b7280)]">Total a transferir</p>
+            <p className="text-3xl font-bold">{totalLabel}</p>
+          </section>
+
+          {bank.bankName || bank.accountNumber ? (
+            <section className="mt-6 space-y-2 text-sm">
+              <h2 className="text-xs font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Datos bancarios</h2>
+              {bank.bankName ? <p><strong>Banco:</strong> {bank.bankName}</p> : null}
+              {bank.accountType ? <p><strong>Tipo:</strong> {bank.accountType}</p> : null}
+              {bank.accountNumber ? <p><strong>Número:</strong> <code className="rounded bg-[color:var(--surface-muted,#f3f4f6)] px-1.5 py-0.5 font-mono">{bank.accountNumber}</code></p> : null}
+              {bank.holderName ? <p><strong>Titular:</strong> {bank.holderName}</p> : null}
+              {bank.ciOrRuc ? <p><strong>CI / RUC:</strong> {bank.ciOrRuc}</p> : null}
+              {bank.instructions ? (
+                <p className="mt-3 whitespace-pre-line rounded bg-amber-50 p-3 text-sm text-amber-900">{bank.instructions}</p>
+              ) : null}
+            </section>
+          ) : (
+            <section className="mt-6 rounded bg-amber-50 p-4 text-sm text-amber-900">
+              <p>
+                <strong>{business.name}</strong> todavía no configuró sus datos bancarios. Te pedimos
+                que lo contactes directamente para coordinar el pago.
+              </p>
+            </section>
+          )}
+
+          <section className="mt-6 space-y-3">
+            <h2 className="text-xs font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Enviar comprobante</h2>
+            {whatsappUrl ? (
+              <a
+                href={whatsappUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-lg bg-[#25D366] px-5 py-3 text-sm font-semibold text-white hover:opacity-90"
+              >
+                Enviar comprobante por WhatsApp
+              </a>
+            ) : (
+              <p className="text-sm text-[color:var(--text-muted,#6b7280)]">
+                El comercio no configuró WhatsApp. Contactalo por otro canal.
+              </p>
+            )}
+            <p className="text-xs text-[color:var(--text-muted,#6b7280)]">
+              Referenciá el pedido <strong>{order.orderNumber}</strong> al enviarlo. Tu pedido se confirma
+              cuando el comercio valida la transferencia.
+            </p>
+          </section>
+
+          <section className="mt-8 border-t border-[color:var(--border,#e5e7eb)] pt-4 text-sm">
+            <Link href={`/s/${locale}/${site}/orden/${order.id}`} className="text-[color:var(--primary,#111)] underline">
+              Ver estado del pedido →
+            </Link>
+          </section>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/web/components/admin/commerce/order-actions.tsx
+++ b/web/components/admin/commerce/order-actions.tsx
@@ -11,6 +11,7 @@ interface Props {
 }
 
 const NEXT_ACTIONS: Partial<Record<OrderStatus, Array<{ label: string; status: OrderStatus }>>> = {
+  awaiting_payment: [{ label: 'Confirmar pago recibido', status: 'paid' }],
   paid: [{ label: 'Marcar como preparada', status: 'fulfilled' }],
   fulfilled: [{ label: 'Marcar como enviada', status: 'shipped' }],
   shipped: [{ label: 'Marcar como entregada', status: 'delivered' }],

--- a/web/components/admin/commerce/payment-credentials-manager.tsx
+++ b/web/components/admin/commerce/payment-credentials-manager.tsx
@@ -48,6 +48,24 @@ const TEMPLATES: ProviderTemplate[] = [
     ],
     publicConfigKeys: [{ key: 'country', label: 'País (ISO-2)', default: 'PY' }],
   },
+  {
+    // Offline bank transfer: no API secrets, just the bank details we show
+    // the shopper on the transfer-instructions page + the WhatsApp number
+    // where they send the comprobante. All fields are public (displayed to
+    // the shopper), so they live in publicConfig instead of encrypted secrets.
+    provider: 'manual',
+    label: 'Transferencia bancaria + WhatsApp',
+    fields: [],
+    publicConfigKeys: [
+      { key: 'bankName', label: 'Banco' },
+      { key: 'accountType', label: 'Tipo de cuenta (ej: Cta. corriente, Cta. ahorro)' },
+      { key: 'accountNumber', label: 'Número de cuenta' },
+      { key: 'holderName', label: 'Titular' },
+      { key: 'ciOrRuc', label: 'CI / RUC del titular' },
+      { key: 'whatsappNumber', label: 'WhatsApp (con código país, ej: +595981...)' },
+      { key: 'instructions', label: 'Instrucciones extra (opcional)' },
+    ],
+  },
 ]
 
 export function PaymentCredentialsManager({ businessId, initialCredentials }: Props) {
@@ -182,15 +200,17 @@ function CredentialFormModal({
       const v = String(form.get(f.key) ?? '').trim()
       if (v) secrets[f.key] = v
     }
-    if (Object.keys(secrets).length === 0) {
-      setError('Completá al menos un campo')
-      setSubmitting(false)
-      return
-    }
     const publicConfig: Record<string, string> = {}
     for (const f of template.publicConfigKeys ?? []) {
       const v = String(form.get(`pc_${f.key}`) ?? '').trim()
       if (v) publicConfig[f.key] = v
+    }
+    // Require at least one field across secrets + publicConfig — the manual
+    // provider has no secrets but at least the bank fields must be filled.
+    if (Object.keys(secrets).length === 0 && Object.keys(publicConfig).length === 0) {
+      setError('Completá al menos un campo')
+      setSubmitting(false)
+      return
     }
     try {
       await onSave(template, secrets, publicConfig)

--- a/web/lib/payments/capabilities.ts
+++ b/web/lib/payments/capabilities.ts
@@ -22,6 +22,21 @@ export const CAPABILITIES: PaymentCapability[] = [
     basePriority: 1,
   },
   {
+    // Offline bank transfer + WhatsApp comprobante. Countries/currencies
+    // empty = works everywhere, but `requiresExplicitAvailable` stops it
+    // from being offered unless the merchant explicitly installed manual
+    // credentials via the admin payments page. That way the router's
+    // default behavior for a fresh PY merchant is still "try Pagopar",
+    // not "silently drop them into manual-transfer mode."
+    provider: 'manual',
+    countries: [],
+    currencies: [],
+    methods: ['bank_transfer'],
+    feeTier: 'low',
+    basePriority: 99,
+    requiresExplicitAvailable: true,
+  },
+  {
     provider: 'bancard',
     countries: ['PY'],
     currencies: ['PYG'],

--- a/web/lib/payments/manual/adapter.ts
+++ b/web/lib/payments/manual/adapter.ts
@@ -1,0 +1,52 @@
+import type { PaymentProviderAdapter } from '../types'
+
+/**
+ * Offline "pay by bank transfer + WhatsApp comprobante" flow. No gateway
+ * integration — the shopper is redirected to a page with the tenant's bank
+ * details and a WhatsApp deep link. The order sits in `awaiting_payment`
+ * until the merchant clicks "Confirmar pago recibido" in the admin.
+ *
+ * This is the right fit for Paraguayan SMBs that don't yet have a Pagopar
+ * merchant account — the same manual flow Ivan already uses for his own
+ * SaaS billing.
+ */
+export const manualAdapter: PaymentProviderAdapter = {
+  name: 'manual',
+
+  async createCheckoutSession(order, opts) {
+    // The checkout route passes returnUrl = `${appUrl}/s/{locale}/{site}/orden/{id}`.
+    // We piggy-back on that to derive the transfer instructions page URL without
+    // needing to thread the site slug through the adapter interface.
+    const redirectUrl = opts.returnUrl.replace('/orden/', '/checkout/transfer/')
+
+    return {
+      redirectUrl,
+      providerRef: `MANUAL-${order.id}`,
+      sandbox: false,
+    }
+  },
+
+  async verifyWebhook() {
+    // Manual transfers have no webhook — the merchant confirms in admin.
+    return {
+      valid: false,
+      eventId: '',
+      resourceId: '',
+      eventType: 'unsupported',
+      reason: 'manual_has_no_webhook',
+    }
+  },
+
+  async fetchPayment(providerPaymentId) {
+    // No gateway to query; we just echo back a pending status. The order's
+    // own DB row is the source of truth; the admin flips it to `paid`.
+    return {
+      providerPaymentId,
+      status: 'pending',
+      amountCents: 0,
+      currency: 'PYG',
+      externalReference: providerPaymentId,
+      rawPayload: { note: 'manual_transfer_pending_merchant_confirmation' },
+    }
+  },
+}

--- a/web/lib/payments/registry.ts
+++ b/web/lib/payments/registry.ts
@@ -1,9 +1,11 @@
 import { pagoparAdapter } from './pagopar/adapter'
+import { manualAdapter } from './manual/adapter'
 import type { PaymentProviderAdapter } from './types'
 import type { PaymentProvider } from '@/lib/schemas/commerce/transaction'
 
 const ADAPTERS: Partial<Record<PaymentProvider, PaymentProviderAdapter>> = {
   pagopar: pagoparAdapter,
+  manual: manualAdapter,
   // bancard: ship in Phase 3 (direct VPOS 2.0 for high-volume merchants)
   // dlocal: ship in Phase 2 (LATAM multi-country aggregator)
 }

--- a/web/lib/payments/router.ts
+++ b/web/lib/payments/router.ts
@@ -41,6 +41,10 @@ export function rankProviders(ctx: RouteContext): PaymentProvider[] {
   const upperCurrency = ctx.currency.toUpperCase()
 
   const eligible = CAPABILITIES.filter((cap) => {
+    // A provider that requires explicit availability (e.g., `manual`)
+    // is only eligible when the merchant has installed credentials for
+    // it — prevents it from matching universally.
+    if (cap.requiresExplicitAvailable && !ctx.available?.includes(cap.provider)) return false
     if (ctx.available && !ctx.available.includes(cap.provider)) return false
     const countryOk = cap.countries.length === 0 || cap.countries.includes(upperCountry)
     const currencyOk = cap.currencies.length === 0 || cap.currencies.includes(upperCurrency)

--- a/web/lib/payments/types.ts
+++ b/web/lib/payments/types.ts
@@ -27,6 +27,13 @@ export interface PaymentCapability {
   // Lower = preferred when multiple providers cover the same country.
   // Tie-breaker is feeTier (low → medium → high).
   basePriority: number
+  /**
+   * When true, this provider is only considered if the merchant has
+   * explicitly installed credentials for it (i.e., `available` is passed
+   * to the router AND includes this provider). Prevents universal-match
+   * adapters like `manual` from hijacking routes they shouldn't.
+   */
+  requiresExplicitAvailable?: boolean
 }
 
 export interface WebhookVerification {


### PR DESCRIPTION
## Summary

Adds a \`manual\` payment provider so tenants who don't have a Pagopar merchant account yet can still take orders. Shoppers are redirected to a bank-transfer instructions page with a WhatsApp deep link for the comprobante. The merchant confirms the payment in the orders admin.

Same pattern Ivan already uses for his own SaaS billing — now available to the pilots as their default checkout.

## What changed

- **Manual adapter** (\`lib/payments/manual/adapter.ts\`): redirects to \`/s/{locale}/{site}/checkout/transfer/{orderId}\`. No webhook.
- **Transfer-instructions page** (\`app/s/[locale]/[site]/checkout/transfer/[orderId]\`): renders bank details + pre-filled WhatsApp deep link.
- **Admin action**: \"Confirmar pago recibido\" button on \`awaiting_payment\` orders → flips to \`paid\`.
- **Admin payments template**: \"Transferencia bancaria + WhatsApp\" form with banco / número / titular / CI+RUC / WhatsApp / instrucciones. All public, no encrypted secrets.
- **Router gate**: new \`requiresExplicitAvailable\` flag on PaymentCapability — \`manual\` only matches when the merchant installed manual creds. PY merchants without creds still get platform-level Pagopar.
- **Relocation registry**: \`commerce.enabled = false\`. Nexa stops showing placeholder products; homepage pricing section handles leads instead.

## Why

Pagopar registration is blocked on merchant-side paperwork. Meanwhile the pilots need to take their first real order. The manual flow mirrors how Paraguayan SMBs already close sales (transfer + WhatsApp confirmation), so there's zero new behavior to teach shoppers.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run test:unit\` — 426 pass / 11 skipped
- [x] \`npm run build\` — \`/s/[locale]/[site]/checkout/transfer/[orderId]\` route built
- [ ] Manual: install manual creds on a test tenant, place an order, verify transfer page renders bank details + WhatsApp link
- [ ] Manual: confirm \"Confirmar pago recibido\" transitions order to paid + stamps paid_at
- [ ] Manual: verify Nexa \`/tienda\` now 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)