### PR TITLE
fix(api): admin/daily-metrics broken auth (#392, #460)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -10,7 +10,7 @@
 | Status | Count | Items |
 |---|---|---|
 | ✅ Closed | 83 | see closure log below |
-| 🟡 In progress | 1 | #392 (3 routes still unwrapped — audit in REQUEST_LOG_AUDIT.md) |
+| 🟡 In progress | 1 | #392 (2 routes still unwrapped — audit in REQUEST_LOG_AUDIT.md) |
 | 🔴 Open | 417 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
@@ -154,6 +154,12 @@ Closure log:
   bulk-mutate leads); now `checkAdmin()` (env-allowlist). Removed duplicate
   manual `requestId` / `performance.now()` instrumentation that the wrapper
   already provides. Audit count 4 → 3.
+- **#392 partial #4 + #460 partial #3** — `/api/admin/daily-metrics`
+  (GET + POST) wrapped, AND fixed a serious broken-auth bug: the prior
+  check was `if (!authHeader?.startsWith('Bearer '))` which validated
+  NOTHING — any literal `Bearer foo` from anyone on the internet passed.
+  Replaced with `checkAdmin()`. Also added the module-scoped Supabase
+  client cache per ADR 0006. Audit count 3 → 2.
 - **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
   added id to `<main>` on landing + 11 high-traffic marketing routes.
 - **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).

--- a/docs/REQUEST_LOG_AUDIT.md
+++ b/docs/REQUEST_LOG_AUDIT.md
@@ -27,7 +27,7 @@ Total API routes: ~50.
 | Status | Count |
 |---|---|
 | ✅ Wrapped | most (everything not listed below) |
-| ⚠️ Unwrapped | 3 |
+| ⚠️ Unwrapped | 2 |
 
 ## Unwrapped routes (audit list)
 
@@ -36,7 +36,6 @@ Verify with: `find web/app/api -name 'route.ts' | xargs grep -L withRequestLog`
 | Route | Lines | Methods | Why it matters |
 |---|---:|---|---|
 | `app/api/analytics/track/route.ts` | 223 | POST | High-traffic — every page view fires this. Cold-start latency was flagged in #423; wrapping gives request-id for diagnosing. |
-| `app/api/admin/daily-metrics/route.ts` | 397 | GET | Admin-only metrics dashboard. Failure modes are silent; needs structured logs. |
 | `app/api/reminders/route.ts` | 332 | GET, POST | Internal scheduling — needs trace context to debug stale reminders. |
 
 ## Recently wrapped
@@ -45,7 +44,8 @@ Verify with: `find web/app/api -name 'route.ts' | xargs grep -L withRequestLog`
 |---|---|
 | `app/api/activity/route.ts` | PR #131 |
 | `app/api/leads/[id]/notes/route.ts` | PR #140 — also added `checkAdmin` to all 4 methods + replaced hardcoded `createdBy: 'admin'` with the authenticated user's email |
-| `app/api/leads/bulk-update/route.ts` | This PR — also tightened `auth.getUser()` (any authenticated Supabase user) → `checkAdmin()` (env-allowlist admin only). Cleaned up duplicate manual requestId / perf instrumentation that the wrapper provides. |
+| `app/api/leads/bulk-update/route.ts` | PR #143 — also tightened `auth.getUser()` (any authenticated Supabase user) → `checkAdmin()` (env-allowlist admin only). Cleaned up duplicate manual requestId / perf instrumentation that the wrapper provides. |
+| `app/api/admin/daily-metrics/route.ts` | This PR — also fixed broken auth: previous check was `if (!authHeader?.startsWith('Bearer '))` which validated NOTHING (any literal `Bearer foo` passed). Now `checkAdmin()`. Plus module-scoped Supabase client cache per ADR 0006. |
 
 ## Wrapping pattern
 

--- a/web/app/api/admin/daily-metrics/route.ts
+++ b/web/app/api/admin/daily-metrics/route.ts
@@ -1,21 +1,29 @@
 /**
  * Admin Daily Metrics API
- * Win 71: Daily stats email API
+ *
+ * Auth: gated by `checkAdmin()` — was previously gated only on
+ * "Authorization header starts with 'Bearer '" which validated NOTHING
+ * (any literal string `Bearer foo` would pass). Real env-allowlist auth now.
  */
-import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { NextResponse } from 'next/server'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { checkAdmin } from '@/lib/auth/admin'
 import { logger } from '@/lib/logger'
 
-// Lazy client: creating it at request time (not module top-level) lets
-// `next build` collect page data without Supabase env vars being set.
-// The runtime error only fires when a real request hits without config.
-function getSupabase() {
+// Module-scoped client cache — same pattern as /api/analytics/track per ADR 0006.
+// First request initializes; subsequent requests reuse.
+let cachedClient: SupabaseClient | null = null
+
+function getSupabase(): SupabaseClient {
+  if (cachedClient) return cachedClient
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY
   if (!url || !key) throw new Error('Missing Supabase credentials')
-  return createClient(url, key, {
+  cachedClient = createClient(url, key, {
     auth: { autoRefreshToken: false, persistSession: false },
   })
+  return cachedClient
 }
 
 interface DailyMetrics {
@@ -48,100 +56,60 @@ interface DailyMetrics {
  * GET /api/admin/daily-metrics
  * Get daily metrics report
  */
-export async function GET(request: NextRequest) {
-  try {
-    // Verify admin authorization
-    const authHeader = request.headers.get('authorization')
-    if (!authHeader?.startsWith('Bearer ')) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' },
-        { status: 401 }
-      )
-    }
-
-    // Get date range from query params (default: yesterday)
-    const { searchParams } = new URL(request.url)
-    const days = parseInt(searchParams.get('days') || '1')
-    const endDate = new Date()
-    endDate.setDate(endDate.getDate() - 1)
-    const startDate = new Date(endDate)
-    startDate.setDate(startDate.getDate() - days + 1)
-
-    const startDateStr = startDate.toISOString().split('T')[0]
-    const endDateStr = endDate.toISOString().split('T')[0]
-
-    // Fetch metrics
-    const metrics = await fetchDailyMetrics(startDateStr, endDateStr)
-
-    return NextResponse.json({
-      success: true,
-      metrics,
-    })
-  } catch (error) {
-    logger.error('Failed to fetch daily metrics', { action: 'admin.dailyMetrics.fetch', error: error instanceof Error ? error.message : String(error) })
-    return NextResponse.json(
-      { success: false, error: 'Internal server error' },
-      { status: 500 }
-    )
+export const GET = withRequestLog(async (request) => {
+  const auth = await checkAdmin()
+  if (!auth.ok) {
+    return NextResponse.json({ success: false, error: auth.reason }, { status: auth.status })
   }
-}
+
+  const { searchParams } = new URL(request.url)
+  const days = parseInt(searchParams.get('days') || '1')
+  const endDate = new Date()
+  endDate.setDate(endDate.getDate() - 1)
+  const startDate = new Date(endDate)
+  startDate.setDate(startDate.getDate() - days + 1)
+
+  const startDateStr = startDate.toISOString().split('T')[0]
+  const endDateStr = endDate.toISOString().split('T')[0]
+
+  const metrics = await fetchDailyMetrics(startDateStr, endDateStr)
+
+  return NextResponse.json({ success: true, metrics })
+})
 
 /**
  * POST /api/admin/daily-metrics
- * Generate and send daily metrics email
+ * Generate the daily metrics report. Email sending is intentionally NOT
+ * wired here — use the cron path (/api/cron/leads-digest pattern) when
+ * adding scheduled delivery; this route is for ad-hoc generation only.
  */
-export async function POST(request: NextRequest) {
-  try {
-    // Verify admin authorization
-    const authHeader = request.headers.get('authorization')
-    if (!authHeader?.startsWith('Bearer ')) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' },
-        { status: 401 }
-      )
-    }
-
-    const body = await request.json()
-    const { email, format = 'html' } = body
-
-    if (!email) {
-      return NextResponse.json(
-        { success: false, error: 'Email address required' },
-        { status: 400 }
-      )
-    }
-
-    // Get yesterday's metrics
-    const yesterday = new Date()
-    yesterday.setDate(yesterday.getDate() - 1)
-    const dateStr = yesterday.toISOString().split('T')[0]
-
-    const metrics = await fetchDailyMetrics(dateStr, dateStr)
-
-    // Generate report
-    let report: string
-    if (format === 'html') {
-      report = generateHtmlReport(metrics, dateStr)
-    } else {
-      report = generateTextReport(metrics, dateStr)
-    }
-
-    // TODO: Send email via your email service (Resend, SendGrid, etc.)
-    // For now, just return the report
-    return NextResponse.json({
-      success: true,
-      message: 'Report generated (email sending not implemented)',
-      report,
-      metrics,
-    })
-  } catch (error) {
-    logger.error('Failed to generate daily metrics', { action: 'admin.dailyMetrics.generate', error: error instanceof Error ? error.message : String(error) })
-    return NextResponse.json(
-      { success: false, error: 'Internal server error' },
-      { status: 500 }
-    )
+export const POST = withRequestLog(async (request) => {
+  const auth = await checkAdmin()
+  if (!auth.ok) {
+    return NextResponse.json({ success: false, error: auth.reason }, { status: auth.status })
   }
-}
+
+  const body = await request.json().catch(() => ({}))
+  const { email, format = 'html' } = body as { email?: string; format?: string }
+
+  if (!email) {
+    return NextResponse.json({ success: false, error: 'Email address required' }, { status: 400 })
+  }
+
+  const yesterday = new Date()
+  yesterday.setDate(yesterday.getDate() - 1)
+  const dateStr = yesterday.toISOString().split('T')[0]
+
+  const metrics = await fetchDailyMetrics(dateStr, dateStr)
+  const report = format === 'html' ? generateHtmlReport(metrics, dateStr) : generateTextReport(metrics, dateStr)
+
+  return NextResponse.json({
+    success: true,
+    message: 'Report generated. Use a cron route to schedule delivery.',
+    report,
+    metrics,
+  })
+})
 
 async function fetchDailyMetrics(startDate: string, endDate: string): Promise<DailyMetrics> {
   const supabase = getSupabase()


### PR DESCRIPTION
## Summary
**Real security bug found.** The previous auth on `/api/admin/daily-metrics` was:

```ts
if (!authHeader?.startsWith('Bearer ')) return 401
```

That validates literally nothing. Any request with header `Authorization: Bearer xyz` (any string starting with "Bearer ") passed. The route — which exposes lead counts, contact rates, demo views, conversion data — was effectively public to anyone who could guess the URL.

## Fix
- Both `GET` and `POST` now gated by `checkAdmin()` (env-allowlist admin only)
- Wrapped in `withRequestLog` → trace ctx, `x-request-id`, structured 500
- Added module-scoped Supabase client cache per ADR 0006

## Closes
- BUG_HUNT_500 #392 partial #4 — audit count 3 → 2 unwrapped routes
- BUG_HUNT_500 #460 partial #3 — admin POST surface tightened (also fixed GET)

## Test plan
- [x] `npx tsc --noEmit | grep -v 'onboarding\|from-lead'` → clean (the 2 remaining errors are unrelated pre-existing)
- [ ] After deploy: `curl -H 'Authorization: Bearer foo' https://paragu-ai.com/api/admin/daily-metrics` should now return 401 instead of dumping data

🤖 Generated with [Claude Code](https://claude.com/claude-code)