### PR TITLE
fix(api): finish route audit — wrap reminders + analytics/track (#392)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 83 | see closure log below |
-| 🟡 In progress | 1 | #392 (2 routes still unwrapped — audit in REQUEST_LOG_AUDIT.md) |
-| 🔴 Open | 417 | the rest |
+| ✅ Closed | 84 | see closure log below |
+| 🟡 In progress | 0 | — |
+| 🔴 Open | 416 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -160,6 +160,14 @@ Closure log:
   NOTHING — any literal `Bearer foo` from anyone on the internet passed.
   Replaced with `checkAdmin()`. Also added the module-scoped Supabase
   client cache per ADR 0006. Audit count 3 → 2.
+- **#392 fully closed + #460 partial #4** — last 2 routes from the
+  original audit wrapped: `/api/reminders` (GET/POST/PATCH/DELETE — was
+  unauthenticated, now `checkAdmin`) and `/api/analytics/track` (POST stays
+  public for browser ingest; GET had the same broken `Bearer foo` pattern,
+  now `checkAdmin`). All 5 original audit routes done. Tests updated:
+  6/6 passing on analytics-track. New unwrapped route flagged in audit
+  doc as a parallel-agent addition (`generate-preview/route.ts`) for
+  follow-up.
 - **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
   added id to `<main>` on landing + 11 high-traffic marketing routes.
 - **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).

--- a/docs/REQUEST_LOG_AUDIT.md
+++ b/docs/REQUEST_LOG_AUDIT.md
@@ -26,8 +26,8 @@ Total API routes: ~50.
 
 | Status | Count |
 |---|---|
-| ✅ Wrapped | most (everything not listed below) |
-| ⚠️ Unwrapped | 2 |
+| ✅ Wrapped | every route in the original audit |
+| ⚠️ Unwrapped | 1 (new since the original audit — see below) |
 
 ## Unwrapped routes (audit list)
 
@@ -35,8 +35,7 @@ Verify with: `find web/app/api -name 'route.ts' | xargs grep -L withRequestLog`
 
 | Route | Lines | Methods | Why it matters |
 |---|---:|---|---|
-| `app/api/analytics/track/route.ts` | 223 | POST | High-traffic — every page view fires this. Cold-start latency was flagged in #423; wrapping gives request-id for diagnosing. |
-| `app/api/reminders/route.ts` | 332 | GET, POST | Internal scheduling — needs trace context to debug stale reminders. |
+| `app/api/leads/[id]/generate-preview/route.ts` | 254 | POST | Added since original audit by a parallel agent. Writes to disk (`sites/preview-<id>/`); has zero auth check — anyone with a lead UUID can trigger preview generation. Wrap + `checkAdmin` in a follow-up. |
 
 ## Recently wrapped
 
@@ -45,7 +44,9 @@ Verify with: `find web/app/api -name 'route.ts' | xargs grep -L withRequestLog`
 | `app/api/activity/route.ts` | PR #131 |
 | `app/api/leads/[id]/notes/route.ts` | PR #140 — also added `checkAdmin` to all 4 methods + replaced hardcoded `createdBy: 'admin'` with the authenticated user's email |
 | `app/api/leads/bulk-update/route.ts` | PR #143 — also tightened `auth.getUser()` (any authenticated Supabase user) → `checkAdmin()` (env-allowlist admin only). Cleaned up duplicate manual requestId / perf instrumentation that the wrapper provides. |
-| `app/api/admin/daily-metrics/route.ts` | This PR — also fixed broken auth: previous check was `if (!authHeader?.startsWith('Bearer '))` which validated NOTHING (any literal `Bearer foo` passed). Now `checkAdmin()`. Plus module-scoped Supabase client cache per ADR 0006. |
+| `app/api/admin/daily-metrics/route.ts` | PR #144 — also fixed broken auth: previous check was `if (!authHeader?.startsWith('Bearer '))` which validated NOTHING (any literal `Bearer foo` passed). Now `checkAdmin()`. Plus module-scoped Supabase client cache per ADR 0006. |
+| `app/api/reminders/route.ts` | This PR — also added `checkAdmin` to all 4 methods (was completely unauthenticated). Dropped dead `ReminderScheduler` import that was never invoked. |
+| `app/api/analytics/track/route.ts` | This PR — POST stays public (browsers fire it). GET fixed: previous check was the same broken `Bearer foo` pattern that gave anyone access to the analytics dump. Now `checkAdmin()`. |
 
 ## Wrapping pattern
 

--- a/web/app/api/analytics/track/route.ts
+++ b/web/app/api/analytics/track/route.ts
@@ -1,10 +1,16 @@
 /**
  * Analytics Track API Route
- * Win 68: Page view tracking API
+ *
+ * - POST: public, ingests one analytics event per request
+ * - GET: admin-only, returns aggregate stats for the dashboard
+ *
+ * GET auth was previously gated only on `authHeader.startsWith('Bearer ')`
+ * which validates nothing — any literal `Bearer foo` passed. Now `checkAdmin()`.
  */
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
-import { logger } from '@/lib/logger'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { checkAdmin } from '@/lib/auth/admin'
 
 // Module-scoped, memoized client. First request pays the init cost (~tens
 // of ms — just wrapper construction, no network); every subsequent request
@@ -61,161 +67,105 @@ interface TrackEventBody {
 
 /**
  * POST /api/analytics/track
- * Track an analytics event
+ * Track an analytics event. Public — no auth (events come from browsers).
  */
-export async function POST(request: NextRequest) {
-  try {
-    const supabase = getSupabase()
-    const body: TrackEventBody = await request.json()
-    
-    // Validate required fields
-    if (!body.eventType) {
-      return NextResponse.json(
-        { success: false, error: 'Missing required field: eventType' },
-        { status: 400 }
-      )
-    }
-    
-    // Validate event type
-    if (!VALID_EVENT_TYPES.includes(body.eventType)) {
-      return NextResponse.json(
-        { success: false, error: `Invalid event type: ${body.eventType}` },
-        { status: 400 }
-      )
-    }
-    
-    // Get request metadata
-    const headers = request.headers
-    const userAgent = body.userAgent || headers.get('user-agent') || 'unknown'
-    const referrer = body.referrer || headers.get('referer') || 'direct'
-    
-    // Get IP (respecting privacy - hash it)
-    const ip = headers.get('x-forwarded-for') || headers.get('x-real-ip') || 'unknown'
-    const ipHash = await hashIp(ip)
-    
-    // Build event record
-    const event = {
-      event_type: body.eventType,
-      business_id: body.businessId || null,
-      lead_id: body.leadId || null,
-      page_url: body.pageUrl || null,
-      section_id: body.sectionId || null,
-      metadata: body.metadata || {},
-      session_id: body.sessionId || generateSessionId(),
-      ip_hash: ipHash,
-      user_agent: userAgent.slice(0, 200), // Limit length
-      referrer: referrer.slice(0, 500),
-      created_at: new Date().toISOString(),
-    }
-    
-    // Insert event
-    const { data, error } = await supabase
-      .from('analytics_events')
-      .insert(event)
-      .select('id')
-      .single()
-    
-    if (error) {
-      logger.error('Failed to track analytics event', {
-        action: 'analytics.track',
-        error: error.message,
-      })
-      return NextResponse.json(
-        { success: false, error: 'Failed to track event' },
-        { status: 500 }
-      )
-    }
+export const POST = withRequestLog(async (request, { log }) => {
+  const supabase = getSupabase()
+  const body: TrackEventBody = await request.json().catch(() => ({} as TrackEventBody))
 
-    return NextResponse.json({
-      success: true,
-      eventId: data.id,
-      sessionId: event.session_id,
-    })
-
-  } catch (error) {
-    logger.error('Unhandled error in analytics track', {
-      action: 'analytics.track',
-      error: error instanceof Error ? error.message : String(error),
-    })
+  if (!body.eventType) {
     return NextResponse.json(
-      { success: false, error: 'Internal server error' },
-      { status: 500 }
+      { success: false, error: 'Missing required field: eventType' },
+      { status: 400 },
     )
   }
-}
+  if (!VALID_EVENT_TYPES.includes(body.eventType)) {
+    return NextResponse.json(
+      { success: false, error: `Invalid event type: ${body.eventType}` },
+      { status: 400 },
+    )
+  }
+    
+  const headers = request.headers
+  const userAgent = body.userAgent || headers.get('user-agent') || 'unknown'
+  const referrer = body.referrer || headers.get('referer') || 'direct'
+  const ip = headers.get('x-forwarded-for') || headers.get('x-real-ip') || 'unknown'
+  const ipHash = await hashIp(ip)
+
+  const event = {
+    event_type: body.eventType,
+    business_id: body.businessId || null,
+    lead_id: body.leadId || null,
+    page_url: body.pageUrl || null,
+    section_id: body.sectionId || null,
+    metadata: body.metadata || {},
+    session_id: body.sessionId || generateSessionId(),
+    ip_hash: ipHash,
+    user_agent: userAgent.slice(0, 200),
+    referrer: referrer.slice(0, 500),
+    created_at: new Date().toISOString(),
+  }
+
+  const { data, error } = await supabase
+    .from('analytics_events')
+    .insert(event)
+    .select('id')
+    .single()
+
+  if (error) {
+    log.error('analytics.track.insert_failed', new Error(error.message))
+    return NextResponse.json({ success: false, error: 'Failed to track event' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true, eventId: data.id, sessionId: event.session_id })
+})
 
 /**
  * GET /api/analytics/track
- * Get tracking stats (admin only)
+ * Get tracking stats. Admin-only via checkAdmin().
  */
-export async function GET(request: NextRequest) {
-  try {
-    // Check for admin authorization
-    const authHeader = request.headers.get('authorization')
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' },
-        { status: 401 }
-      )
-    }
-
-    const supabase = getSupabase()
-
-    // Parse time range from query params
-    const { searchParams } = new URL(request.url)
-    const days = parseInt(searchParams.get('days') || '7')
-    const eventType = searchParams.get('eventType')
-
-    // Build query
-    let query = supabase
-      .from('analytics_events')
-      .select('*', { count: 'exact' })
-      .gte('created_at', new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString())
-    
-    if (eventType) {
-      query = query.eq('event_type', eventType)
-    }
-    
-    const { data, count, error } = await query
-      .order('created_at', { ascending: false })
-      .limit(100)
-    
-    if (error) {
-      logger.error('Failed to get analytics stats', {
-        action: 'analytics.getStats',
-        error: error.message,
-      })
-      return NextResponse.json(
-        { success: false, error: 'Failed to get stats' },
-        { status: 500 }
-      )
-    }
-    
-    // Aggregate by event type
-    const byType = (data || []).reduce((acc: Record<string, number>, event: { event_type: string }) => {
-      acc[event.event_type] = (acc[event.event_type] || 0) + 1
-      return acc
-    }, {})
-    
-    return NextResponse.json({
-      success: true,
-      totalCount: count,
-      period: `${days} days`,
-      byType,
-      recentEvents: data,
-    })
-    
-  } catch (error) {
-    logger.error('Unhandled error in analytics stats', {
-      action: 'analytics.getStats',
-      error: error instanceof Error ? error.message : String(error),
-    })
-    return NextResponse.json(
-      { success: false, error: 'Internal server error' },
-      { status: 500 }
-    )
+export const GET = withRequestLog(async (request, { log }) => {
+  const auth = await checkAdmin()
+  if (!auth.ok) {
+    return NextResponse.json({ success: false, error: auth.reason }, { status: auth.status })
   }
-}
+
+  const supabase = getSupabase()
+  const { searchParams } = new URL(request.url)
+  const days = parseInt(searchParams.get('days') || '7')
+  const eventType = searchParams.get('eventType')
+
+  let query = supabase
+    .from('analytics_events')
+    .select('*', { count: 'exact' })
+    .gte('created_at', new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString())
+
+  if (eventType) {
+    query = query.eq('event_type', eventType)
+  }
+
+  const { data, count, error } = await query
+    .order('created_at', { ascending: false })
+    .limit(100)
+
+  if (error) {
+    log.error('analytics.stats.failed', new Error(error.message))
+    return NextResponse.json({ success: false, error: 'Failed to get stats' }, { status: 500 })
+  }
+
+  const byType = (data || []).reduce((acc: Record<string, number>, event: { event_type: string }) => {
+    acc[event.event_type] = (acc[event.event_type] || 0) + 1
+    return acc
+  }, {})
+
+  return NextResponse.json({
+    success: true,
+    totalCount: count,
+    period: `${days} days`,
+    byType,
+    recentEvents: data,
+  })
+})
 
 // Helper functions
 async function hashIp(ip: string): Promise<string> {

--- a/web/app/api/reminders/route.ts
+++ b/web/app/api/reminders/route.ts
@@ -1,17 +1,22 @@
 /**
  * Reminders API
- * 
+ *
  * Manage follow-up reminders:
  * - GET: List reminders (optionally filtered by lead or status)
  * - POST: Create a new reminder
  * - PATCH: Update reminder status
  * - DELETE: Remove a reminder
+ *
+ * All methods admin-only via `checkAdmin()` — these are internal CRM data.
+ *
+ * Storage is currently in-memory `Map`s (one keyed by leadId, one by
+ * reminderId). Survives within a container lifetime; restart loses data.
+ * A real `reminders` table is the next iteration.
  */
-import { logger } from '@/lib/logger'
-
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 import { z } from 'zod'
-import { ReminderScheduler, DEFAULT_REMINDER_SCHEDULES } from '@/lib/reminders/scheduler'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { checkAdmin } from '@/lib/auth/admin'
 
 export const runtime = 'nodejs'
 
@@ -24,7 +29,7 @@ const CreateReminderSchema = z.object({
   description: z.string().max(2000).optional(),
   dueDate: z.string().regex(isoDateRegex, 'Invalid date format'),
   priority: z.enum(['high', 'medium', 'low']).default('medium'),
-  metadata: z.object({}).passthrough().optional()
+  metadata: z.object({}).passthrough().optional(),
 })
 
 const UpdateReminderSchema = z.object({
@@ -33,11 +38,10 @@ const UpdateReminderSchema = z.object({
   description: z.string().max(2000).optional(),
   dueDate: z.string().regex(isoDateRegex, 'Invalid date format').optional(),
   priority: z.enum(['high', 'medium', 'low']).optional(),
-  snoozeDays: z.number().int().min(1).max(30).optional()
+  snoozeDays: z.number().int().min(1).max(30).optional(),
 })
 
-// In-memory storage for demo (replace with database in production)
-const remindersStore = new Map<string, Array<{
+interface Reminder {
   id: string
   leadId: string
   type: string
@@ -50,283 +54,170 @@ const remindersStore = new Map<string, Array<{
   completedAt?: string
   snoozedUntil?: string
   metadata?: Record<string, unknown>
-}>>()
+}
 
-// Global reminder index for quick lookup
-const allReminders = new Map<string, {
-  id: string
-  leadId: string
-  type: string
-  title: string
-  description?: string
-  dueDate: string
-  status: string
-  priority: string
-  createdAt: string
-  completedAt?: string
-  snoozedUntil?: string
-  metadata?: Record<string, unknown>
-}>()
+const remindersByLead = new Map<string, Reminder[]>()
+const reminderById = new Map<string, Reminder>()
 
 function generateId(): string {
-  return `rem-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+  return `rem-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
 }
 
-const scheduler = new ReminderScheduler(DEFAULT_REMINDER_SCHEDULES)
+export const GET = withRequestLog(async (request) => {
+  const auth = await checkAdmin()
+  if (!auth.ok) return NextResponse.json({ error: auth.reason }, { status: auth.status })
 
-export async function GET(request: NextRequest) {
-  try {
-    const { searchParams } = new URL(request.url)
-    const leadId = searchParams.get('leadId')
-    const status = searchParams.get('status')
-    const priority = searchParams.get('priority')
-    const type = searchParams.get('type')
-    const overdue = searchParams.get('overdue') === 'true'
-    const upcoming = searchParams.get('upcoming')
-    
-    let reminders = Array.from(allReminders.values())
-    
-    // Apply filters
-    if (leadId) {
-      reminders = reminders.filter(r => r.leadId === leadId)
-    }
-    
-    if (status) {
-      reminders = reminders.filter(r => r.status === status)
-    }
-    
-    if (priority) {
-      reminders = reminders.filter(r => r.priority === priority)
-    }
-    
-    if (type) {
-      reminders = reminders.filter(r => r.type === type)
-    }
-    
-    if (overdue) {
-      const now = new Date().toISOString()
-      reminders = reminders.filter(r => 
-        r.status === 'pending' && r.dueDate < now
-      )
-    }
-    
-    if (upcoming) {
-      const days = parseInt(upcoming, 10) || 7
-      const now = new Date()
-      const cutoff = new Date(now)
-      cutoff.setDate(cutoff.getDate() + days)
-      
-      reminders = reminders.filter(r => {
-        const dueDate = new Date(r.dueDate)
-        return r.status === 'pending' && 
-               dueDate >= now && 
-               dueDate <= cutoff
-      })
-    }
-    
-    // Sort by due date, pending first
-    reminders.sort((a, b) => {
-      if (a.status === 'pending' && b.status !== 'pending') return -1
-      if (a.status !== 'pending' && b.status === 'pending') return 1
-      return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime()
-    })
+  const { searchParams } = new URL(request.url)
+  const leadId = searchParams.get('leadId')
+  const status = searchParams.get('status')
+  const priority = searchParams.get('priority')
+  const type = searchParams.get('type')
+  const overdue = searchParams.get('overdue') === 'true'
+  const upcoming = searchParams.get('upcoming')
 
-    // Calculate stats
+  let reminders = Array.from(reminderById.values())
+  if (leadId) reminders = reminders.filter((r) => r.leadId === leadId)
+  if (status) reminders = reminders.filter((r) => r.status === status)
+  if (priority) reminders = reminders.filter((r) => r.priority === priority)
+  if (type) reminders = reminders.filter((r) => r.type === type)
+
+  if (overdue) {
     const now = new Date().toISOString()
-    const stats = {
-      total: reminders.length,
-      pending: reminders.filter(r => r.status === 'pending').length,
-      completed: reminders.filter(r => r.status === 'completed').length,
-      overdue: reminders.filter(r => r.status === 'pending' && r.dueDate < now).length,
-      highPriority: reminders.filter(r => r.priority === 'high' && r.status === 'pending').length
-    }
+    reminders = reminders.filter((r) => r.status === 'pending' && r.dueDate < now)
+  }
 
-    return NextResponse.json({
-      success: true,
-      data: reminders,
-      stats,
-      count: reminders.length
+  if (upcoming) {
+    const days = parseInt(upcoming, 10) || 7
+    const now = new Date()
+    const cutoff = new Date(now)
+    cutoff.setDate(cutoff.getDate() + days)
+    reminders = reminders.filter((r) => {
+      const due = new Date(r.dueDate)
+      return r.status === 'pending' && due >= now && due <= cutoff
     })
-  } catch (error) {
-    logger.error('Failed to fetch reminders', { action: 'reminders.list', error: error instanceof Error ? error.message : String(error) })
+  }
+
+  reminders.sort((a, b) => {
+    if (a.status === 'pending' && b.status !== 'pending') return -1
+    if (a.status !== 'pending' && b.status === 'pending') return 1
+    return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime()
+  })
+
+  const now = new Date().toISOString()
+  const stats = {
+    total: reminders.length,
+    pending: reminders.filter((r) => r.status === 'pending').length,
+    completed: reminders.filter((r) => r.status === 'completed').length,
+    overdue: reminders.filter((r) => r.status === 'pending' && r.dueDate < now).length,
+    highPriority: reminders.filter((r) => r.priority === 'high' && r.status === 'pending').length,
+  }
+
+  return NextResponse.json({ success: true, data: reminders, stats, count: reminders.length })
+})
+
+export const POST = withRequestLog(async (request, { log }) => {
+  const auth = await checkAdmin()
+  if (!auth.ok) return NextResponse.json({ error: auth.reason }, { status: auth.status })
+
+  const body = await request.json().catch(() => null)
+  const validated = CreateReminderSchema.safeParse(body)
+  if (!validated.success) {
     return NextResponse.json(
-      { error: 'Failed to fetch reminders' },
-      { status: 500 }
+      { error: 'Validation failed', details: validated.error.flatten().fieldErrors },
+      { status: 400 },
     )
   }
-}
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json()
-    const validated = CreateReminderSchema.safeParse(body)
+  const reminder: Reminder = {
+    id: generateId(),
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+    ...validated.data,
+  }
 
-    if (!validated.success) {
-      return NextResponse.json(
-        { 
-          error: 'Validation failed', 
-          details: validated.error.flatten().fieldErrors 
-        },
-        { status: 400 }
-      )
-    }
+  const leadReminders = remindersByLead.get(reminder.leadId) || []
+  leadReminders.push(reminder)
+  remindersByLead.set(reminder.leadId, leadReminders)
+  reminderById.set(reminder.id, reminder)
 
-    const { leadId, type, title, description, dueDate, priority, metadata } = validated.data
+  log.info('reminders.created', { reminderId: reminder.id, leadId: reminder.leadId, type: reminder.type })
+  return NextResponse.json({ success: true, data: reminder }, { status: 201 })
+})
 
-    const reminder = {
-      id: generateId(),
-      leadId,
-      type,
-      title,
-      description,
-      dueDate,
-      status: 'pending',
-      priority,
-      createdAt: new Date().toISOString(),
-      metadata
-    }
+export const PATCH = withRequestLog(async (request, { log }) => {
+  const auth = await checkAdmin()
+  if (!auth.ok) return NextResponse.json({ error: auth.reason }, { status: auth.status })
 
-    // Store in lead-specific array
-    const leadReminders = remindersStore.get(leadId) || []
-    leadReminders.push(reminder)
-    remindersStore.set(leadId, leadReminders)
-    
-    // Store in global index
-    allReminders.set(reminder.id, reminder)
+  const reminderId = new URL(request.url).searchParams.get('id')
+  if (!reminderId) {
+    return NextResponse.json({ error: 'Reminder ID is required' }, { status: 400 })
+  }
 
-    return NextResponse.json({
-      success: true,
-      data: reminder,
-      message: 'Reminder created successfully'
-    }, { status: 201 })
-  } catch (error) {
-    logger.error('Failed to create reminder', { action: 'reminders.create', error: error instanceof Error ? error.message : String(error) })
+  const body = await request.json().catch(() => ({}))
+  const validated = UpdateReminderSchema.safeParse(body)
+  if (!validated.success) {
     return NextResponse.json(
-      { error: 'Failed to create reminder' },
-      { status: 500 }
+      { error: 'Validation failed', details: validated.error.flatten().fieldErrors },
+      { status: 400 },
     )
   }
-}
 
-export async function PATCH(request: NextRequest) {
-  try {
-    const { searchParams } = new URL(request.url)
-    const reminderId = searchParams.get('id')
-    
-    if (!reminderId) {
-      return NextResponse.json(
-        { error: 'Reminder ID is required' },
-        { status: 400 }
-      )
-    }
-
-    const body = await request.json()
-    const validated = UpdateReminderSchema.safeParse(body)
-
-    if (!validated.success) {
-      return NextResponse.json(
-        { 
-          error: 'Validation failed', 
-          details: validated.error.flatten().fieldErrors 
-        },
-        { status: 400 }
-      )
-    }
-
-    const reminder = allReminders.get(reminderId)
-    if (!reminder) {
-      return NextResponse.json(
-        { error: 'Reminder not found' },
-        { status: 404 }
-      )
-    }
-
-    const updates = validated.data
-    
-    // Handle snooze
-    if (updates.status === 'snoozed' && updates.snoozeDays) {
-      const snoozedUntil = new Date()
-      snoozedUntil.setDate(snoozedUntil.getDate() + updates.snoozeDays)
-      reminder.snoozedUntil = snoozedUntil.toISOString()
-    }
-    
-    // Handle completion
-    if (updates.status === 'completed') {
-      reminder.completedAt = new Date().toISOString()
-    }
-    
-    // Update fields
-    if (updates.title) reminder.title = updates.title
-    if (updates.description !== undefined) reminder.description = updates.description
-    if (updates.dueDate) reminder.dueDate = updates.dueDate
-    if (updates.priority) reminder.priority = updates.priority
-    if (updates.status) reminder.status = updates.status
-
-    // Update in lead-specific array too
-    const leadReminders = remindersStore.get(reminder.leadId) || []
-    const index = leadReminders.findIndex(r => r.id === reminderId)
-    if (index !== -1) {
-      leadReminders[index] = { ...reminder }
-      remindersStore.set(reminder.leadId, leadReminders)
-    }
-    
-    allReminders.set(reminderId, reminder)
-
-    return NextResponse.json({
-      success: true,
-      data: reminder,
-      message: 'Reminder updated successfully'
-    })
-  } catch (error) {
-    logger.error('Failed to update reminder', { action: 'reminders.update', error: error instanceof Error ? error.message : String(error) })
-    return NextResponse.json(
-      { error: 'Failed to update reminder' },
-      { status: 500 }
-    )
+  const reminder = reminderById.get(reminderId)
+  if (!reminder) {
+    return NextResponse.json({ error: 'Reminder not found' }, { status: 404 })
   }
-}
+  const updates = validated.data
 
-export async function DELETE(request: NextRequest) {
-  try {
-    const { searchParams } = new URL(request.url)
-    const reminderId = searchParams.get('id')
-    
-    if (!reminderId) {
-      return NextResponse.json(
-        { error: 'Reminder ID is required' },
-        { status: 400 }
-      )
-    }
-
-    const reminder = allReminders.get(reminderId)
-    if (!reminder) {
-      return NextResponse.json(
-        { error: 'Reminder not found' },
-        { status: 404 }
-      )
-    }
-
-    // Remove from global index
-    allReminders.delete(reminderId)
-    
-    // Remove from lead-specific array
-    const leadReminders = remindersStore.get(reminder.leadId) || []
-    const filtered = leadReminders.filter(r => r.id !== reminderId)
-    if (filtered.length === 0) {
-      remindersStore.delete(reminder.leadId)
-    } else {
-      remindersStore.set(reminder.leadId, filtered)
-    }
-
-    return NextResponse.json({
-      success: true,
-      message: 'Reminder deleted successfully'
-    })
-  } catch (error) {
-    logger.error('Failed to delete reminder', { action: 'reminders.delete', error: error instanceof Error ? error.message : String(error) })
-    return NextResponse.json(
-      { error: 'Failed to delete reminder' },
-      { status: 500 }
-    )
+  if (updates.status === 'snoozed' && updates.snoozeDays) {
+    const snoozedUntil = new Date()
+    snoozedUntil.setDate(snoozedUntil.getDate() + updates.snoozeDays)
+    reminder.snoozedUntil = snoozedUntil.toISOString()
   }
-}
+  if (updates.status === 'completed') {
+    reminder.completedAt = new Date().toISOString()
+  }
+  if (updates.title) reminder.title = updates.title
+  if (updates.description !== undefined) reminder.description = updates.description
+  if (updates.dueDate) reminder.dueDate = updates.dueDate
+  if (updates.priority) reminder.priority = updates.priority
+  if (updates.status) reminder.status = updates.status
+
+  // Mirror into the per-lead bucket.
+  const leadReminders = remindersByLead.get(reminder.leadId) || []
+  const idx = leadReminders.findIndex((r) => r.id === reminderId)
+  if (idx !== -1) {
+    leadReminders[idx] = { ...reminder }
+    remindersByLead.set(reminder.leadId, leadReminders)
+  }
+  reminderById.set(reminderId, reminder)
+
+  log.info('reminders.updated', { reminderId, status: reminder.status })
+  return NextResponse.json({ success: true, data: reminder })
+})
+
+export const DELETE = withRequestLog(async (request, { log }) => {
+  const auth = await checkAdmin()
+  if (!auth.ok) return NextResponse.json({ error: auth.reason }, { status: auth.status })
+
+  const reminderId = new URL(request.url).searchParams.get('id')
+  if (!reminderId) {
+    return NextResponse.json({ error: 'Reminder ID is required' }, { status: 400 })
+  }
+
+  const reminder = reminderById.get(reminderId)
+  if (!reminder) {
+    return NextResponse.json({ error: 'Reminder not found' }, { status: 404 })
+  }
+
+  reminderById.delete(reminderId)
+  const leadReminders = remindersByLead.get(reminder.leadId) || []
+  const filtered = leadReminders.filter((r) => r.id !== reminderId)
+  if (filtered.length === 0) {
+    remindersByLead.delete(reminder.leadId)
+  } else {
+    remindersByLead.set(reminder.leadId, filtered)
+  }
+
+  log.info('reminders.deleted', { reminderId, leadId: reminder.leadId })
+  return NextResponse.json({ success: true })
+})

--- a/web/tests/integration/api-analytics-track.test.ts
+++ b/web/tests/integration/api-analytics-track.test.ts
@@ -1,16 +1,15 @@
 /**
- * Tests for /api/analytics/track. Closes BUG_HUNT_500 #423.
+ * Tests for /api/analytics/track. Closes BUG_HUNT_500 #423 + #460.
  *
  * Coverage:
  *   - 400 on missing/invalid event type
  *   - 200 happy path returns event id + session id
  *   - supabase client is created exactly once across N requests (proves
  *     the module-scoped cache works — was the cold-start bug)
- *   - 401 on GET without bearer token
+ *   - 401 on GET when checkAdmin returns unauthenticated
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-const mockInsert = vi.fn()
 const mockSelect = vi.fn(() => ({
   single: vi.fn(async () => ({ data: { id: 'evt-1' }, error: null })),
 }))
@@ -21,6 +20,11 @@ const createClientSpy = vi.fn(() => ({ from: mockFrom }))
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: (...args: unknown[]) => createClientSpy(...args),
+}))
+
+const mockCheckAdmin = vi.fn()
+vi.mock('@/lib/auth/admin', () => ({
+  checkAdmin: () => mockCheckAdmin(),
 }))
 
 const ORIGINAL_ENV = { ...process.env }
@@ -104,10 +108,19 @@ describe('/api/analytics/track GET', () => {
     process.env = ORIGINAL_ENV
   })
 
-  it('returns 401 without bearer token', async () => {
+  it('returns 401 when checkAdmin reports unauthenticated', async () => {
+    mockCheckAdmin.mockResolvedValueOnce({ ok: false, status: 401, reason: 'unauthenticated' })
     const { GET } = await import('@/app/api/analytics/track/route')
     const req = new Request('http://localhost/api/analytics/track', { method: 'GET' })
     const res = await GET(req as never)
     expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when checkAdmin reports forbidden', async () => {
+    mockCheckAdmin.mockResolvedValueOnce({ ok: false, status: 403, reason: 'forbidden' })
+    const { GET } = await import('@/app/api/analytics/track/route')
+    const req = new Request('http://localhost/api/analytics/track', { method: 'GET' })
+    const res = await GET(req as never)
+    expect(res.status).toBe(403)
   })
 })


### PR DESCRIPTION
## Summary
Last 2 routes from the original `REQUEST_LOG_AUDIT` wrapped:

**`/api/reminders`** (GET/POST/PATCH/DELETE)
- All 4 methods wrapped in `withRequestLog`
- All 4 methods now require admin via `checkAdmin()` — was completely unauthenticated; anyone could read/write/delete CRM reminders by leadId
- Dropped dead `ReminderScheduler` instance (was never invoked)

**`/api/analytics/track`** (POST + GET)
- POST stays public — browsers fire this from every page
- GET had the same broken `Bearer <anything>` auth pattern we just found in `/api/admin/daily-metrics`. Anyone could dump the analytics events table. Now `checkAdmin()`.
- Existing tests updated to mock `checkAdmin` — 6/6 passing

## Closes
- BUG_HUNT_500 #392 — original audit fully done (5/5 routes wrapped)
- BUG_HUNT_500 #460 partial #4 — admin GET surfaces tightened too

## Follow-up flagged
A NEW unwrapped + zero-auth route was found by a parallel agent during this PR: `/api/leads/[id]/generate-preview` (writes to disk). Documented in audit doc as a separate follow-up.

## Test plan
- [x] `npx vitest run tests/integration/api-analytics-track.test.ts` → 6/6
- [x] `npx tsc --noEmit | grep -v 'onboarding\|from-lead'` → clean
- [ ] After deploy: `curl -H 'Authorization: Bearer foo' https://paragu-ai.com/api/analytics/track?days=7` should now return 401 instead of dumping events

🤖 Generated with [Claude Code](https://claude.com/claude-code)