### PR TITLE
feat(sites): migrate Fun4Me from vete as real tenant (path-only)

### DIFF
--- a/sites/fun4me/content/es.json
+++ b/sites/fun4me/content/es.json
@@ -1,0 +1,259 @@
+{
+  "_meta": {
+    "translationQuality": "native",
+    "author": "Fun4Me",
+    "lastReviewed": "2026-04-21",
+    "notes": "Content ported from vete/web/.content_data/fun4me/. Original source: home.json, about.json, testimonials.json, faq.json, config.json. Placeholders flagged in site.json.placeholderFields. Awaiting owner confirmation.",
+    "placeholders": [
+      "home.partners.logos use placeholder SVGs — replace with real Satisfyer/LELO/We-Vibe logos",
+      "about.team empty — decide whether to publish team or keep anonymous for privacy",
+      "location.googleMapsId is ChIJxxxxxxxxxx — needs real Google Place ID for Herrera 875"
+    ]
+  },
+  "siteName": "Fun4Me",
+  "tagline": "Tu tienda de placer — envio discreto a todo Paraguay",
+  "placeholders": {
+    "businessName": "Fun4Me",
+    "city": "Asuncion",
+    "year": 2026,
+    "foundedYear": 2018
+  },
+  "navigation": {
+    "businessName": "Fun4Me",
+    "items": [
+      { "label": "Inicio", "href": "/" },
+      { "label": "Tienda", "href": "/store" },
+      { "label": "Nosotros", "href": "#about" },
+      { "label": "Contacto", "href": "#contact" }
+    ],
+    "ctaText": "WhatsApp",
+    "ctaHref": "https://wa.me/595976569739"
+  },
+  "home": {
+    "seo": {
+      "title": "Fun4Me — Sex Shop Online en Paraguay | Envio Discreto",
+      "description": "Juguetes para adultos, lenceria, accesorios y mas. Compra online con envio discreto a todo Paraguay. Tienda fisica en Asuncion. Solo mayores de 18."
+    },
+    "ageGate": {
+      "title": "Verificacion de Edad",
+      "message": "Este sitio contiene contenido para adultos. Debes ser mayor de 18 anos para continuar.",
+      "confirmText": "Soy mayor de 18",
+      "denyText": "Salir",
+      "denyHref": "https://google.com"
+    },
+    "hero": {
+      "badgeText": "Envio Discreto",
+      "headline": "Tu Tienda de Placer",
+      "subheadline": "Haz tus compras online o veni a visitarnos. Delivery a todo el pais con total discrecion.",
+      "ctaPrimaryText": "Explorar Tienda",
+      "ctaPrimaryHref": "/store",
+      "ctaSecondaryText": "Contactanos",
+      "ctaSecondaryHref": "https://wa.me/595976569739"
+    },
+    "trustBadges": [
+      { "icon": "truck", "text": "Envio a Todo el Pais" },
+      { "icon": "shield", "text": "Pago Seguro" },
+      { "icon": "package", "text": "Empaque Discreto" }
+    ],
+    "features": {
+      "badge": "Nuestras Ventajas",
+      "title": "Por que elegirnos?",
+      "subtitle": "Discrecion, calidad y variedad en cada compra.",
+      "items": [
+        {
+          "icon": "lock",
+          "title": "100% Discreto",
+          "text": "Empaque neutro, facturacion discreta y envio confidencial garantizado."
+        },
+        {
+          "icon": "truck",
+          "title": "Delivery a Todo el Pais",
+          "text": "Envios rapidos y seguros a cualquier punto de Paraguay."
+        },
+        {
+          "icon": "shield-check",
+          "title": "Productos de Calidad",
+          "text": "Seleccion de las mejores marcas con garantia de calidad."
+        },
+        {
+          "icon": "heart",
+          "title": "Atencion Personalizada",
+          "text": "Te asesoramos para encontrar el producto perfecto para vos."
+        }
+      ]
+    },
+    "promo": {
+      "enabled": true,
+      "text": "Envio GRATIS en compras mayores a Gs. 200.000",
+      "href": "/store"
+    },
+    "categories": {
+      "title": "Categorias Destacadas",
+      "subtitle": "Todo lo que necesitas para disfrutar",
+      "items": [
+        { "id": "vibradores", "name": "Vibradores", "icon": "sparkles", "description": "Desde clasicos hasta tecnologia de punta" },
+        { "id": "dildos", "name": "Dildos", "icon": "adjustments-vertical", "description": "Realistas, fantasy y de todas las formas" },
+        { "id": "anal", "name": "Juguetes Anales", "icon": "arrow-uturn-down", "description": "Explora nuevos territorios de placer" },
+        { "id": "parejas", "name": "Para Parejas", "icon": "heart", "description": "Juguetes disenados para compartir" },
+        { "id": "bdsm", "name": "BDSM & Fetish", "icon": "link", "description": "Equipamiento para juegos de poder" },
+        { "id": "lenceria", "name": "Lenceria", "icon": "gift", "description": "Piezas sensuales y provocativas" },
+        { "id": "lubricantes", "name": "Lubricantes", "icon": "beaker", "description": "Mejora cada experiencia" },
+        { "id": "bienestar", "name": "Bienestar Intimo", "icon": "shield-check", "description": "Cuidado y salud sexual" }
+      ],
+      "ctaText": "Ver Todo el Catalogo",
+      "ctaHref": "/store"
+    },
+    "stats": {
+      "title": "Numeros que nos respaldan",
+      "items": [
+        { "value": "7+", "label": "Anos de Experiencia" },
+        { "value": "5.000+", "label": "Clientes Satisfechos" },
+        { "value": "200+", "label": "Productos Disponibles" },
+        { "value": "100%", "label": "Envio Discreto" }
+      ]
+    },
+    "testimonials": {
+      "title": "Lo que dicen nuestros clientes",
+      "subtitle": "Testimonios reales de clientes satisfechos.",
+      "items": [
+        {
+          "author": "Maria L.",
+          "location": "Asuncion",
+          "rating": 5,
+          "text": "Llevaba anos con verguenza de entrar a un sex shop. En Fun4Me me senti comoda desde el primer momento. La atencion fue super profesional y me ayudaron a encontrar exactamente lo que buscaba sin hacerme sentir juzgada.",
+          "verified": true
+        },
+        {
+          "author": "Mariana T.",
+          "location": "Encarnacion",
+          "rating": 5,
+          "text": "Vivo en el interior y el envio fue super rapido y discreto. El paquete llego perfecto, sin ninguna indicacion de que era. 10/10 por la discrecion.",
+          "verified": true
+        },
+        {
+          "author": "Lucas A.",
+          "location": "Ciudad del Este",
+          "rating": 5,
+          "text": "Compre un vibrador como regalo para mi pareja. La asesoria online fue excelente, me explicaron todo sobre el uso. El producto supero todas mis expectativas.",
+          "verified": true
+        },
+        {
+          "author": "Camila R.",
+          "location": "Lambare",
+          "rating": 5,
+          "text": "El Satisfyer Pro 2 cambio mi vida. Y lo mejor es que aca te explican como usarlo bien, no como en otras tiendas que te tiran el producto y chau.",
+          "verified": true
+        },
+        {
+          "author": "Diego V.",
+          "location": "Asuncion",
+          "rating": 5,
+          "text": "Excelente variedad de productos y precios accesibles. El delivery llego al dia siguiente y todo muy bien empacado. Definitivamente vuelvo a comprar.",
+          "verified": true
+        },
+        {
+          "author": "Ana P.",
+          "location": "Fernando de la Mora",
+          "rating": 5,
+          "text": "Primera vez comprando en una tienda asi y la experiencia fue genial. Sin presiones, respuestas claras a todas mis preguntas. Muy recomendado.",
+          "verified": true
+        }
+      ]
+    },
+    "partners": {
+      "title": "Marcas Disponibles",
+      "logos": [
+        { "name": "Satisfyer", "image": "/branding/fun4me/images/partner-satisfyer.svg" },
+        { "name": "LELO", "image": "/branding/fun4me/images/partner-lelo.svg" },
+        { "name": "We-Vibe", "image": "/branding/fun4me/images/partner-wevibe.svg" }
+      ]
+    },
+    "faq": {
+      "title": "Preguntas Frecuentes",
+      "items": [
+        {
+          "q": "El envio es realmente discreto?",
+          "a": "100% discreto. El paquete no tiene logos, nombres ni ninguna indicacion del contenido. Nadie sabra que hay dentro excepto vos."
+        },
+        {
+          "q": "Que formas de pago aceptan?",
+          "a": "Tarjetas de credito/debito (Visa, Mastercard), transferencia bancaria, billeteras electronicas (Tigo Money, Personal Pay), y efectivo contra entrega en Asuncion."
+        },
+        {
+          "q": "Que aparece en mi estado de cuenta?",
+          "a": "El cargo aparece de forma discreta sin referencias explicitas al tipo de productos."
+        },
+        {
+          "q": "Cuanto tarda el envio?",
+          "a": "Asuncion: 24-48 horas. Gran Asuncion: 48-72 horas. Interior: 3-5 dias habiles. Envio express disponible con entrega el mismo dia en Asuncion."
+        },
+        {
+          "q": "Puedo devolver un producto?",
+          "a": "Por razones de higiene, no aceptamos devoluciones de productos intimos una vez abiertos. Si el producto llega defectuoso o danado, lo reemplazamos sin costo. Lenceria sin usar con etiquetas puede devolverse en 7 dias."
+        },
+        {
+          "q": "Los productos son seguros?",
+          "a": "Trabajamos con productos de marcas reconocidas. Todos nuestros vibradores son de silicona, ABS libre de ftalatos, o materiales seguros para el cuerpo."
+        },
+        {
+          "q": "Tienen envio gratis?",
+          "a": "Si, el envio es gratis en compras mayores a Gs. 200.000 a todo el pais."
+        },
+        {
+          "q": "Puedo visitar la tienda fisica?",
+          "a": "Claro! Te esperamos en Herrera 875, Asuncion. Lunes a viernes de 09:00 a 20:00 y sabados de 09:00 a 18:00."
+        },
+        {
+          "q": "Los productos tienen garantia?",
+          "a": "Los productos electronicos tienen garantia segun el fabricante. Satisfyer tiene 15 anos de garantia, LELO 1 ano, We-Vibe 2 anos."
+        }
+      ]
+    },
+    "cta": {
+      "title": "Tenes alguna consulta?",
+      "subtitle": "Escribinos por WhatsApp y te asesoramos sin compromiso.",
+      "ctaPrimaryText": "Ver Tienda",
+      "ctaPrimaryHref": "/store",
+      "ctaSecondaryText": "Escribir por WhatsApp",
+      "ctaSecondaryHref": "https://wa.me/595976569739"
+    },
+    "contact": {
+      "title": "Visitanos o Escribinos",
+      "address": "Herrera 875, Asuncion, Paraguay",
+      "phone": "+595 976 569 739",
+      "email": "hola@fun4me.com.py",
+      "hours": "Lun-Vie 09:00-20:00 · Sab 09:00-18:00 · Dom Cerrado"
+    }
+  },
+  "about": {
+    "intro": {
+      "title": "Sobre Fun4Me",
+      "text": "Fun4Me nacio en 2018 con la mision de ofrecer productos de calidad para adultos en Paraguay, con la discrecion y el profesionalismo que nuestros clientes merecen. Desde nuestra tienda en Herrera 875, Asuncion, atendemos a clientes de todo el pais con envios discretos y seguros. Creemos que cada persona tiene derecho a explorar su intimidad de manera segura y sin juicios."
+    },
+    "mission": {
+      "title": "Nuestra Mision",
+      "text": "Ofrecer productos de calidad para adultos con total discrecion, profesionalismo y respeto. Queremos que cada cliente se sienta comodo explorando su intimidad con productos seguros y de las mejores marcas."
+    },
+    "vision": {
+      "title": "Nuestra Vision",
+      "text": "Ser la tienda de referencia en Paraguay para productos de adultos, reconocida por la calidad, la discrecion de nuestro servicio y la confianza que generamos en nuestros clientes."
+    },
+    "values": [
+      { "icon": "eye-slash", "title": "Discrecion Total", "text": "Entendemos la importancia de la privacidad. Desde el empaque hasta la facturacion, todo es 100% discreto." },
+      { "icon": "truck", "title": "Envio a Todo el Pais", "text": "Delivery rapido y seguro a cualquier punto de Paraguay con total confidencialidad." },
+      { "icon": "shield-check", "title": "Productos de Calidad", "text": "Seleccionamos productos de marcas reconocidas para garantizar tu satisfaccion y seguridad." },
+      { "icon": "heart", "title": "Atencion Sin Juicios", "text": "Nuestro equipo esta capacitado para asesorarte con respeto y profesionalismo." }
+    ]
+  },
+  "footer": {
+    "rights": "Todos los derechos reservados.",
+    "privacy": "Politica de Privacidad",
+    "terms": "Terminos y Condiciones",
+    "legal": "Solo mayores de 18 anos."
+  },
+  "whatsapp": {
+    "number": "595976569739",
+    "message": "Hola! Quiero consultar sobre un producto.",
+    "label": "Chat con Fun4Me"
+  }
+}

--- a/sites/fun4me/docs/onboarding-questionnaire.md
+++ b/sites/fun4me/docs/onboarding-questionnaire.md
@@ -1,0 +1,101 @@
+# Cuestionario de onboarding — Fun4Me
+
+**Para:** equipo Fun4Me · **De:** equipo ParaguAI · **Fecha:** 21 abr 2026
+
+Hola 👋. Tu sitio está armado en **[paragu-ai.com/fun4me](https://paragu-ai.com/fun4me)** con el contenido que teníamos de la versión anterior (Vete). Hay cosas que **precargamos** y otras que necesitamos que **confirmen** para lanzarlo en público.
+
+El dominio propio `fun4me.com.py` queda diferido — arrancamos en `paragu-ai.com/fun4me` (path-only) y después migramos cuando lo decidan.
+
+---
+
+## Parte A — Confirmar lo que ya tenemos
+
+| Campo | Valor actual | ✓/✗ | Corrección |
+|---|---|---|---|
+| Nombre comercial | **Fun4Me** | | |
+| Tagline | **"Tu tienda de placer — envío discreto a todo Paraguay"** | | |
+| Slug en la URL | **fun4me** (paragu-ai.com/fun4me) | | |
+| Dirección | **Herrera 875, Asunción** | | |
+| WhatsApp | **+595 976 569 739** | | |
+| Email | **hola@fun4me.com.py** | | |
+| Instagram | **@fun4me_store** | | |
+| Facebook | **FUN4MEStore** | | |
+| Año de fundación | **2018** | | |
+| Horario L-V | **09:00 - 20:00** | | |
+| Horario Sábado | **09:00 - 18:00** | | |
+| Horario Domingo | **Cerrado** | | |
+
+### A.1 Delivery y envíos
+
+| Campo | Valor actual | ✓/✗ | Corrección |
+|---|---|---|---|
+| Envío gratis desde | **Gs. 200.000** | | |
+| Zonas de delivery cercano | **Asunción, FDM, San Lorenzo, Lambaré, Luque** | | |
+| Envío al interior | **Sí, 3-5 días hábiles** | | |
+| Empaque discreto | **100% sin logos ni indicaciones** | | |
+| Facturación discreta | **Sí, sin referencias al tipo de producto** | | |
+
+---
+
+## Parte B — Datos que faltan
+
+### B.1 ⭐ Google Maps
+El Place ID actual es placeholder (`ChIJxxxxxxxxxx`). Necesitamos el **Place ID real** para que el mapa muestre la tienda.
+
+Cómo obtenerlo: buscá "Fun4Me Herrera 875" en Google Maps → compartir → copiar link. Mandanos el link completo.
+
+### B.2 ⭐ Medios de pago
+Actualmente listamos: tarjetas Visa/Mastercard, transferencia bancaria, Tigo Money, Personal Pay, efectivo contra entrega en Asunción. ¿Está todo vigente? ¿Agregamos Pagopar / tarjeta online?
+
+### B.3 Logos de marcas partners
+Ahora mostramos logos placeholder de Satisfyer / LELO / We-Vibe. ¿Nos pasan los logos oficiales (PNG o SVG, fondo transparente)? ¿Querés sumar otras marcas?
+
+### B.4 Equipo
+La sección "equipo" está vacía. Dos opciones:
+1. **Publicar equipo** — fotos y nombres del personal (genera confianza pero puede ir contra la discreción que ofrecen)
+2. **Mantener anónimo** — no mostramos equipo (más discreto)
+
+Ustedes deciden.
+
+### B.5 Catálogo de productos
+Traemos el catálogo de 921 productos de la versión anterior. ¿Está al día? ¿Hay productos nuevos / discontinuados? ¿Precios actualizados?
+
+---
+
+## Parte C — Legal y cumplimiento
+
+### C.1 ⭐ Verificación de edad
+El sitio tiene un modal "Soy mayor de 18" obligatorio antes de entrar. Es **legalmente necesario** para contenido adulto. ¿Les parece bien el texto actual o quieren ajustarlo?
+
+### C.2 RUC / Timbrado
+Para facturación electrónica necesitamos:
+- RUC:
+- Razón social:
+- Timbrado vigente:
+- Tipo de comprobante (factura / contado / crédito):
+
+### C.3 Política de privacidad
+Texto borrador listo. Revisar y firmar.
+
+### C.4 Términos y condiciones
+Texto borrador listo. Revisar y firmar.
+
+---
+
+## Parte D — Dominio propio (opcional, a futuro)
+
+Arrancamos en `paragu-ai.com/fun4me`. Cuando quieran migrar a dominio propio:
+
+- ¿Tienen `fun4me.com.py` registrado?
+- Si no, lo podemos registrar nosotros (costo ~Gs. 150.000/año)
+- Migración sin downtime, pero requiere cambios DNS de su lado
+
+No urgente — el path en paragu-ai.com funciona igual de bien para empezar.
+
+---
+
+## Tiempo estimado
+
+30-45 minutos con detalle. Crítico para el lanzamiento: items con ⭐.
+
+Contestá en este mismo Markdown, en Google Doc, o agendamos llamada.

--- a/sites/fun4me/pages/home.json
+++ b/sites/fun4me/pages/home.json
@@ -1,0 +1,82 @@
+{
+  "slug": "",
+  "titleKey": "home.seo.title",
+  "descriptionKey": "home.seo.description",
+  "sections": [
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "ageGate"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "image",
+      "content": "home.hero"
+    },
+    {
+      "id": "trust-badges",
+      "variant": "strip",
+      "content": "home.trustBadges"
+    },
+    {
+      "id": "features",
+      "variant": "cards",
+      "content": "home.features"
+    },
+    {
+      "id": "promo-banner",
+      "variant": "strip",
+      "content": "home.promo"
+    },
+    {
+      "id": "categories",
+      "variant": "grid",
+      "content": "home.categories"
+    },
+    {
+      "id": "stats",
+      "variant": "counters",
+      "content": "home.stats"
+    },
+    {
+      "id": "testimonials",
+      "variant": "carousel",
+      "content": "home.testimonials"
+    },
+    {
+      "id": "partners",
+      "variant": "logos",
+      "content": "home.partners"
+    },
+    {
+      "id": "faq",
+      "variant": "accordion",
+      "content": "home.faq"
+    },
+    {
+      "id": "cta",
+      "variant": "split",
+      "content": "home.cta"
+    },
+    {
+      "id": "contact",
+      "variant": "split",
+      "content": "home.contact"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
+  ]
+}

--- a/sites/fun4me/site.json
+++ b/sites/fun4me/site.json
@@ -1,0 +1,66 @@
+{
+  "vertical": "retail-local",
+  "businessType": "sex_shop",
+  "country": "Paraguay",
+  "domain": null,
+  "path": "/fun4me",
+  "publicUrl": "https://paragu-ai.com/fun4me",
+  "stagingDomain": "fun4me.sunstein.cloud",
+  "defaultLocale": "es",
+  "locales": [
+    "es"
+  ],
+  "contact": {
+    "phone": "+595976569739",
+    "email": "hola@fun4me.com.py",
+    "whatsapp": "+595976569739",
+    "instagram": "@fun4me_store",
+    "facebook": "FUN4MEStore"
+  },
+  "location": {
+    "address": "Herrera 875",
+    "city": "Asuncion",
+    "country": "Paraguay",
+    "coordinates": {
+      "lat": -25.2867,
+      "lng": -57.6474
+    }
+  },
+  "hours": {
+    "Lunes - Viernes": "09:00 - 20:00",
+    "Sabado": "09:00 - 18:00",
+    "Domingo": "Cerrado"
+  },
+  "settings": {
+    "currency": "PYG",
+    "locale": "es-PY",
+    "timezone": "America/Asuncion",
+    "ageGate": 18,
+    "delivery": {
+      "enabled": true,
+      "freeThreshold": 200000,
+      "zones": ["Asuncion", "Fernando de la Mora", "San Lorenzo", "Lambare", "Luque"],
+      "national": true
+    }
+  },
+  "integrations": {
+    "analytics": "ga4"
+  },
+  "features": {
+    "whatsappFloat": true,
+    "testimonials": true,
+    "productCatalog": true,
+    "ageGate": true,
+    "discretePackaging": true,
+    "faq": true
+  },
+  "placeholderFields": {
+    "googleMapsId": "ChIJxxxxxxxxxx from vete config — needs real Place ID for Herrera 875",
+    "domain": "Path-only on paragu-ai.com/fun4me for now. Custom domain (fun4me.com.py) deferred.",
+    "brandPartners": "Satisfyer/LELO/We-Vibe logos use placeholder SVGs — replace with real logos",
+    "team": "about.team empty — decide whether to publish team or keep anonymous"
+  },
+  "migratedFrom": "vete/web/.content_data/fun4me/",
+  "migratedAt": "2026-04-21",
+  "is_demo": false
+}

--- a/sites/fun4me/tokens.json
+++ b/sites/fun4me/tokens.json
@@ -1,0 +1,45 @@
+{
+  "$comment": "Fun4Me — purple/pink Material-inspired palette ported from vete theme.json. Primary #9C27B0, secondary #E91E63. Extends retail-local vertical defaults.",
+  "extends": "vertical:retail-local",
+  "colors": {
+    "primary": "#9C27B0",
+    "primaryForeground": "#FFFFFF",
+    "primaryLight": "#BA68C8",
+    "primaryDark": "#7B1FA2",
+    "secondary": "#E91E63",
+    "secondaryForeground": "#FFFFFF",
+    "secondaryLight": "#F06292",
+    "secondaryDark": "#C2185B",
+    "accent": "#FF4081",
+    "accentForeground": "#FFFFFF",
+    "background": "#FDF8FC",
+    "backgroundAlt": "#F8F0F6",
+    "surface": "#FFFFFF",
+    "surfaceAlt": "#FDF8FC",
+    "text": "#2D1B36",
+    "textMuted": "#5C4066",
+    "textSubtle": "#8B7394",
+    "border": "#E8D5ED",
+    "borderDark": "#D4B8DC",
+    "success": "#4CAF50",
+    "warning": "#FF9800",
+    "error": "#F44336",
+    "heroBg": "#4A148C"
+  },
+  "gradients": {
+    "hero": "linear-gradient(135deg, #4A148C 0%, #7B1FA2 50%, #9C27B0 100%)",
+    "primary": "linear-gradient(135deg, #9C27B0 0%, #7B1FA2 100%)",
+    "accent": "linear-gradient(135deg, #E91E63 0%, #C2185B 100%)",
+    "vibrant": "linear-gradient(135deg, #9C27B0 0%, #E91E63 100%)"
+  },
+  "typography": {
+    "fontHeading": "Poppins",
+    "fontBody": "Inter",
+    "fontAccent": "Poppins"
+  },
+  "ui": {
+    "borderRadius": "16px",
+    "borderRadiusSm": "8px",
+    "borderRadiusLg": "24px"
+  }
+}

--- a/src/registry/sex_shop.type.json
+++ b/src/registry/sex_shop.type.json
@@ -1,0 +1,49 @@
+{
+  "id": "sex_shop",
+  "nameEs": "Tienda Erotica",
+  "nameEn": "Sex Shop / Adult Retail",
+  "verticalId": "retail-local",
+  "subVertical": "intimacy-wellness",
+  "extends": "retail_base",
+  "tokens": "sex_shop",
+  "ageGate": 18,
+  "seo": {
+    "schemaType": "Store",
+    "titleTemplate": "{{businessName}} - Tienda Erotica en {{city}} | Envio Discreto",
+    "descriptionTemplate": "Juguetes para adultos, lenceria, lubricantes y mas. Envio 100% discreto a todo Paraguay. Solo mayores de 18.",
+    "keywords": [
+      "sex shop {{city}}",
+      "juguetes adultos {{city}}",
+      "lenceria {{city}}",
+      "tienda erotica {{city}}",
+      "productos intimos {{city}}"
+    ]
+  },
+  "hero": {
+    "headlineTemplate": "{{businessName}}",
+    "subheadlineTemplate": "Tu tienda de placer. Envio discreto a todo {{country}}."
+  },
+  "categories": [
+    "vibradores",
+    "dildos",
+    "anal",
+    "parejas",
+    "bdsm",
+    "lenceria",
+    "lubricantes",
+    "bienestar"
+  ],
+  "features": {
+    "productCatalog": { "enabled": true, "whatsappOrder": true, "showPrices": true },
+    "ageGate": { "enabled": true, "minAge": 18 },
+    "discretePackaging": { "enabled": true },
+    "whatsappFloat": { "enabled": true },
+    "deliveryCalculator": { "enabled": true },
+    "testimonials": { "enabled": true },
+    "faq": { "enabled": true }
+  },
+  "legal": {
+    "requiresAgeVerification": true,
+    "privacyNotes": "Envio discreto, facturacion neutra, datos no compartidos"
+  }
+}


### PR DESCRIPTION
## Summary

- Migrates **Fun4Me** (sex shop, Asunción Herrera 875, founded 2018) from the legacy vete repo into paragu-ai-builder as real tenant #8.
- Adds a new `sex_shop` business type under `retail-local/intimacy-wellness` — `lingerie_shop` was too narrow for Fun4Me's 8-category catalog (vibradores / dildos / anal / parejas / bdsm / lencería / lubricantes / bienestar).
- Serves at **paragu-ai.com/fun4me** (path-only; no custom domain yet).

## What's in the tenant

- `sites/fun4me/site.json` — contact, delivery zones (Asu/FDM/San Lorenzo/Lambaré/Luque + national), 18+ age gate, free shipping ≥ Gs. 200k
- `sites/fun4me/tokens.json` — purple/pink theme (`#9C27B0` primary, `#E91E63` secondary) ported from vete `theme.json`, Poppins/Inter
- `sites/fun4me/pages/home.json` — section layout: age-gate modal → hero → trust badges → features → promo → categories → stats → testimonials → partners → FAQ → CTA → contact
- `sites/fun4me/content/es.json` — full Spanish content ported from vete (4 features, 8 categories, 6 testimonials, 9 FAQs, about/mission/vision/values)
- `sites/fun4me/docs/onboarding-questionnaire.md` — owner confirmation form

## New business type

- `src/registry/sex_shop.type.json` — declares `ageGate: 18`, discrete packaging, WhatsApp-order catalog, SEO templates

## Known placeholders (flagged in `site.json.placeholderFields`)

1. Google Maps Place ID (still `ChIJxxxxxxxxxx` from vete config)
2. Partner logos (Satisfyer / LELO / We-Vibe use placeholder SVGs)
3. Team section empty — awaiting owner decision on discretion vs. personalization
4. Custom domain `fun4me.com.py` deferred; path-only for now

## Test plan

- [ ] JSON validates on all 5 new files (verified locally with `node -e JSON.parse(...)`)
- [ ] `paragu-ai.com/fun4me` renders after deploy
- [ ] Age-gate modal blocks entry until "Soy mayor de 18" confirmed
- [ ] Hero CTA "Explorar Tienda" routes to `/store` (existing catalog infra)
- [ ] WhatsApp float targets `+595976569739`
- [ ] Theme: purple hero gradient renders, not fallback blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)