### PR TITLE
feat(storefront): kill MP copy, real names in cart, breadcrumbs, locale + a11y

### DIFF
--- a/web/app/s/[locale]/[site]/carrito/page.tsx
+++ b/web/app/s/[locale]/[site]/carrito/page.tsx
@@ -8,20 +8,20 @@ import { CartPageClient } from '@/components/commerce/cart-page-client'
 
 export const runtime = 'nodejs'
 
-export default async function CartPage({ params }: { params: Promise<{ site: string }> }) {
-  const { site } = await params
+export default async function CartPage({ params }: { params: Promise<{ site: string; locale: string }> }) {
+  const { site, locale } = await params
   const business = await resolveBusinessBySlug(site)
   if (!business || !(await isCommerceEnabled(business.type))) notFound()
 
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <CartStoreHydrator siteSlug={site} initialCart={null} />
-      <CommerceHeader siteSlug={site} businessName={business.name} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
       <main className="mx-auto max-w-4xl px-4 py-8">
         <h1 className="mb-6 text-2xl font-bold">Tu carrito</h1>
-        <CartPageClient siteSlug={site} />
+        <CartPageClient siteSlug={site} locale={locale} />
         <div className="mt-6">
-          <Link href={`/s/es/${site}/tienda`} className="text-sm text-[color:var(--primary,#111)] underline">
+          <Link href={`/s/${locale}/${site}/tienda`} className="text-sm text-[color:var(--primary,#111)] underline">
             ← Seguir comprando
           </Link>
         </div>

--- a/web/app/s/[locale]/[site]/checkout/page.tsx
+++ b/web/app/s/[locale]/[site]/checkout/page.tsx
@@ -7,18 +7,18 @@ import { CheckoutForm } from '@/components/commerce/checkout-form'
 
 export const runtime = 'nodejs'
 
-export default async function CheckoutPage({ params }: { params: Promise<{ site: string }> }) {
-  const { site } = await params
+export default async function CheckoutPage({ params }: { params: Promise<{ site: string; locale: string }> }) {
+  const { site, locale } = await params
   const business = await resolveBusinessBySlug(site)
   if (!business || !(await isCommerceEnabled(business.type))) notFound()
 
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <CartStoreHydrator siteSlug={site} initialCart={null} />
-      <CommerceHeader siteSlug={site} businessName={business.name} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
       <main className="mx-auto max-w-5xl px-4 py-8">
         <h1 className="mb-6 text-2xl font-bold">Finalizar compra</h1>
-        <CheckoutForm siteSlug={site} />
+        <CheckoutForm siteSlug={site} locale={locale} />
       </main>
     </div>
   )

--- a/web/app/s/[locale]/[site]/orden/[id]/page.tsx
+++ b/web/app/s/[locale]/[site]/orden/[id]/page.tsx
@@ -12,10 +12,10 @@ export default async function OrderPage({
   params,
   searchParams,
 }: {
-  params: Promise<{ site: string; id: string }>
+  params: Promise<{ site: string; locale: string; id: string }>
   searchParams: Promise<{ status?: string }>
 }) {
-  const { site, id } = await params
+  const { site, locale, id } = await params
   const { status } = await searchParams
   const business = await resolveBusinessBySlug(site)
   if (!business || !(await isCommerceEnabled(business.type))) notFound()
@@ -32,8 +32,8 @@ export default async function OrderPage({
 
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
-      <CommerceHeader siteSlug={site} businessName={business.name} />
-      <OrderConfirmation siteSlug={site} initialOrder={order} initialStatus={initial} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+      <OrderConfirmation siteSlug={site} locale={locale} initialOrder={order} initialStatus={initial} />
     </div>
   )
 }

--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation'
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { getProductBySlug } from '@/lib/commerce/products'
@@ -32,8 +33,8 @@ export async function generateMetadata({ params }: { params: Promise<{ site: str
   }
 }
 
-export default async function ProductPage({ params }: { params: Promise<{ site: string; slug: string }> }) {
-  const { site, slug } = await params
+export default async function ProductPage({ params }: { params: Promise<{ site: string; locale: string; slug: string }> }) {
+  const { site, locale, slug } = await params
   const business = await resolveBusinessBySlug(site)
   if (!business || !(await isCommerceEnabled(business.type))) notFound()
 
@@ -64,9 +65,23 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <CartStoreHydrator siteSlug={site} initialCart={null} />
-      <CommerceHeader siteSlug={site} businessName={business.name} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
 
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+
+      <nav aria-label="Migas de pan" className="mx-auto max-w-5xl px-4 pt-4 text-sm text-[color:var(--text-muted,#6b7280)]">
+        <ol className="flex flex-wrap items-center gap-1.5">
+          <li>
+            <Link href={`/s/${locale}/${site}`} className="hover:underline">{business.name}</Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li>
+            <Link href={`/s/${locale}/${site}/tienda`} className="hover:underline">Tienda</Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li className="truncate text-[color:var(--text,#111)]" aria-current="page">{product.name}</li>
+        </ol>
+      </nav>
 
       <main className="mx-auto grid max-w-5xl gap-8 px-4 py-8 md:grid-cols-2">
         <div>
@@ -110,7 +125,7 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
           </div>
 
           <div className="mt-8 rounded-lg bg-[color:var(--surface,#fff)] p-4 text-sm text-[color:var(--text-muted,#6b7280)]">
-            <p>✓ Pago seguro con Mercado Pago</p>
+            <p>✓ Pago seguro</p>
             <p>✓ Envío a todo el Paraguay</p>
             <p>✓ Atención por WhatsApp</p>
           </div>

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -11,7 +11,7 @@ export const runtime = 'nodejs'
 export const revalidate = 300
 
 export default async function StorePage({ params }: { params: Promise<{ site: string; locale: string }> }) {
-  const { site } = await params
+  const { site, locale } = await params
   const business = await resolveBusinessBySlug(site)
   if (!business || !(await isCommerceEnabled(business.type))) notFound()
 
@@ -20,7 +20,7 @@ export default async function StorePage({ params }: { params: Promise<{ site: st
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <CartStoreHydrator siteSlug={site} initialCart={null} />
-      <CommerceHeader siteSlug={site} businessName={business.name} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
 
       <main className="mx-auto max-w-6xl px-4 py-8">
         <h1 className="mb-6 text-3xl font-bold text-[color:var(--text,#111)]">Nuestra tienda</h1>
@@ -32,7 +32,7 @@ export default async function StorePage({ params }: { params: Promise<{ site: st
         ) : (
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 lg:gap-6">
             {products.map((product, idx) => (
-              <ProductCard key={product.id} siteSlug={site} product={product} priority={idx < 4} rates={rates} />
+              <ProductCard key={product.id} siteSlug={site} product={product} priority={idx < 4} rates={rates} locale={locale} />
             ))}
           </div>
         )}

--- a/web/components/commerce/cart-drawer.tsx
+++ b/web/components/commerce/cart-drawer.tsx
@@ -1,27 +1,54 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { useCartStore, cartSubtotalCents } from '@/lib/stores/cart-store'
 import { formatCents } from '@/lib/commerce/compute-totals'
 
 interface Props {
   siteSlug: string
+  locale: string
   open: boolean
   onClose: () => void
 }
 
-export function CartDrawer({ siteSlug, open, onClose }: Props) {
+const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+export function CartDrawer({ siteSlug, locale, open, onClose }: Props) {
   const cart = useCartStore((s) => s.cart)
   const status = useCartStore((s) => s.status)
   const updateItem = useCartStore((s) => s.updateItem)
   const removeItem = useCartStore((s) => s.removeItem)
+  const drawerRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
+    if (!open) return
+    const drawer = drawerRef.current
+    if (!drawer) return
+    // Focus the first actionable control so screen readers land inside the
+    // dialog, and so Tab cycles stay within it.
+    const focusables = drawer.querySelectorAll<HTMLElement>(FOCUSABLE)
+    focusables[0]?.focus()
+
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') {
+        onClose()
+        return
+      }
+      if (e.key !== 'Tab') return
+      const list = drawer.querySelectorAll<HTMLElement>(FOCUSABLE)
+      if (list.length === 0) return
+      const first = list[0]
+      const last = list[list.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
     }
-    if (open) document.addEventListener('keydown', onKey)
+    document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)
   }, [open, onClose])
 
@@ -36,6 +63,7 @@ export function CartDrawer({ siteSlug, open, onClose }: Props) {
         className={`fixed inset-0 z-40 bg-black/40 transition-opacity ${open ? 'opacity-100' : 'opacity-0'}`}
       />
       <aside
+        ref={drawerRef}
         role="dialog"
         aria-modal="true"
         aria-label="Carrito de compras"
@@ -60,43 +88,58 @@ export function CartDrawer({ siteSlug, open, onClose }: Props) {
             </div>
           ) : (
             <ul className="space-y-4">
-              {items.map((it) => (
-                <li key={it.id} className="flex gap-3">
-                  <div className="flex-1">
-                    <p className="text-sm font-medium text-[color:var(--text,#111)]">{it.productId.slice(0, 8)}…</p>
-                    <p className="text-xs text-[color:var(--text-muted,#6b7280)]">{formatCents(it.unitPriceCents, currency)}</p>
-                    <div className="mt-2 flex items-center gap-2">
-                      <button
-                        type="button"
-                        aria-label="Quitar uno"
-                        onClick={() => updateItem(siteSlug, it.id, Math.max(0, it.quantity - 1))}
-                        className="rounded border border-[color:var(--border,#e5e7eb)] px-2 py-0.5 text-sm"
-                      >
-                        −
-                      </button>
-                      <span className="min-w-[2rem] text-center text-sm">{it.quantity}</span>
-                      <button
-                        type="button"
-                        aria-label="Sumar uno"
-                        onClick={() => updateItem(siteSlug, it.id, it.quantity + 1)}
-                        className="rounded border border-[color:var(--border,#e5e7eb)] px-2 py-0.5 text-sm"
-                      >
-                        +
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => removeItem(siteSlug, it.id)}
-                        className="ml-auto text-xs text-[color:var(--text-muted,#6b7280)] hover:underline"
-                      >
-                        Eliminar
-                      </button>
+              {items.map((it) => {
+                const displayName = it.productName ?? 'Producto'
+                return (
+                  <li key={it.id} className="flex gap-3">
+                    {it.productImageUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={it.productImageUrl}
+                        alt=""
+                        className="h-16 w-16 flex-shrink-0 rounded border border-[color:var(--border,#e5e7eb)] object-cover"
+                      />
+                    ) : null}
+                    <div className="flex-1">
+                      <p className="text-sm font-medium text-[color:var(--text,#111)]">{displayName}</p>
+                      <p className="text-xs text-[color:var(--text-muted,#6b7280)]">{formatCents(it.unitPriceCents, currency)}</p>
+                      <div className="mt-2 flex items-center gap-2">
+                        <button
+                          type="button"
+                          aria-label={`Quitar uno de ${displayName}`}
+                          onClick={() => updateItem(siteSlug, it.id, Math.max(0, it.quantity - 1))}
+                          className="rounded border border-[color:var(--border,#e5e7eb)] px-2 py-0.5 text-sm"
+                        >
+                          <span aria-hidden="true">−</span>
+                        </button>
+                        <span aria-live="polite" className="min-w-[2rem] text-center text-sm">
+                          <span className="sr-only">Cantidad: </span>
+                          {it.quantity}
+                        </span>
+                        <button
+                          type="button"
+                          aria-label={`Sumar uno a ${displayName}`}
+                          onClick={() => updateItem(siteSlug, it.id, it.quantity + 1)}
+                          className="rounded border border-[color:var(--border,#e5e7eb)] px-2 py-0.5 text-sm"
+                        >
+                          <span aria-hidden="true">+</span>
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={`Eliminar ${displayName} del carrito`}
+                          onClick={() => removeItem(siteSlug, it.id)}
+                          className="ml-auto text-xs text-[color:var(--text-muted,#6b7280)] hover:underline"
+                        >
+                          Eliminar
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                  <div className="text-right text-sm font-semibold text-[color:var(--text,#111)]">
-                    {formatCents(it.unitPriceCents * it.quantity, currency)}
-                  </div>
-                </li>
-              ))}
+                    <div className="text-right text-sm font-semibold text-[color:var(--text,#111)]">
+                      {formatCents(it.unitPriceCents * it.quantity, currency)}
+                    </div>
+                  </li>
+                )
+              })}
             </ul>
           )}
         </div>
@@ -108,7 +151,7 @@ export function CartDrawer({ siteSlug, open, onClose }: Props) {
               <span className="text-lg font-semibold">{formatCents(subtotal, currency)}</span>
             </div>
             <Link
-              href={`/s/es/${siteSlug}/checkout`}
+              href={`/s/${locale}/${siteSlug}/checkout`}
               className="block w-full rounded-lg bg-[color:var(--primary,#111)] px-4 py-3 text-center font-semibold text-[color:var(--primary-foreground,#fff)] hover:opacity-90"
             >
               {status === 'syncing' ? 'Actualizando…' : 'Pagar ahora'}

--- a/web/components/commerce/cart-page-client.tsx
+++ b/web/components/commerce/cart-page-client.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { useCartStore, cartSubtotalCents } from '@/lib/stores/cart-store'
 import { formatCents } from '@/lib/commerce/compute-totals'
 
-export function CartPageClient({ siteSlug }: { siteSlug: string }) {
+export function CartPageClient({ siteSlug, locale = 'es' }: { siteSlug: string; locale?: string }) {
   const cart = useCartStore((s) => s.cart)
   const status = useCartStore((s) => s.status)
   const refresh = useCartStore((s) => s.refresh)
@@ -19,7 +19,7 @@ export function CartPageClient({ siteSlug }: { siteSlug: string }) {
     return (
       <div className="rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-12 text-center">
         <p className="text-[color:var(--text-muted,#6b7280)]">Tu carrito está vacío.</p>
-        <Link href={`/s/es/${siteSlug}/tienda`} className="mt-4 inline-block text-sm font-medium text-[color:var(--primary,#111)] underline">
+        <Link href={`/s/${locale}/${siteSlug}/tienda`} className="mt-4 inline-block text-sm font-medium text-[color:var(--primary,#111)] underline">
           Ir a la tienda
         </Link>
       </div>
@@ -31,34 +31,53 @@ export function CartPageClient({ siteSlug }: { siteSlug: string }) {
   return (
     <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
       <ul className="space-y-4">
-        {cart.items.map((it) => (
-          <li key={it.id} className="flex items-center gap-4 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4">
-            <div className="flex-1">
-              <p className="font-medium text-[color:var(--text,#111)]">{it.productId.slice(0, 8)}…</p>
-              <p className="text-sm text-[color:var(--text-muted,#6b7280)]">{formatCents(it.unitPriceCents, cart.currency)} c/u</p>
-            </div>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => updateItem(siteSlug, it.id, Math.max(0, it.quantity - 1))}
-                className="rounded border border-[color:var(--border,#e5e7eb)] px-2 py-1 text-sm"
-                aria-label="Quitar uno"
-              >
-                −
-              </button>
-              <span className="min-w-[2rem] text-center">{it.quantity}</span>
-              <button
-                type="button"
-                onClick={() => updateItem(siteSlug, it.id, it.quantity + 1)}
-                className="rounded border border-[color:var(--border,#e5e7eb)] px-2 py-1 text-sm"
-                aria-label="Sumar uno"
-              >
-                +
-              </button>
-            </div>
-            <p className="w-24 text-right font-semibold">{formatCents(it.unitPriceCents * it.quantity, cart.currency)}</p>
-          </li>
-        ))}
+        {cart.items.map((it) => {
+          const displayName = it.productName ?? 'Producto'
+          return (
+            <li key={it.id} className="flex items-center gap-4 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4">
+              {it.productImageUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={it.productImageUrl}
+                  alt=""
+                  className="h-16 w-16 flex-shrink-0 rounded object-cover"
+                />
+              ) : null}
+              <div className="flex-1">
+                {it.productSlug ? (
+                  <Link href={`/s/${locale}/${siteSlug}/producto/${it.productSlug}`} className="font-medium text-[color:var(--text,#111)] hover:underline">
+                    {displayName}
+                  </Link>
+                ) : (
+                  <p className="font-medium text-[color:var(--text,#111)]">{displayName}</p>
+                )}
+                <p className="text-sm text-[color:var(--text-muted,#6b7280)]">{formatCents(it.unitPriceCents, cart.currency)} c/u</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => updateItem(siteSlug, it.id, Math.max(0, it.quantity - 1))}
+                  className="rounded border border-[color:var(--border,#e5e7eb)] px-2 py-1 text-sm"
+                  aria-label={`Quitar uno de ${displayName}`}
+                >
+                  <span aria-hidden="true">−</span>
+                </button>
+                <span className="min-w-[2rem] text-center" aria-live="polite">
+                  <span className="sr-only">Cantidad: </span>{it.quantity}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => updateItem(siteSlug, it.id, it.quantity + 1)}
+                  className="rounded border border-[color:var(--border,#e5e7eb)] px-2 py-1 text-sm"
+                  aria-label={`Sumar uno a ${displayName}`}
+                >
+                  <span aria-hidden="true">+</span>
+                </button>
+              </div>
+              <p className="w-24 text-right font-semibold">{formatCents(it.unitPriceCents * it.quantity, cart.currency)}</p>
+            </li>
+          )
+        })}
       </ul>
 
       <aside className="h-fit rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-6">
@@ -66,9 +85,9 @@ export function CartPageClient({ siteSlug }: { siteSlug: string }) {
           <span>Subtotal</span>
           <span>{formatCents(subtotal, cart.currency)}</span>
         </div>
-        <p className="mt-1 text-xs text-[color:var(--text-muted,#6b7280)]">Envío se calcula en el siguiente paso</p>
+        <p className="mt-1 text-xs text-[color:var(--text-muted,#6b7280)]">El envío se calcula al confirmar la dirección.</p>
         <Link
-          href={`/s/es/${siteSlug}/checkout`}
+          href={`/s/${locale}/${siteSlug}/checkout`}
           className="mt-4 block w-full rounded-lg bg-[color:var(--primary,#111)] px-4 py-3 text-center font-semibold text-[color:var(--primary-foreground,#fff)] hover:opacity-90"
         >
           {status === 'syncing' ? 'Actualizando…' : 'Finalizar compra'}

--- a/web/components/commerce/checkout-form.tsx
+++ b/web/components/commerce/checkout-form.tsx
@@ -7,9 +7,10 @@ import { formatCents } from '@/lib/commerce/compute-totals'
 
 interface Props {
   siteSlug: string
+  locale?: string
 }
 
-export function CheckoutForm({ siteSlug }: Props) {
+export function CheckoutForm({ siteSlug, locale = 'es' }: Props) {
   const router = useRouter()
   const cart = useCartStore((s) => s.cart)
   const [submitting, setSubmitting] = useState(false)
@@ -113,7 +114,7 @@ export function CheckoutForm({ siteSlug }: Props) {
         window.location.href = data.redirectUrl
         return
       }
-      router.push(`/s/es/${siteSlug}/orden/${data.orderId}`)
+      router.push(`/s/${locale}/${siteSlug}/orden/${data.orderId}`)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Error al procesar el pedido')
       setSubmitting(false)
@@ -224,6 +225,14 @@ export function CheckoutForm({ siteSlug }: Props) {
               <span>−{formatCents(discountAmount, cart.currency)}</span>
             </div>
           ) : null}
+          <div className="flex justify-between text-[color:var(--text-muted,#6b7280)]">
+            <span>Envío</span>
+            <span>
+              {discountStatus.kind === 'applied' && discountStatus.freeShipping
+                ? 'Gratis'
+                : 'Se calcula al confirmar'}
+            </span>
+          </div>
           <div className="flex justify-between pt-1 text-base font-semibold text-[color:var(--text,#111)]">
             <span>Total</span>
             <span>{formatCents(total, cart.currency)}</span>
@@ -241,10 +250,10 @@ export function CheckoutForm({ siteSlug }: Props) {
           disabled={submitting}
           className="mt-4 w-full rounded-lg bg-[color:var(--primary,#111)] px-4 py-3 font-semibold text-[color:var(--primary-foreground,#fff)] hover:opacity-90 disabled:opacity-60"
         >
-          {submitting ? 'Procesando…' : 'Pagar con Mercado Pago'}
+          {submitting ? 'Procesando…' : 'Confirmar pedido'}
         </button>
         <p className="mt-3 text-center text-xs text-[color:var(--text-muted,#6b7280)]">
-          Pago seguro · Mercado Pago · Visa · Mastercard · Tigo Money
+          Te llevamos a la siguiente pantalla para completar el pago.
         </p>
       </aside>
     </form>

--- a/web/components/commerce/commerce-header.tsx
+++ b/web/components/commerce/commerce-header.tsx
@@ -6,17 +6,25 @@ import { MiniCartBadge } from './mini-cart-badge'
 import { CartDrawer } from './cart-drawer'
 import { CurrencyToggle } from './currency-toggle'
 
-export function CommerceHeader({ siteSlug, businessName }: { siteSlug: string; businessName: string }) {
+interface Props {
+  siteSlug: string
+  businessName: string
+  /** Active locale slug from the URL — threaded through to cart links so
+   * `/s/pt/...` sites don't get sent back to `/s/es/...`. */
+  locale?: string
+}
+
+export function CommerceHeader({ siteSlug, businessName, locale = 'es' }: Props) {
   const [open, setOpen] = useState(false)
   return (
     <>
       <header className="sticky top-0 z-30 border-b border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)]/90 backdrop-blur">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
-          <Link href={`/s/es/${siteSlug}`} className="text-lg font-semibold">
+          <Link href={`/s/${locale}/${siteSlug}`} className="text-lg font-semibold">
             {businessName}
           </Link>
           <nav className="flex items-center gap-4 text-sm">
-            <Link href={`/s/es/${siteSlug}/tienda`} className="hover:underline">
+            <Link href={`/s/${locale}/${siteSlug}/tienda`} className="hover:underline">
               Tienda
             </Link>
             <CurrencyToggle />
@@ -24,7 +32,7 @@ export function CommerceHeader({ siteSlug, businessName }: { siteSlug: string; b
           </nav>
         </div>
       </header>
-      <CartDrawer siteSlug={siteSlug} open={open} onClose={() => setOpen(false)} />
+      <CartDrawer siteSlug={siteSlug} locale={locale} open={open} onClose={() => setOpen(false)} />
     </>
   )
 }

--- a/web/components/commerce/order-confirmation.tsx
+++ b/web/components/commerce/order-confirmation.tsx
@@ -7,11 +7,12 @@ import { formatCents } from '@/lib/commerce/compute-totals'
 
 interface Props {
   siteSlug: string
+  locale: string
   initialOrder: Order
   initialStatus?: 'success' | 'pending' | 'failure' | null
 }
 
-export function OrderConfirmation({ siteSlug, initialOrder, initialStatus }: Props) {
+export function OrderConfirmation({ siteSlug, locale, initialOrder, initialStatus }: Props) {
   const [order, setOrder] = useState(initialOrder)
   const [polling, setPolling] = useState(initialOrder.status === 'awaiting_payment')
 
@@ -65,7 +66,7 @@ export function OrderConfirmation({ siteSlug, initialOrder, initialStatus }: Pro
         </p>
 
         <Link
-          href={`/s/es/${siteSlug}/tienda`}
+          href={`/s/${locale}/${siteSlug}/tienda`}
           className="inline-block rounded-lg border border-[color:var(--primary,#111)] px-4 py-2 font-medium text-[color:var(--primary,#111)] hover:bg-[color:var(--primary,#111)] hover:text-[color:var(--primary-foreground,#fff)]"
         >
           Seguir comprando
@@ -87,5 +88,5 @@ function bodyFor(status: Order['status'], initial: 'success' | 'pending' | 'fail
   if (status === 'paid') return 'Gracias por tu compra. Tu pedido se está preparando.'
   if (status === 'failed' || initial === 'failure') return 'No pudimos procesar tu pago. Intentá con otro método.'
   if (status === 'cancelled') return 'Esta orden fue cancelada. Si crees que es un error, contactanos.'
-  return 'Estamos esperando la confirmación de Mercado Pago. Esto puede tardar unos minutos.'
+  return 'Estamos esperando la confirmación del pago. Esto puede tardar unos minutos.'
 }

--- a/web/components/commerce/product-card.tsx
+++ b/web/components/commerce/product-card.tsx
@@ -13,9 +13,10 @@ interface Props {
   product: Product
   priority?: boolean
   rates?: Record<string, number>
+  locale?: string
 }
 
-export function ProductCard({ siteSlug, product, priority, rates }: Props) {
+export function ProductCard({ siteSlug, product, priority, rates, locale = 'es' }: Props) {
   const addItem = useCartStore((s) => s.addItem)
   const [adding, setAdding] = useState(false)
   const cover = product.images.find((i) => i.isCover) ?? product.images[0] ?? null
@@ -38,7 +39,7 @@ export function ProductCard({ siteSlug, product, priority, rates }: Props) {
 
   return (
     <article className="group flex flex-col">
-      <Link href={`/s/es/${siteSlug}/producto/${product.slug}`} className="block">
+      <Link href={`/s/${locale}/${siteSlug}/producto/${product.slug}`} className="block">
         <div className="relative">
           <ProductImage image={cover} alt={product.name} priority={priority} isSeed={product.isSeed} />
           {discount ? (

--- a/web/lib/commerce/cart.ts
+++ b/web/lib/commerce/cart.ts
@@ -91,17 +91,40 @@ export async function getOrCreateCart(
   return rowToCart(data[0], [])
 }
 
+interface CartItemRowJoined extends CartItemRow {
+  products?: {
+    name: string | null
+    slug: string | null
+    images: Array<{ url?: string; isCover?: boolean }> | null
+  } | null
+}
+
 async function fetchItems(businessId: string, cartId: string): Promise<CartItem[]> {
   const supabase = await createAdminClient()
-  const scoped = scopedQueries(supabase, businessId)
-  const { data, error } = await scoped.select<CartItemRow>('cart_items', '*', {
-    filter: (q) => q.eq('cart_id', cartId).order('created_at'),
-  })
+  // Single query with embedded product join — we need name/slug/cover image
+  // so the cart drawer can render "Remera azul talle M" instead of a UUID
+  // fragment. PostgREST syntax: `products(name, slug, images)` embeds the
+  // related row via the product_id FK.
+  const { data, error } = await supabase
+    .from('cart_items')
+    .select('*, products(name, slug, images)')
+    .eq('cart_id', cartId)
+    .eq('business_id', businessId)
+    .order('created_at')
   if (error) {
     logger.error('[commerce] fetchItems failed', { action: 'commerce.cart.items', cartId, error: error.message })
     return []
   }
-  return (Array.isArray(data) ? data : []).map(rowToCartItem)
+  return (Array.isArray(data) ? data : []).map((row) => {
+    const joined = row as CartItemRowJoined
+    const cover = joined.products?.images?.find((i) => i?.isCover) ?? joined.products?.images?.[0]
+    return {
+      ...rowToCartItem(joined),
+      productName: joined.products?.name ?? null,
+      productSlug: joined.products?.slug ?? null,
+      productImageUrl: cover?.url ?? null,
+    }
+  })
 }
 
 export async function addItem(

--- a/web/lib/commerce/email-templates.ts
+++ b/web/lib/commerce/email-templates.ts
@@ -21,7 +21,7 @@ export function orderConfirmationEmail({ order, businessName, storeUrl }: Contex
 <!doctype html><html><body style="font-family:system-ui,-apple-system,sans-serif;color:#111;max-width:600px;margin:0 auto;padding:24px;">
   <h1 style="font-size:20px;">Gracias por tu pedido</h1>
   <p>Hola ${escape(order.customerName)},</p>
-  <p>Recibimos tu pedido <strong>${order.orderNumber}</strong>. Estamos esperando la confirmación de Mercado Pago.</p>
+  <p>Recibimos tu pedido <strong>${order.orderNumber}</strong>. Estamos esperando la confirmación del pago.</p>
   <table style="width:100%;border-collapse:collapse;margin:16px 0;">
     ${itemsHtml}
     <tr><td style="padding:8px 0;border-top:1px solid #eee;font-weight:600;">Total</td><td style="padding:8px 0;border-top:1px solid #eee;text-align:right;font-weight:600;">${formatCents(order.totalCents, order.currency)}</td></tr>

--- a/web/lib/schemas/commerce/cart.ts
+++ b/web/lib/schemas/commerce/cart.ts
@@ -16,6 +16,14 @@ export const CartItemSchema = z.object({
   quantity: z.number().int().positive(),
   unitPriceCents: z.number().int().nonnegative(),
   createdAt: z.string(),
+  /**
+   * Product display fields joined in at read time. Optional because older
+   * clients / older stored payloads may not include them; callers must
+   * fall back to a sensible default when null.
+   */
+  productName: z.string().nullable().optional(),
+  productSlug: z.string().nullable().optional(),
+  productImageUrl: z.string().nullable().optional(),
 })
 export type CartItem = z.infer<typeof CartItemSchema>
 


### PR DESCRIPTION
## Summary

Audit-driven storefront cleanup. Six concrete shopper-visible fixes:

1. **Mercado Pago copy purged** from checkout button, PDP trust list, order confirmation pending state, and order email. MP no longer processes payments — promising it was a trust killer.
2. **Cart drawer + cart page show product NAME and cover image** instead of an opaque UUID fragment. Reads via PostgREST embedded \`cart_items.products(name, slug, images)\` join. Each line links to the PDP.
3. **Breadcrumbs on PDP** (Business → Tienda → Product).
4. **Storefront links respect URL \`locale\` param** everywhere (header, drawer, cart page, checkout form, product card, order confirmation). Previously all hardcoded \`/s/es/\`, so a \`/s/pt/\` shopper got bounced to Spanish on any nav.
5. **Cart drawer a11y**: focus trap (Tab cycles inside modal, Esc closes), descriptive per-item aria-labels, aria-live on quantity readout.
6. **Checkout summary surfaces a shipping line** (\"Gratis\" when a free-shipping discount applies, otherwise \"Se calcula al confirmar\") so the total isn't a surprise at submit.

## Out of scope (deferred to later PR)

Product variants, tienda search/filter, related products, full i18n string extraction, reviews. All need schema or design work first.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run test:unit\` — 426 pass
- [x] \`npm run build\` — clean
- [ ] Manual: open cart drawer, verify product name + image, Tab cycles inside, Esc closes
- [ ] Manual: open PDP, click breadcrumb \"Tienda\" link
- [ ] Manual: apply free-shipping discount in checkout, verify summary shows \"Envío: Gratis\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)