### PR TITLE
feat(storefront): tienda search + sort + drive-by fix for broken Main typecheck

### DIFF
--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -1,21 +1,40 @@
 import { notFound } from 'next/navigation'
 import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
-import { listActiveProducts } from '@/lib/commerce/products'
+import { listActiveProducts, type ProductSort } from '@/lib/commerce/products'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { ProductCard } from '@/components/commerce/product-card'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
+import { TiendaToolbar } from '@/components/commerce/tienda-toolbar'
 import { loadPygRates } from '@/lib/commerce/currency-server'
 
 export const runtime = 'nodejs'
-export const revalidate = 300
+export const dynamic = 'force-dynamic' // search/sort params kill static caching
 
-export default async function StorePage({ params }: { params: Promise<{ site: string; locale: string }> }) {
+const VALID_SORTS: ProductSort[] = ['newest', 'price-asc', 'price-desc', 'name-asc']
+
+function parseSort(raw: string | undefined): ProductSort {
+  return raw && (VALID_SORTS as string[]).includes(raw) ? (raw as ProductSort) : 'newest'
+}
+
+export default async function StorePage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ site: string; locale: string }>
+  searchParams: Promise<{ q?: string; sort?: string }>
+}) {
   const { site, locale } = await params
+  const { q, sort } = await searchParams
   const business = await resolveBusinessBySlug(site)
   if (!business || !(await isCommerceEnabled(business.type))) notFound()
 
-  const [products, rates] = await Promise.all([listActiveProducts(business.id, { limit: 48 }), loadPygRates()])
+  const search = (q ?? '').trim()
+  const sortKey = parseSort(sort)
+  const [products, rates] = await Promise.all([
+    listActiveProducts(business.id, { limit: 48, search, sort: sortKey }),
+    loadPygRates(),
+  ])
 
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
@@ -25,12 +44,16 @@ export default async function StorePage({ params }: { params: Promise<{ site: st
       <main className="mx-auto max-w-6xl px-4 py-8">
         <h1 className="mb-6 text-3xl font-bold text-[color:var(--text,#111)]">Nuestra tienda</h1>
 
+        <TiendaToolbar initialQuery={search} initialSort={sortKey} resultCount={products.length} />
+
         {products.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-12 text-center">
-            <p className="text-[color:var(--text-muted,#6b7280)]">Estamos cargando nuestro catálogo. Volvé pronto.</p>
+          <div className="mt-6 rounded-lg border border-dashed border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-12 text-center">
+            <p className="text-[color:var(--text-muted,#6b7280)]">
+              {search ? `No encontramos productos para "${search}".` : 'Estamos cargando nuestro catálogo. Volvé pronto.'}
+            </p>
           </div>
         ) : (
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 lg:gap-6">
+          <div className="mt-6 grid grid-cols-1 gap-4 min-[420px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 lg:gap-6">
             {products.map((product, idx) => (
               <ProductCard key={product.id} siteSlug={site} product={product} priority={idx < 4} rates={rates} locale={locale} />
             ))}

--- a/web/components/commerce/tienda-toolbar.tsx
+++ b/web/components/commerce/tienda-toolbar.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
+import type { ProductSort } from '@/lib/commerce/products'
+
+interface Props {
+  initialQuery: string
+  initialSort: ProductSort
+  resultCount: number
+}
+
+const SORT_OPTIONS: Array<{ value: ProductSort; label: string }> = [
+  { value: 'newest', label: 'Más nuevos' },
+  { value: 'price-asc', label: 'Precio: menor a mayor' },
+  { value: 'price-desc', label: 'Precio: mayor a menor' },
+  { value: 'name-asc', label: 'Nombre A→Z' },
+]
+
+/**
+ * URL-driven search + sort. State lives in the query string so back/forward
+ * + share-link both work, and the page is a Server Component that re-runs
+ * the DB query on every change. No client cache, no out-of-sync risk.
+ */
+export function TiendaToolbar({ initialQuery, initialSort, resultCount }: Props) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [query, setQuery] = useState(initialQuery)
+  const [pending, startTransition] = useTransition()
+
+  function pushParams(next: { q?: string; sort?: string }) {
+    const params = new URLSearchParams(searchParams.toString())
+    if (next.q !== undefined) {
+      if (next.q) params.set('q', next.q)
+      else params.delete('q')
+    }
+    if (next.sort !== undefined) {
+      if (next.sort && next.sort !== 'newest') params.set('sort', next.sort)
+      else params.delete('sort')
+    }
+    const qs = params.toString()
+    startTransition(() => {
+      router.push(qs ? `${pathname}?${qs}` : pathname)
+    })
+  }
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    pushParams({ q: query.trim() })
+  }
+
+  function onClear() {
+    setQuery('')
+    pushParams({ q: '' })
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-3 sm:flex-row sm:items-center sm:justify-between">
+      <form onSubmit={onSubmit} role="search" className="flex flex-1 items-center gap-2">
+        <label className="flex flex-1 items-center gap-2 rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface-muted,#f9fafb)] px-3 py-2 focus-within:border-[color:var(--primary,#111)]">
+          <span className="sr-only">Buscar productos</span>
+          <svg aria-hidden="true" className="h-4 w-4 text-[color:var(--text-muted,#6b7280)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z" />
+          </svg>
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Buscar productos…"
+            className="w-full bg-transparent text-sm outline-none placeholder:text-[color:var(--text-muted,#9ca3af)]"
+          />
+          {query ? (
+            <button
+              type="button"
+              onClick={onClear}
+              aria-label="Limpiar búsqueda"
+              className="text-xs text-[color:var(--text-muted,#6b7280)] hover:underline"
+            >
+              ×
+            </button>
+          ) : null}
+        </label>
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded bg-[color:var(--primary,#111)] px-3 py-2 text-sm font-medium text-[color:var(--primary-foreground,#fff)] disabled:opacity-50"
+        >
+          Buscar
+        </button>
+      </form>
+
+      <div className="flex items-center gap-3 text-sm">
+        <span className="text-xs text-[color:var(--text-muted,#6b7280)]" aria-live="polite">
+          {resultCount} {resultCount === 1 ? 'producto' : 'productos'}
+        </span>
+        <label className="flex items-center gap-2">
+          <span className="text-xs text-[color:var(--text-muted,#6b7280)]">Ordenar:</span>
+          <select
+            value={initialSort}
+            onChange={(e) => pushParams({ sort: e.target.value })}
+            className="rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-2 py-1 text-sm"
+          >
+            {SORT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </div>
+  )
+}

--- a/web/lib/commerce/products.ts
+++ b/web/lib/commerce/products.ts
@@ -50,16 +50,44 @@ function rowToProduct(row: ProductRow): Product {
   }
 }
 
+export type ProductSort = 'newest' | 'price-asc' | 'price-desc' | 'name-asc'
+
+export interface ListActiveProductsOpts {
+  category?: string
+  limit?: number
+  offset?: number
+  /** Free-text name search (ilike). Empty string is treated as no filter. */
+  search?: string
+  /** Sort order. Defaults to 'newest'. */
+  sort?: ProductSort
+}
+
+const SORT_FIELDS: Record<ProductSort, { column: string; ascending: boolean }> = {
+  newest: { column: 'created_at', ascending: false },
+  'price-asc': { column: 'price_cents', ascending: true },
+  'price-desc': { column: 'price_cents', ascending: false },
+  'name-asc': { column: 'name', ascending: true },
+}
+
 export async function listActiveProducts(
   businessId: string,
-  opts: { category?: string; limit?: number; offset?: number } = {},
+  opts: ListActiveProductsOpts = {},
 ): Promise<Product[]> {
   const supabase = await createAdminClient()
   const scoped = scopedQueries(supabase, businessId)
+  const sortKey = opts.sort && SORT_FIELDS[opts.sort] ? opts.sort : 'newest'
+  const sort = SORT_FIELDS[sortKey]
   const { data } = await scoped.select<ProductRow>('products', '*', {
     filter: (q) => {
-      let query = q.eq('status', 'active').order('created_at', { ascending: false })
+      let query = q.eq('status', 'active').order(sort.column, { ascending: sort.ascending })
       if (opts.category) query = query.eq('category', opts.category)
+      if (opts.search && opts.search.trim()) {
+        // ilike with leading/trailing wildcards = case-insensitive substring
+        // match. Cheap enough at the catalog sizes we expect; replace with
+        // a tsvector + GIN index when a tenant grows past ~5k products.
+        const pattern = `%${opts.search.trim().replace(/[\\%_]/g, (ch) => `\\${ch}`)}%`
+        query = query.ilike('name', pattern)
+      }
       if (opts.limit) query = query.limit(opts.limit)
       if (opts.offset) query = query.range(opts.offset, (opts.offset ?? 0) + (opts.limit ?? 50) - 1)
       return query

--- a/web/lib/generation/from-lead.ts
+++ b/web/lib/generation/from-lead.ts
@@ -1,0 +1,35 @@
+/**
+ * Stub for the lead → preview-site config mapper. The real implementation
+ * was supposed to land alongside `app/api/leads/[id]/generate-preview`
+ * (commit 34a5313, PR #150) but the module file was never committed,
+ * leaving Main with a broken typecheck.
+ *
+ * This stub exposes the types the route needs and a throwing implementation
+ * so the codebase compiles. The route itself is admin-only, so until a real
+ * mapper lands the only effect is a 500 to an admin who tries to trigger it
+ * — preferable to keeping Main red for everyone else.
+ */
+
+export interface BusinessSchema {
+  businessName: string
+  contact: {
+    email?: string
+    phone?: string
+    whatsapp?: string
+  }
+  location?: Record<string, unknown>
+  hours?: Record<string, unknown>
+  seo?: Record<string, unknown>
+}
+
+export interface PreviewConfig {
+  siteSlug: string
+  verticalId: string
+  businessType: 'gimnasio' | 'peluqueria' | string
+  schema: BusinessSchema
+  source: string
+}
+
+export function mapLeadToPreviewConfig(_lead: Record<string, unknown>): PreviewConfig {
+  throw new Error('not_implemented: mapLeadToPreviewConfig is a stub awaiting the real mapper')
+}


### PR DESCRIPTION
## Summary

Tienda gets a real toolbar:
- **Search** — name contains, ilike, case-insensitive
- **Sort** — newest / price asc / price desc / name A→Z
- State in URL query (\`?q=\`, \`?sort=\`) so back/forward + share-link work; page stays Server Component
- Empty result state shows the actual query (\"No encontramos productos para 'foo'\")
- Mobile grid drops to 1-col below 420px so iPhone SE shoppers aren't cramped

\`listActiveProducts\` gains \`search\` + \`sort\` options. Search is ilike — good for catalogs <5k items. Swap for tsvector + GIN later if a tenant grows past that.

## Drive-by: unbreak Main typecheck

PR #150 (commit \`34a5313\`) added \`app/api/leads/[id]/generate-preview/route.ts\` which imports \`@/lib/generation/from-lead\` — a module that was never committed. Main's Lint & Typecheck has been red on that commit; my PR can't pass CI without fixing it.

Stubbed the module with the BusinessSchema + PreviewConfig types and a throwing \`mapLeadToPreviewConfig\`. The route is admin-gated, so until someone fills in the real mapper an admin who triggers it gets a 500. Better than leaving Main red for everyone else.

## Test plan
- [x] \`npm run typecheck\` — clean (Main was red without the stub)
- [x] \`npm run lint\` — clean
- [x] \`npm run test:unit\` — 426 pass
- [x] \`npm run build\` — clean
- [ ] Manual: visit \`/s/es/{site}/tienda\`, type a search, hit enter, verify URL updates and grid filters
- [ ] Manual: change sort dropdown, verify URL updates and ordering changes
- [ ] Manual: clear search via × button, verify back to full grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)