### PR TITLE
test(api): lock #392 — every route must use withRequestLog (regression test)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -191,6 +191,11 @@ Closure log:
   API route at test time and fails if any route lacks an auth helper or
   isn't in the explicit `PUBLIC_ROUTE_ALLOWLIST`. This regression test
   would have caught all 6 broken-auth bugs from the audit at PR time.
+- **#392 regression-locked** — Added a 2nd describe to the same test file:
+  every API route must contain `withRequestLog`. No allowlist (every route
+  needs the wrapper). Locks #392 so it can't regress when someone adds a
+  new route. Pairs with the auth coverage test as a "you cannot ship a
+  broken route" social contract.
 - **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
   added id to `<main>` on landing + 11 high-traffic marketing routes.
 - **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).

--- a/web/tests/integration/admin-route-auth-coverage.test.ts
+++ b/web/tests/integration/admin-route-auth-coverage.test.ts
@@ -117,7 +117,45 @@ describe('admin route auth coverage', () => {
           `Either:\n` +
           `  (a) wire checkAdmin()/requireAdmin() into the route, OR\n` +
           `  (b) add the route to PUBLIC_ROUTE_ALLOWLIST in this test with a reason for why it's public.\n\n` +
-          `This test exists because we found 5 broken-auth bugs during the #392 audit.`,
+          `This test exists because we found 6 broken-auth bugs during the #392 audit.`,
+      )
+    }
+
+    expect(violations).toHaveLength(0)
+  })
+})
+
+/**
+ * Companion test to the auth coverage above. Locks in #392 (every API
+ * route wrapped in withRequestLog) so it can't regress when someone adds
+ * a new route. No allowlist — every route should be wrapped, period.
+ *
+ * Recognized as wrapped if the source mentions `withRequestLog`. Both
+ * the import and the call site use the same identifier, so this catches
+ * either form (`export const POST = withRequestLog(...)` or
+ * `withRequestLog<{ id: string }>(async (...) => {...})`).
+ */
+describe('request-log middleware coverage', () => {
+  it('every API route is wrapped in withRequestLog', () => {
+    const routeFiles = findRouteFiles(join(WEB_ROOT, 'app/api'))
+    const violations: string[] = []
+
+    for (const abs of routeFiles) {
+      const rel = abs.slice(WEB_ROOT.length + 1)
+      const src = readFileSync(abs, 'utf-8')
+      if (!/\bwithRequestLog\b/.test(src)) {
+        violations.push(rel)
+      }
+    }
+
+    if (violations.length > 0) {
+      const list = violations.map((v) => `  - ${v}`).join('\n')
+      throw new Error(
+        `These API routes are NOT wrapped in withRequestLog:\n${list}\n\n` +
+          `Wrap each with the pattern from docs/REQUEST_LOG_AUDIT.md:\n\n` +
+          `  export const POST = withRequestLog(async (req, { log }) => { ... })\n\n` +
+          `withRequestLog gives every request a request-id, trace context,\n` +
+          `perf tracker, and a structured 500 fallback. See #392 audit.`,
       )
     }
 


### PR DESCRIPTION
## Summary
Companion to the auth-coverage test from PR #151. Same file, same pattern, second describe block:

```ts
describe('request-log middleware coverage', () => {
  it('every API route is wrapped in withRequestLog', () => { ... })
})
```

No allowlist — every route needs the wrapper. If a future agent adds a route without it, CI fails with a descriptive error pointing to `docs/REQUEST_LOG_AUDIT.md`.

Locks BUG_HUNT_500 #392 so it can't regress.

## Test plan
- [x] `npx vitest run tests/integration/admin-route-auth-coverage.test.ts` → 2/2 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)