### PR TITLE
feat(api): /api/cron/health env-readiness endpoint (#436)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 87 | see closure log below |
+| ✅ Closed | 88 | see closure log below |
 | 🟡 In progress | 0 | — |
-| 🔴 Open | 413 | the rest |
+| 🔴 Open | 412 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -196,6 +196,12 @@ Closure log:
   needs the wrapper). Locks #392 so it can't regress when someone adds a
   new route. Pairs with the auth coverage test as a "you cannot ship a
   broken route" social contract.
+- **#436** — `/api/cron/health` route reports per-cron env readiness.
+  Returns 503 + the missing-env list if any required env var is unset for
+  any of the 5 cron routes. CRON_SECRET-protected, GET aliases POST. 4
+  tests passing. Wired into CRON_STRATEGY.md as an hourly check. Wire
+  this URL into your monitor of choice (Better Uptime, UptimeRobot, etc.)
+  to get alerted before a cron silently no-ops on missing env.
 - **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
   added id to `<main>` on landing + 11 high-traffic marketing routes.
 - **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).

--- a/docs/runbooks/CRON_STRATEGY.md
+++ b/docs/runbooks/CRON_STRATEGY.md
@@ -34,6 +34,7 @@ No extra moving parts.**
 | `POST /api/cron/commerce-email-flush` | `*/5 * * * *` | `CRON_SECRET`, `RESEND_API_KEY`, `COMMERCE_EMAIL_FROM` | Send queued commerce emails |
 | `POST /api/cron/commerce-abandoned-cart` | `0 */4 * * *` | `CRON_SECRET` | Abandoned cart recovery |
 | `POST /api/cron/commerce-reconcile-pending` | `0 * * * *` | `CRON_SECRET` | Reconcile MP pending payments |
+| `POST /api/cron/health` | `0 * * * *` (UTC, hourly) | `CRON_SECRET` | Returns `{ ok, crons[] }` per-cron env-readiness. 503 if any required env is missing. Wire to your monitor of choice. |
 
 > Asunción is UTC-3 / UTC-4 (DST). Most ops choose to schedule in UTC and
 > ignore DST. The above uses UTC offsets matching standard time (UTC-3).

--- a/web/app/api/cron/health/route.ts
+++ b/web/app/api/cron/health/route.ts
@@ -1,0 +1,90 @@
+/**
+ * Cron health endpoint. Returns a snapshot of:
+ *   - which env vars each cron route depends on are configured
+ *   - the current server time (so an external monitor can correlate
+ *     this against expected schedules in CRON_STRATEGY.md)
+ *   - the route-list (so a human can eyeball that all 5 + this one exist)
+ *
+ * Schedule (UTC): hourly via the same crontab that runs the others. See
+ * docs/runbooks/CRON_STRATEGY.md. Protected by CRON_SECRET header.
+ *
+ * Closes BUG_HUNT_500 #436.
+ *
+ * Why this design (vs writing heartbeats to a `cron_runs` table):
+ * heartbeats need a schema migration + every cron updated to write one.
+ * This route is the simpler version: it tells you "what would prevent
+ * each cron from working" without any DB writes. If a cron silently
+ * fails, this endpoint tells you the probable reason (missing env).
+ */
+import { NextResponse } from 'next/server'
+import { withRequestLog } from '@/lib/api/with-request-log'
+
+export const runtime = 'nodejs'
+
+interface CronCheck {
+  path: string
+  schedule: string
+  requiredEnv: string[]
+  status: 'ok' | 'missing_env'
+  missing: string[]
+}
+
+const CRONS: Array<Omit<CronCheck, 'status' | 'missing'>> = [
+  {
+    path: '/api/cron/leads-digest',
+    schedule: '0 12 * * * (UTC, daily 9am Asunción)',
+    requiredEnv: ['CRON_SECRET', 'RESEND_API_KEY', 'LEADS_DIGEST_FROM', 'LEADS_DIGEST_TO'],
+  },
+  {
+    path: '/api/cron/sitemap-ping',
+    schedule: '0 11 * * 1 (UTC, Mon 8am Asunción)',
+    requiredEnv: ['CRON_SECRET'],
+  },
+  {
+    path: '/api/cron/commerce-email-flush',
+    schedule: '*/5 * * * * (UTC, every 5 min)',
+    requiredEnv: ['CRON_SECRET', 'RESEND_API_KEY', 'COMMERCE_EMAIL_FROM'],
+  },
+  {
+    path: '/api/cron/commerce-abandoned-cart',
+    schedule: '0 */4 * * * (UTC, every 4 h)',
+    requiredEnv: ['CRON_SECRET'],
+  },
+  {
+    path: '/api/cron/commerce-reconcile-pending',
+    schedule: '0 * * * * (UTC, hourly)',
+    requiredEnv: ['CRON_SECRET'],
+  },
+]
+
+function envCheck(required: string[]): { status: 'ok' | 'missing_env'; missing: string[] } {
+  const missing = required.filter((k) => !process.env[k])
+  return { status: missing.length === 0 ? 'ok' : 'missing_env', missing }
+}
+
+export const POST = withRequestLog(async (request, { log }) => {
+  const cronSecret = process.env.CRON_SECRET
+  if (cronSecret && request.headers.get('x-cron-secret') !== cronSecret) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+
+  const checks: CronCheck[] = CRONS.map((c) => ({ ...c, ...envCheck(c.requiredEnv) }))
+  const anyMissing = checks.some((c) => c.status !== 'ok')
+
+  log.info('cron.health.report', {
+    healthy: checks.filter((c) => c.status === 'ok').length,
+    degraded: checks.filter((c) => c.status === 'missing_env').length,
+  })
+
+  return NextResponse.json(
+    {
+      ok: !anyMissing,
+      now: new Date().toISOString(),
+      crons: checks,
+    },
+    { status: anyMissing ? 503 : 200 },
+  )
+})
+
+// Allow GET for one-off browser checks by an admin (CRON_SECRET still required).
+export const GET = POST

--- a/web/tests/integration/admin-route-auth-coverage.test.ts
+++ b/web/tests/integration/admin-route-auth-coverage.test.ts
@@ -59,6 +59,7 @@ const PUBLIC_ROUTE_ALLOWLIST: Array<{ path: string; reason: string }> = [
   { path: 'app/api/cron/commerce-email-flush/route.ts', reason: 'Cron route gated by CRON_SECRET header.' },
   { path: 'app/api/cron/commerce-abandoned-cart/route.ts', reason: 'Cron route gated by CRON_SECRET header.' },
   { path: 'app/api/cron/commerce-reconcile-pending/route.ts', reason: 'Cron route gated by CRON_SECRET header.' },
+  { path: 'app/api/cron/health/route.ts', reason: 'Cron route gated by CRON_SECRET header.' },
   // Storefront routes — public per-tenant by design (cart, checkout, etc.).
   // Authentication, when needed, happens at the order/payment level.
   ...[

--- a/web/tests/integration/cron-health.test.ts
+++ b/web/tests/integration/cron-health.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for /api/cron/health. Closes BUG_HUNT_500 #436.
+ *
+ * Coverage:
+ *   - 403 when x-cron-secret mismatches
+ *   - 200 + ok:true when all required env vars are set
+ *   - 503 + ok:false when any cron's required env is missing
+ *   - GET aliases POST
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+const ORIGINAL_ENV = { ...process.env }
+
+const FULL_ENV: Record<string, string> = {
+  CRON_SECRET: 's',
+  RESEND_API_KEY: 're_test',
+  LEADS_DIGEST_FROM: 'leads@paragu-ai.com',
+  LEADS_DIGEST_TO: 'a@example.com',
+  COMMERCE_EMAIL_FROM: 'commerce@paragu-ai.com',
+}
+
+describe('/api/cron/health', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV, ...FULL_ENV }
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('returns 403 when x-cron-secret mismatches', async () => {
+    const { POST } = await import('@/app/api/cron/health/route')
+    const req = new Request('http://localhost/api/cron/health', {
+      method: 'POST',
+      headers: { 'x-cron-secret': 'wrong' },
+    })
+    const res = await POST(req as never)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 200 + ok:true when all required env is configured', async () => {
+    const { POST } = await import('@/app/api/cron/health/route')
+    const req = new Request('http://localhost/api/cron/health', {
+      method: 'POST',
+      headers: { 'x-cron-secret': 's' },
+    })
+    const res = await POST(req as never)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.crons).toHaveLength(5)
+    expect(body.crons.every((c: { status: string }) => c.status === 'ok')).toBe(true)
+  })
+
+  it('returns 503 + ok:false + missing env list when any cron is misconfigured', async () => {
+    delete process.env.RESEND_API_KEY
+    const { POST } = await import('@/app/api/cron/health/route')
+    const req = new Request('http://localhost/api/cron/health', {
+      method: 'POST',
+      headers: { 'x-cron-secret': 's' },
+    })
+    const res = await POST(req as never)
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body.ok).toBe(false)
+    // Both leads-digest and commerce-email-flush require RESEND_API_KEY.
+    const degraded = body.crons.filter((c: { status: string }) => c.status !== 'ok')
+    expect(degraded.length).toBeGreaterThanOrEqual(2)
+    expect(degraded.every((c: { missing: string[] }) => c.missing.includes('RESEND_API_KEY'))).toBe(true)
+  })
+
+  it('GET aliases POST', async () => {
+    const mod = await import('@/app/api/cron/health/route')
+    expect(mod.GET).toBe(mod.POST)
+  })
+})


### PR DESCRIPTION
## Summary
A single endpoint that tells you which crons can/can't fire based on env-var configuration.

Returns `{ ok, now, crons[] }`. 503 + `ok:false` when any cron has missing env (e.g. `RESEND_API_KEY` unset silently makes `leads-digest` + `commerce-email-flush` no-op).

**Why this design instead of heartbeat-table:** heartbeats need a schema migration + every cron updated. This endpoint is the simpler version — tells you the probable reason a cron isn't working without DB writes. Heartbeats can come later if needed.

Wire the URL into an uptime monitor (Better Uptime, UptimeRobot, etc.) to get alerted before a cron silently no-ops.

Closes BUG_HUNT_500 #436.

## Test plan
- [x] `npx vitest run tests/integration/cron-health.test.ts tests/integration/admin-route-auth-coverage.test.ts` → 6/6
- [x] Allowlisted in admin-auth-coverage test (cron-secret gating, not session)
- [x] Documented in CRON_STRATEGY.md as hourly probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)