### PR TITLE
feat(storefront): related products on PDP + checkout a11y polish

### DIFF
--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -2,13 +2,14 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import type { Metadata } from 'next'
 import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
-import { getProductBySlug } from '@/lib/commerce/products'
+import { getProductBySlug, listRelatedProducts } from '@/lib/commerce/products'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { ProductImage } from '@/components/commerce/product-image'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { formatCents } from '@/lib/commerce/compute-totals'
 import { ProductDetailActions } from '@/components/commerce/product-detail-actions'
+import { ProductCard } from '@/components/commerce/product-card'
 import { PriceDisplay } from '@/components/commerce/price-display'
 import { loadPygRates } from '@/lib/commerce/currency-server'
 
@@ -42,7 +43,10 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
   if (!product || product.status !== 'active') notFound()
 
   const cover = product.images.find((i) => i.isCover) ?? product.images[0]
-  const rates = await loadPygRates()
+  const [rates, related] = await Promise.all([
+    loadPygRates(),
+    listRelatedProducts(business.id, { excludeId: product.id, category: product.category, limit: 4 }),
+  ])
 
   const structuredData = {
     '@context': 'https://schema.org',
@@ -131,6 +135,19 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
           </div>
         </div>
       </main>
+
+      {related.length > 0 ? (
+        <section aria-labelledby="related-heading" className="mx-auto max-w-5xl px-4 pb-12">
+          <h2 id="related-heading" className="mb-4 text-xl font-semibold text-[color:var(--text,#111)]">
+            {product.category ? `Más en ${product.category}` : 'También te puede gustar'}
+          </h2>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {related.map((p) => (
+              <ProductCard key={p.id} siteSlug={site} product={p} rates={rates} locale={locale} />
+            ))}
+          </div>
+        </section>
+      ) : null}
     </div>
   )
 }

--- a/web/components/commerce/checkout-form.tsx
+++ b/web/components/commerce/checkout-form.tsx
@@ -200,16 +200,19 @@ export function CheckoutForm({ siteSlug, locale = 'es' }: Props) {
             </div>
           )}
           {discountStatus.kind === 'rejected' ? (
-            <p className="mt-1 text-xs text-red-700">
-              {discountStatus.reason === 'not_found'
-                ? 'Ese código no existe.'
-                : discountStatus.reason === 'expired'
-                ? 'Ese código venció.'
-                : discountStatus.reason === 'min_subtotal'
-                ? 'No alcanzás el subtotal mínimo para este código.'
-                : discountStatus.reason === 'usage_exceeded'
-                ? 'Ese código ya se usó el máximo de veces.'
-                : 'Código inválido.'}
+            <p role="alert" className="mt-1 flex items-start gap-1 text-xs text-red-700">
+              <span aria-hidden="true">⚠️</span>
+              <span>
+                {discountStatus.reason === 'not_found'
+                  ? 'Ese código no existe.'
+                  : discountStatus.reason === 'expired'
+                  ? 'Ese código venció.'
+                  : discountStatus.reason === 'min_subtotal'
+                  ? 'No alcanzás el subtotal mínimo para este código.'
+                  : discountStatus.reason === 'usage_exceeded'
+                  ? 'Ese código ya se usó el máximo de veces.'
+                  : 'Código inválido.'}
+              </span>
             </p>
           ) : null}
         </div>
@@ -277,12 +280,25 @@ function Field({
   placeholder?: string
   className?: string
 }) {
+  // Explicit htmlFor + id so screen readers anchor reliably (the wrapping
+  // <label> alone is technically valid but some AT versions stumble). The
+  // red asterisk gets a sr-only "obligatorio" so the required-ness isn't
+  // color-only — non-visual users get the same signal.
+  const inputId = `checkout-field-${name}`
   return (
-    <label className={`block ${className ?? ''}`}>
-      <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">
-        {label} {required ? <span className="text-red-600">*</span> : null}
-      </span>
+    <div className={`block ${className ?? ''}`}>
+      <label htmlFor={inputId} className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">
+        {label}
+        {required ? (
+          <>
+            {' '}
+            <span aria-hidden="true" className="text-red-600">*</span>
+            <span className="sr-only">(obligatorio)</span>
+          </>
+        ) : null}
+      </label>
       <input
+        id={inputId}
         name={name}
         type={type}
         required={required}
@@ -290,6 +306,6 @@ function Field({
         placeholder={placeholder}
         className="block w-full rounded-md border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm focus:border-[color:var(--primary,#111)] focus:outline-none"
       />
-    </label>
+    </div>
   )
 }

--- a/web/components/commerce/product-card.tsx
+++ b/web/components/commerce/product-card.tsx
@@ -43,13 +43,21 @@ export function ProductCard({ siteSlug, product, priority, rates, locale = 'es' 
         <div className="relative">
           <ProductImage image={cover} alt={product.name} priority={priority} isSeed={product.isSeed} />
           {discount ? (
-            <span className="absolute left-2 top-2 rounded bg-red-600 px-2 py-0.5 text-xs font-semibold text-white">-{discount}%</span>
+            <span className="absolute left-2 top-2 rounded bg-red-600 px-2 py-0.5 text-xs font-semibold text-white" aria-label={`Descuento del ${discount} por ciento`}>
+              −{discount}%
+            </span>
           ) : null}
           {lowStock ? (
-            <span className="absolute right-2 top-2 rounded bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white">¡Últimas {product.inventoryQty}!</span>
+            <span className="absolute right-2 top-2 inline-flex items-center gap-1 rounded bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white">
+              <span aria-hidden="true">⚠</span>
+              ¡Últimas {product.inventoryQty}!
+            </span>
           ) : null}
           {outOfStock ? (
-            <span className="absolute right-2 top-2 rounded bg-gray-700 px-2 py-0.5 text-xs font-semibold text-white">Agotado</span>
+            <span className="absolute right-2 top-2 inline-flex items-center gap-1 rounded bg-gray-700 px-2 py-0.5 text-xs font-semibold text-white">
+              <span aria-hidden="true">✕</span>
+              Agotado
+            </span>
           ) : null}
         </div>
       </Link>

--- a/web/lib/commerce/products.ts
+++ b/web/lib/commerce/products.ts
@@ -106,6 +106,44 @@ export async function getProductBySlug(businessId: string, slug: string): Promis
   return row ? rowToProduct(row) : null
 }
 
+/**
+ * Suggestions for the "More from this category" rail on a PDP. Excludes
+ * the current product, falls back to recent active products from any
+ * category if the source product has no category set or there aren't
+ * enough siblings.
+ */
+export async function listRelatedProducts(
+  businessId: string,
+  opts: { excludeId: string; category: string | null; limit?: number },
+): Promise<Product[]> {
+  const limit = opts.limit ?? 4
+  const supabase = await createAdminClient()
+  const scoped = scopedQueries(supabase, businessId)
+
+  const fetchBatch = async (filterCategory: boolean): Promise<Product[]> => {
+    const { data } = await scoped.select<ProductRow>('products', '*', {
+      filter: (q) => {
+        let query = q
+          .eq('status', 'active')
+          .neq('id', opts.excludeId)
+          .order('created_at', { ascending: false })
+          .limit(limit)
+        if (filterCategory && opts.category) query = query.eq('category', opts.category)
+        return query
+      },
+    })
+    return (Array.isArray(data) ? data : []).map(rowToProduct)
+  }
+
+  const sameCategory = opts.category ? await fetchBatch(true) : []
+  if (sameCategory.length >= limit) return sameCategory
+
+  // Top up with recent products from any category, excluding what we already have.
+  const seen = new Set([opts.excludeId, ...sameCategory.map((p) => p.id)])
+  const fallback = await fetchBatch(false)
+  return [...sameCategory, ...fallback.filter((p) => !seen.has(p.id))].slice(0, limit)
+}
+
 export async function createProduct(
   businessId: string,
   input: ProductCreate & { isSeed?: boolean },


### PR DESCRIPTION
## Summary

PDP gets a **\"Más en {category}\"** rail — same-category recommendations at the bottom of the product page, with fallback to recent active products if the source has no category or not enough siblings. Eliminates the dead-end at the bottom of every PDP.

A11y polish:

- **Checkout \`Field\`** now uses explicit \`htmlFor\` + \`id\` pairing (the implicit-via-wrapping label still works in modern AT but some screen-reader versions stumble). Required marker (red \`*\`) gets a sr-only \"(obligatorio)\" so the required-ness isn't color-only.
- **Discount-rejected message** gets a leading ⚠ icon + \`role=\"alert\"\` so colorblind shoppers get the failure signal.
- **Product-card stock badges** (low/out) get leading ⚠/✕ icons so they parse without color. Discount badge gains an explicit \`aria-label\` (\"Descuento del 25 por ciento\") since \"−25%\" alone is ambiguous to screen readers.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run test:unit\` — 426 pass
- [x] \`npm run build\` — clean
- [ ] Manual: visit a PDP, verify rail renders below the main panel with same-category items
- [ ] Manual: PDP for a product whose category has zero siblings → rail shows recent products from elsewhere
- [ ] Manual: enter invalid discount in checkout → verify ⚠ icon + alert role
- [ ] Manual: tab into a required field with VoiceOver/NVDA → confirm \"(obligatorio)\" announces

🤖 Generated with [Claude Code](https://claude.com/claude-code)