### PR TITLE
fix(analytics): accept 'web_vital' eventType + nest metric fields

### DIFF
--- a/web/app/api/analytics/track/route.ts
+++ b/web/app/api/analytics/track/route.ts
@@ -49,6 +49,7 @@ const VALID_EVENT_TYPES = [
   'demo_generated',
   'lead_created',
   'conversion',
+  'web_vital',
 ] as const
 
 type EventType = typeof VALID_EVENT_TYPES[number]

--- a/web/components/analytics/web-vitals-reporter.tsx
+++ b/web/components/analytics/web-vitals-reporter.tsx
@@ -15,13 +15,15 @@ export function WebVitalsReporter(): null {
     try {
       const body = JSON.stringify({
         eventType: 'web_vital',
-        name: metric.name,
-        id: metric.id,
-        value: metric.value,
-        rating: metric.rating,
-        delta: metric.delta,
-        navigationType: metric.navigationType,
         pageUrl: typeof window !== 'undefined' ? window.location.pathname : undefined,
+        metadata: {
+          name: metric.name,
+          id: metric.id,
+          value: metric.value,
+          rating: metric.rating,
+          delta: metric.delta,
+          navigationType: metric.navigationType,
+        },
       })
       if (navigator.sendBeacon) {
         navigator.sendBeacon('/api/analytics/track', new Blob([body], { type: 'application/json' }))


### PR DESCRIPTION
## Summary

Kills the 400-spam on \`/api/analytics/track\` every time any page loads on \`paragu-ai.com\`.

## Root cause

\`web/components/analytics/web-vitals-reporter.tsx\` sends \`eventType: 'web_vital'\` on every LCP/CLS/INP/TTFB/FCP measurement. The server route's \`VALID_EVENT_TYPES\` allowlist didn't include \`web_vital\`, so every beacon 400'd.

User's browser console (paragu-ai.com):
\`\`\`
POST https://paragu-ai.com/api/analytics/track 400 (Bad Request)  (×N per page load)
\`\`\`

Second-order bug: metric fields (\`name\`, \`value\`, \`rating\`, \`delta\`, \`navigationType\`, \`id\`) were sent as top-level JSON keys, but the route only persists fields under \`metadata.*\`. Web Vitals data was being silently dropped even before the 400.

## Fix — 2 files, 9 lines changed

1. \`web/app/api/analytics/track/route.ts\` — add \`'web_vital'\` to \`VALID_EVENT_TYPES\`.
2. \`web/components/analytics/web-vitals-reporter.tsx\` — wrap metric fields in \`metadata: {...}\` so they actually land in the DB.

## Test plan

- [ ] CI green
- [ ] After deploy, \`paragu-ai.com/\` browser console shows no 400s on \`/api/analytics/track\`
- [ ] \`analytics_events\` table in Supabase gets new rows with \`event_type='web_vital'\` and populated \`metadata\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)