### PR TITLE
feat(storefront): WhatsApp share on PDP + resend confirmation email

### DIFF
--- a/web/app/api/storefront/[site]/orders/[id]/resend-email/route.ts
+++ b/web/app/api/storefront/[site]/orders/[id]/resend-email/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
+import { getOrder, CheckoutError } from '@/lib/commerce/orders'
+import { enqueueOrderEmail } from '@/lib/commerce/notifications'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { env } from '@/lib/env'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/storefront/[site]/orders/[id]/resend-email
+ *
+ * Re-enqueues the order_confirmation email for a shopper who lost or
+ * never got the original (spam folder, typo on email at checkout that
+ * was later corrected, etc.). Rate-limited to one resend per minute per
+ * order to keep this from being a spam vector.
+ *
+ * No auth — the only thing protecting against abuse is "you need a
+ * valid order id" (UUID, opaque) plus the per-order cooldown. The email
+ * always goes to the address recorded on the order, never to a
+ * caller-supplied address, so worst case is the legitimate shopper
+ * gets a duplicate email.
+ */
+const COOLDOWN_MS = 60_000
+
+export const POST = withRequestLog<{ site: string; id: string }>(async (_req, { log }, { site, id }) => {
+  const business = await resolveBusinessBySlug(site)
+  if (!business) return NextResponse.json({ error: 'not_found' }, { status: 404 })
+
+  let order
+  try {
+    order = await getOrder(business.id, id)
+  } catch (err) {
+    if (err instanceof CheckoutError && err.code === 'order_not_found') {
+      return NextResponse.json({ error: 'not_found' }, { status: 404 })
+    }
+    throw err
+  }
+
+  // Cooldown: look at the most recent order_confirmation row in the outbox
+  // for this order and refuse if it was queued in the last minute.
+  const supabase = await createAdminClient()
+  const { data: lastSent } = await supabase
+    .from('commerce_email_outbox')
+    .select('created_at')
+    .eq('business_id', business.id)
+    .eq('order_id', id)
+    .eq('template', 'order_confirmation')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (lastSent?.created_at) {
+    const ageMs = Date.now() - new Date(lastSent.created_at).getTime()
+    if (ageMs < COOLDOWN_MS) {
+      const waitSeconds = Math.ceil((COOLDOWN_MS - ageMs) / 1000)
+      return NextResponse.json({ error: 'rate_limited', retryAfterSeconds: waitSeconds }, { status: 429 })
+    }
+  }
+
+  await enqueueOrderEmail({
+    businessId: business.id,
+    businessName: business.name,
+    orderId: id,
+    template: 'order_confirmation',
+    order,
+    storeUrl: `${env.APP_URL}/s/es/${site}/orden/${id}`,
+  })
+
+  log.info('commerce.order.email_resent', { businessId: business.id, orderId: id })
+  return NextResponse.json({ ok: true, sentTo: maskEmail(order.customerEmail) })
+})
+
+/** Mask the email so the response can be logged safely. */
+function maskEmail(email: string): string {
+  const [name, domain] = email.split('@')
+  if (!domain) return '***'
+  const head = name.slice(0, 2)
+  return `${head}***@${domain}`
+}

--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -10,8 +10,10 @@ import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { formatCents } from '@/lib/commerce/compute-totals'
 import { ProductDetailActions } from '@/components/commerce/product-detail-actions'
 import { ProductCard } from '@/components/commerce/product-card'
+import { ProductShare } from '@/components/commerce/product-share'
 import { PriceDisplay } from '@/components/commerce/price-display'
 import { loadPygRates } from '@/lib/commerce/currency-server'
+import { env } from '@/lib/env'
 
 export const runtime = 'nodejs'
 export const revalidate = 300
@@ -127,6 +129,8 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
           <div className="mt-6">
             <ProductDetailActions siteSlug={site} productId={product.id} inventoryQty={product.inventoryQty} inventoryPolicy={product.inventoryPolicy} />
           </div>
+
+          <ProductShare productName={product.name} productUrl={`${env.APP_URL}/s/${locale}/${site}/producto/${product.slug}`} />
 
           <div className="mt-8 rounded-lg bg-[color:var(--surface,#fff)] p-4 text-sm text-[color:var(--text-muted,#6b7280)]">
             <p>✓ Pago seguro</p>

--- a/web/components/commerce/order-confirmation.tsx
+++ b/web/components/commerce/order-confirmation.tsx
@@ -15,6 +15,32 @@ interface Props {
 export function OrderConfirmation({ siteSlug, locale, initialOrder, initialStatus }: Props) {
   const [order, setOrder] = useState(initialOrder)
   const [polling, setPolling] = useState(initialOrder.status === 'awaiting_payment')
+  const [resendState, setResendState] = useState<
+    | { kind: 'idle' }
+    | { kind: 'sending' }
+    | { kind: 'sent'; sentTo: string }
+    | { kind: 'rate_limited'; waitSeconds: number }
+    | { kind: 'error'; message: string }
+  >({ kind: 'idle' })
+
+  async function handleResend() {
+    setResendState({ kind: 'sending' })
+    try {
+      const res = await fetch(`/api/storefront/${siteSlug}/orders/${order.id}/resend-email`, { method: 'POST' })
+      const data = await res.json().catch(() => ({}))
+      if (res.status === 429) {
+        setResendState({ kind: 'rate_limited', waitSeconds: data.retryAfterSeconds ?? 60 })
+        return
+      }
+      if (!res.ok) {
+        setResendState({ kind: 'error', message: data.error ?? 'resend_failed' })
+        return
+      }
+      setResendState({ kind: 'sent', sentTo: data.sentTo ?? order.customerEmail })
+    } catch {
+      setResendState({ kind: 'error', message: 'network_error' })
+    }
+  }
 
   useEffect(() => {
     if (!polling) return
@@ -61,9 +87,28 @@ export function OrderConfirmation({ siteSlug, locale, initialOrder, initialStatu
           </div>
         </div>
 
-        <p className="mb-4 text-sm text-[color:var(--text-muted,#6b7280)]">
+        <p className="mb-2 text-sm text-[color:var(--text-muted,#6b7280)]">
           Enviamos la confirmación a <strong>{order.customerEmail}</strong>.
         </p>
+
+        <div className="mb-6 text-xs">
+          {resendState.kind === 'sent' ? (
+            <p className="text-green-700">✓ Te reenviamos el email a {resendState.sentTo}.</p>
+          ) : resendState.kind === 'rate_limited' ? (
+            <p className="text-amber-700">Esperá {resendState.waitSeconds}s antes de reintentar.</p>
+          ) : resendState.kind === 'error' ? (
+            <p className="text-red-700">No pudimos reenviar el email ({resendState.message}). Probá más tarde.</p>
+          ) : (
+            <button
+              type="button"
+              onClick={handleResend}
+              disabled={resendState.kind === 'sending'}
+              className="text-[color:var(--primary,#111)] underline disabled:opacity-50"
+            >
+              {resendState.kind === 'sending' ? 'Enviando…' : '¿No te llegó? Reenviar email'}
+            </button>
+          )}
+        </div>
 
         <Link
           href={`/s/${locale}/${siteSlug}/tienda`}

--- a/web/components/commerce/product-share.tsx
+++ b/web/components/commerce/product-share.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Props {
+  productName: string
+  productUrl: string
+}
+
+/**
+ * Share affordance on PDPs. PY shoppers expect WhatsApp share + copy-link
+ * — those are the two ways products actually get recommended in country.
+ * Web Share API is preferred when available (mobile gets the native sheet
+ * with all installed apps), with explicit WA + copy fallbacks for desktop.
+ */
+export function ProductShare({ productName, productUrl }: Props) {
+  const [copied, setCopied] = useState(false)
+  const shareText = `Mirá este producto: ${productName}`
+
+  async function handleNativeShare() {
+    if (typeof navigator === 'undefined' || !navigator.share) {
+      // No Web Share API — fall back to copy
+      await handleCopy()
+      return
+    }
+    try {
+      await navigator.share({ title: productName, text: shareText, url: productUrl })
+    } catch {
+      // User cancelled or share failed; do nothing.
+    }
+  }
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(productUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard blocked — last resort: prompt
+      window.prompt('Copiá este enlace:', productUrl)
+    }
+  }
+
+  const whatsappHref = `https://wa.me/?text=${encodeURIComponent(`${shareText} ${productUrl}`)}`
+
+  return (
+    <div className="mt-6 flex flex-wrap items-center gap-2 text-sm">
+      <span className="text-xs font-medium uppercase text-[color:var(--text-muted,#6b7280)]">Compartir</span>
+      <button
+        type="button"
+        onClick={handleNativeShare}
+        className="inline-flex items-center gap-1 rounded border border-[color:var(--border,#e5e7eb)] px-3 py-1.5 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+      >
+        <span aria-hidden="true">↗</span>
+        Compartir
+      </button>
+      <a
+        href={whatsappHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 rounded bg-[#25D366] px-3 py-1.5 text-xs font-medium text-white hover:opacity-90"
+      >
+        <span aria-hidden="true">💬</span>
+        WhatsApp
+      </a>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="inline-flex items-center gap-1 rounded border border-[color:var(--border,#e5e7eb)] px-3 py-1.5 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+      >
+        <span aria-hidden="true">{copied ? '✓' : '🔗'}</span>
+        {copied ? '¡Copiado!' : 'Copiar enlace'}
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Two recovery + sharing affordances Paraguayan shoppers actually use:

**1. PDP share row** — native Web Share API where available (mobile gets the OS sheet), explicit WhatsApp deep link (the dominant share channel locally), and copy-link fallback. Pre-fills *\"Mirá este producto: {name} {url}\"*.

**2. \"¿No te llegó? Reenviar email\"** on the order confirmation page → POST \`/api/storefront/[site]/orders/[id]/resend-email\` re-enqueues \`order_confirmation\` into \`commerce_email_outbox\`. 60s per-order cooldown; the email always goes to the address on the order (never caller-supplied), so worst case is one duplicate.

## Why no auth on resend

Gated by \"you must know an opaque order UUID\" plus the per-order cooldown. Email-on-record only — caller can't leak addresses or spam strangers. Trade-off is acceptable for the recovery UX (a typo at checkout is the most common reason for resend, and the legitimate shopper has the URL).

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run test:unit\` — 426 pass
- [x] \`npm run build\` — clean
- [ ] Manual: PDP share buttons render, WhatsApp opens chat picker with prefilled text
- [ ] Manual: copy-link → check pastes the canonical product URL
- [ ] Manual: place an order, click resend, see green confirmation
- [ ] Manual: click resend twice fast → 429 with countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)