### PR TITLE
fix(api): WhatsApp webhook signature verification (#476)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 89 | see closure log below |
+| ✅ Closed | 90 | see closure log below |
 | 🟡 In progress | 0 | — |
-| 🔴 Open | 411 | the rest |
+| 🔴 Open | 410 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -207,6 +207,13 @@ Closure log:
   from the footer "Recursos" group. Doubles as live proof of engineering
   velocity for prospects. Added a comprehensive 2026-04-21 entry to the
   CHANGELOG covering all the wave's security + observability work.
+- **#476 (whatsapp half) + auth fix** — `/api/whatsapp-webhook` POST was
+  accepting any payload — anyone on the internet could inject fake
+  inbound messages into the leads table. Added Meta `x-hub-signature-256`
+  HMAC verification using `WHATSAPP_APP_SECRET` (fail-closed when unset).
+  6 tests cover the GET verify-challenge flow + POST signed-inbound + 3
+  failure modes. ENV_VARS.md updated. MP webhook half of #476 not needed
+  per ADR 0004 (MP removed in favor of Pagopar).
 - **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
   added id to `<main>` on landing + 11 high-traffic marketing routes.
 - **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).

--- a/docs/runbooks/ENV_VARS.md
+++ b/docs/runbooks/ENV_VARS.md
@@ -76,6 +76,14 @@ If you change `LOG_FORMAT=pretty` on the VPS for one-off debugging, remember
 that `docker service logs` will keep showing colorized output until you set
 it back. The diagnostics route at `/api/diagnostics` reflects current values.
 
+### WhatsApp Business API webhook
+
+| Var | Where to get | Notes |
+|---|---|---|
+| `WHATSAPP_VERIFY_TOKEN` | You choose any string when configuring the webhook in Meta's Business Manager | Used by GET `/api/whatsapp-webhook` for the initial verify-token challenge. |
+| `WHATSAPP_APP_SECRET` | Meta App Dashboard → App settings → Basic → "App secret" | Used by POST `/api/whatsapp-webhook` to verify Meta's `x-hub-signature-256` HMAC. **Without this set, every POST is 401-rejected** (fail-closed). |
+| `WHATSAPP_PHONE_SITE_MAP` | Self-managed JSON, e.g. `{"5959810000":"nexa-paraguay"}` | Maps Meta `phone_number_id` to a tenant slug for inbound lead routing. |
+
 ### Mailchimp (deferred per Q8.2)
 
 Skip until the newsletter flow becomes a priority. When you wire it:

--- a/web/app/api/whatsapp-webhook/route.ts
+++ b/web/app/api/whatsapp-webhook/route.ts
@@ -2,16 +2,40 @@
  * GET + POST /api/whatsapp-webhook — Meta WhatsApp Business API webhook.
  * GET handles Meta's verify-token challenge.
  * POST parses inbound text messages and inserts them into leads.
+ *
+ * POST signature verification: Meta signs the raw body with HMAC-SHA256
+ * using `WHATSAPP_APP_SECRET` and sends `x-hub-signature-256: sha256=...`.
+ * Without `WHATSAPP_APP_SECRET` configured the route fail-closes (401).
+ * Previously the route accepted any POST → anyone could inject fake
+ * inbound messages into the leads table.
+ *
  * Multi-tenant routing key: we prefix the business phone number (pnid)
  * so ops can map it to a site_slug via env.WHATSAPP_PHONE_SITE_MAP
  * (JSON map, e.g. {"595...":"nexa-paraguay"}).
  */
 
 import { NextResponse } from 'next/server'
+import { createHmac, timingSafeEqual } from 'crypto'
 import { withRequestLog } from '@/lib/api/with-request-log'
 import { createClient } from '@/lib/supabase/server'
 
 export const runtime = 'nodejs'
+
+/**
+ * Verify Meta's `x-hub-signature-256` header against the raw request body.
+ * Header format: `sha256=<hex-hmac>`.
+ */
+function verifyMetaSignature(rawBody: string, header: string | null, secret: string): boolean {
+  if (!header || !header.startsWith('sha256=')) return false
+  const provided = header.slice(7)
+  const expected = createHmac('sha256', secret).update(rawBody).digest('hex')
+  if (provided.length !== expected.length) return false
+  try {
+    return timingSafeEqual(Buffer.from(provided, 'hex'), Buffer.from(expected, 'hex'))
+  } catch {
+    return false
+  }
+}
 
 interface WhatsAppPayload {
   object?: string
@@ -57,7 +81,26 @@ export const GET = withRequestLog(async (req) => {
 })
 
 export const POST = withRequestLog(async (req, { log }) => {
-  const body = (await req.json().catch(() => ({}))) as WhatsAppPayload
+  const secret = process.env.WHATSAPP_APP_SECRET
+  if (!secret) {
+    log.warn('whatsapp.webhook.not_configured')
+    return NextResponse.json({ error: 'webhook_not_configured' }, { status: 401 })
+  }
+
+  const rawBody = await req.text()
+  const valid = verifyMetaSignature(rawBody, req.headers.get('x-hub-signature-256'), secret)
+  if (!valid) {
+    log.warn('whatsapp.webhook.signature_invalid')
+    return NextResponse.json({ error: 'invalid_signature' }, { status: 401 })
+  }
+
+  let body: WhatsAppPayload
+  try {
+    body = JSON.parse(rawBody) as WhatsAppPayload
+  } catch (err) {
+    log.warn('whatsapp.webhook.bad_json', { error: err instanceof Error ? err.message : String(err) })
+    return NextResponse.json({ error: 'bad_json' }, { status: 400 })
+  }
   log.info('whatsapp inbound', { object: body.object, entries: body.entry?.length ?? 0 })
 
   const supabase = await createClient('service_role')

--- a/web/tests/integration/webhook-whatsapp.test.ts
+++ b/web/tests/integration/webhook-whatsapp.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for /api/whatsapp-webhook. Closes part of BUG_HUNT_500 #476.
+ *
+ * Coverage:
+ *   - GET 200 + challenge echo when verify-token matches
+ *   - GET 403 when verify-token mismatches
+ *   - POST 401 when WHATSAPP_APP_SECRET unset (fail-closed)
+ *   - POST 401 when x-hub-signature-256 missing
+ *   - POST 401 when signature mismatches
+ *   - POST 200 + lead inserted on valid HMAC + valid payload
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createHmac } from 'crypto'
+
+const mockInsert = vi.fn()
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    from: () => ({ insert: (row: unknown) => mockInsert(row) }),
+  })),
+}))
+
+const ORIGINAL_ENV = { ...process.env }
+
+function signedRequest(rawBody: string, secret: string) {
+  const sig = createHmac('sha256', secret).update(rawBody).digest('hex')
+  return new Request('http://localhost/api/whatsapp-webhook', {
+    method: 'POST',
+    headers: { 'x-hub-signature-256': `sha256=${sig}` },
+    body: rawBody,
+  })
+}
+
+describe('/api/whatsapp-webhook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = {
+      ...ORIGINAL_ENV,
+      WHATSAPP_VERIFY_TOKEN: 'verify-me',
+      WHATSAPP_APP_SECRET: 'shared-secret',
+    }
+    mockInsert.mockReset()
+    mockInsert.mockResolvedValue({ error: null })
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  describe('GET (verify-token challenge)', () => {
+    it('returns 200 + the challenge when token matches', async () => {
+      const { GET } = await import('@/app/api/whatsapp-webhook/route')
+      const req = new Request(
+        'http://localhost/api/whatsapp-webhook?hub.mode=subscribe&hub.verify_token=verify-me&hub.challenge=42',
+        { method: 'GET' },
+      )
+      const res = await GET(req as never)
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('42')
+    })
+
+    it('returns 403 when token mismatches', async () => {
+      const { GET } = await import('@/app/api/whatsapp-webhook/route')
+      const req = new Request(
+        'http://localhost/api/whatsapp-webhook?hub.mode=subscribe&hub.verify_token=wrong&hub.challenge=42',
+        { method: 'GET' },
+      )
+      const res = await GET(req as never)
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe('POST (signed inbound)', () => {
+    it('returns 401 when WHATSAPP_APP_SECRET is unset (fail closed)', async () => {
+      delete process.env.WHATSAPP_APP_SECRET
+      const { POST } = await import('@/app/api/whatsapp-webhook/route')
+      const req = new Request('http://localhost/api/whatsapp-webhook', {
+        method: 'POST',
+        body: '{}',
+      })
+      const res = await POST(req as never)
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 401 when x-hub-signature-256 missing', async () => {
+      const { POST } = await import('@/app/api/whatsapp-webhook/route')
+      const req = new Request('http://localhost/api/whatsapp-webhook', {
+        method: 'POST',
+        body: '{}',
+      })
+      const res = await POST(req as never)
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 401 when signature mismatches', async () => {
+      const { POST } = await import('@/app/api/whatsapp-webhook/route')
+      const req = new Request('http://localhost/api/whatsapp-webhook', {
+        method: 'POST',
+        headers: { 'x-hub-signature-256': 'sha256=deadbeef' },
+        body: '{}',
+      })
+      const res = await POST(req as never)
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 200 + inserts lead on valid HMAC + valid payload', async () => {
+      const { POST } = await import('@/app/api/whatsapp-webhook/route')
+      const payload = JSON.stringify({
+        object: 'whatsapp_business_account',
+        entry: [
+          {
+            changes: [
+              {
+                value: {
+                  metadata: { phone_number_id: '595981000000' },
+                  contacts: [{ profile: { name: 'Maria' }, wa_id: '595987111222' }],
+                  messages: [
+                    { from: '595987111222', type: 'text', text: { body: 'Hola, info?' } },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      })
+      const req = signedRequest(payload, 'shared-secret')
+      const res = await POST(req as never)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.ok).toBe(true)
+      expect(body.inserted).toBe(1)
+      expect(mockInsert).toHaveBeenCalledTimes(1)
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Maria',
+          phone: '595987111222',
+          source: 'whatsapp',
+          referer: 'Hola, info?',
+        }),
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
**Real security bug found.** `/api/whatsapp-webhook` POST accepted ANY payload. Anyone on the internet could inject fake inbound messages into the `leads` table — pollute the CRM, trigger lead-status flows, etc.

## Fix
- Verify Meta's `x-hub-signature-256` HMAC against the raw body using `WHATSAPP_APP_SECRET`
- Fail closed when `WHATSAPP_APP_SECRET` is unset (401, not "skip")
- Constant-time comparison via `crypto.timingSafeEqual`

## Tests
6 integration tests cover:
- GET verify-token challenge: 200 + echo on match, 403 on mismatch
- POST: 401 when secret unset / signature missing / signature mismatch
- POST: 200 + lead inserted on valid HMAC + valid payload

## Docs
ENV_VARS.md updated with `WHATSAPP_VERIFY_TOKEN`, `WHATSAPP_APP_SECRET`, and `WHATSAPP_PHONE_SITE_MAP`.

## Closes
- BUG_HUNT_500 #476 (WhatsApp half — MP half not needed per ADR 0004)

## Action required after deploy
Set `WHATSAPP_APP_SECRET` on the VPS from Meta App Dashboard → App settings → Basic → "App secret". Until set, every WhatsApp inbound POST will 401-reject (fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)