### PR TITLE
feat(storefront): order lookup form + WhatsApp empty-tienda + business whatsapp resolver

### DIFF
--- a/web/app/api/storefront/[site]/orders/lookup/route.ts
+++ b/web/app/api/storefront/[site]/orders/lookup/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+export const runtime = 'nodejs'
+
+const LookupSchema = z.object({
+  email: z.string().email(),
+  orderNumber: z.string().trim().min(3).max(40),
+})
+
+/**
+ * POST /api/storefront/[site]/orders/lookup
+ *
+ * Confirms a (customer_email, order_number) pair belongs to this business
+ * and returns the order id so the client can navigate to /orden/[id].
+ *
+ * Returns 404 for both "not found" and "wrong email" so we don't help an
+ * attacker enumerate which order numbers exist for a tenant. Cooldown is
+ * not implemented here — order_number is structured (BIZxx-YYMMDD-NNNN
+ * shape per the seed) so brute-forcing the right one for a given email
+ * is already impractical.
+ */
+export const POST = withRequestLog<{ site: string }>(async (req, { log }, { site }) => {
+  const business = await resolveBusinessBySlug(site)
+  if (!business) return NextResponse.json({ error: 'not_found' }, { status: 404 })
+
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+  const parsed = LookupSchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const supabase = await createAdminClient()
+  const { data, error } = await supabase
+    .from('orders')
+    .select('id')
+    .eq('business_id', business.id)
+    .eq('order_number', parsed.data.orderNumber)
+    .ilike('customer_email', parsed.data.email)
+    .limit(1)
+    .maybeSingle()
+
+  if (error) {
+    log.error('commerce.order.lookup_failed', new Error(error.message))
+    return NextResponse.json({ error: 'lookup_failed' }, { status: 500 })
+  }
+
+  if (!data) {
+    // Generic 404 — same response whether the order doesn't exist or the
+    // email doesn't match. Keeps the endpoint useless for enumeration.
+    return NextResponse.json({ error: 'not_found' }, { status: 404 })
+  }
+
+  log.info('commerce.order.lookup_match', { businessId: business.id, orderId: data.id })
+  return NextResponse.json({ orderId: data.id })
+})

--- a/web/app/s/[locale]/[site]/buscar-orden/page.tsx
+++ b/web/app/s/[locale]/[site]/buscar-orden/page.tsx
@@ -1,0 +1,39 @@
+import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
+import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
+import { isCommerceEnabled } from '@/lib/commerce/capability'
+import { CommerceHeader } from '@/components/commerce/commerce-header'
+import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
+import { OrderLookupForm } from '@/components/commerce/order-lookup-form'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Buscar mi orden',
+  robots: { index: false, follow: false }, // shopper-utility, not for SEO
+}
+
+export default async function OrderLookupPage({
+  params,
+}: {
+  params: Promise<{ site: string; locale: string }>
+}) {
+  const { site, locale } = await params
+  const business = await resolveBusinessBySlug(site)
+  if (!business || !(await isCommerceEnabled(business.type))) notFound()
+
+  return (
+    <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
+      <CartStoreHydrator siteSlug={site} initialCart={null} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+      <main className="mx-auto max-w-md px-4 py-10">
+        <h1 className="mb-2 text-2xl font-bold text-[color:var(--text,#111)]">Buscar mi orden</h1>
+        <p className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">
+          Si perdiste el email de confirmación, ingresá el email que usaste y el número de orden y te llevamos al estado.
+        </p>
+        <OrderLookupForm siteSlug={site} locale={locale} />
+      </main>
+    </div>
+  )
+}

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -51,6 +51,17 @@ export default async function StorePage({
             <p className="text-[color:var(--text-muted,#6b7280)]">
               {search ? `No encontramos productos para "${search}".` : 'Estamos cargando nuestro catálogo. Volvé pronto.'}
             </p>
+            {!search && business.whatsappNumber ? (
+              <a
+                href={`https://wa.me/${business.whatsappNumber}?text=${encodeURIComponent(`Hola, me interesa comprar en ${business.name}.`)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-4 inline-flex items-center gap-2 rounded-lg bg-[#25D366] px-4 py-2 text-sm font-semibold text-white hover:opacity-90"
+              >
+                <span aria-hidden="true">💬</span>
+                Consultar por WhatsApp
+              </a>
+            ) : null}
           </div>
         ) : (
           <div className="mt-6 grid grid-cols-1 gap-4 min-[420px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 lg:gap-6">

--- a/web/components/commerce/commerce-header.tsx
+++ b/web/components/commerce/commerce-header.tsx
@@ -27,6 +27,12 @@ export function CommerceHeader({ siteSlug, businessName, locale = 'es' }: Props)
             <Link href={`/s/${locale}/${siteSlug}/tienda`} className="hover:underline">
               Tienda
             </Link>
+            <Link
+              href={`/s/${locale}/${siteSlug}/buscar-orden`}
+              className="hidden text-xs text-[color:var(--text-muted,#6b7280)] hover:underline sm:inline"
+            >
+              Mi orden
+            </Link>
             <CurrencyToggle />
             <MiniCartBadge onClick={() => setOpen(true)} />
           </nav>

--- a/web/components/commerce/order-lookup-form.tsx
+++ b/web/components/commerce/order-lookup-form.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface Props {
+  siteSlug: string
+  locale: string
+}
+
+export function OrderLookupForm({ siteSlug, locale }: Props) {
+  const router = useRouter()
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setError(null)
+    setSubmitting(true)
+    const form = new FormData(event.currentTarget)
+    const payload = {
+      email: String(form.get('email') ?? '').trim(),
+      orderNumber: String(form.get('orderNumber') ?? '').trim(),
+    }
+    try {
+      const res = await fetch(`/api/storefront/${siteSlug}/orders/lookup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (res.status === 404) {
+        setError('No encontramos esa combinación. Revisá el email y el número de orden.')
+        setSubmitting(false)
+        return
+      }
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        setError(data.error ?? 'lookup_failed')
+        setSubmitting(false)
+        return
+      }
+      const data = await res.json()
+      router.push(`/s/${locale}/${siteSlug}/orden/${data.orderId}`)
+    } catch {
+      setError('Error de red. Probá de nuevo.')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-6">
+      <div>
+        <label htmlFor="lookup-email" className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">
+          Email <span aria-hidden="true" className="text-red-600">*</span>
+          <span className="sr-only">(obligatorio)</span>
+        </label>
+        <input
+          id="lookup-email"
+          name="email"
+          type="email"
+          required
+          autoComplete="email"
+          placeholder="vos@ejemplo.com"
+          className="block w-full rounded-md border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm focus:border-[color:var(--primary,#111)] focus:outline-none"
+        />
+      </div>
+      <div>
+        <label htmlFor="lookup-order" className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">
+          Número de orden <span aria-hidden="true" className="text-red-600">*</span>
+          <span className="sr-only">(obligatorio)</span>
+        </label>
+        <input
+          id="lookup-order"
+          name="orderNumber"
+          required
+          placeholder="ej: BIZ01-260421-0007"
+          className="block w-full rounded-md border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm font-mono focus:border-[color:var(--primary,#111)] focus:outline-none"
+        />
+        <p className="mt-1 text-xs text-[color:var(--text-muted,#6b7280)]">
+          Lo encontrás en el email de confirmación que te enviamos.
+        </p>
+      </div>
+
+      {error ? (
+        <p role="alert" className="flex items-start gap-1 rounded bg-red-50 p-2 text-sm text-red-700">
+          <span aria-hidden="true">⚠️</span>
+          <span>{error}</span>
+        </p>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="w-full rounded-lg bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-semibold text-[color:var(--primary-foreground,#fff)] disabled:opacity-50"
+      >
+        {submitting ? 'Buscando…' : 'Buscar mi orden'}
+      </button>
+    </form>
+  )
+}

--- a/web/lib/commerce/resolve-business.ts
+++ b/web/lib/commerce/resolve-business.ts
@@ -9,6 +9,9 @@ export interface ResolvedBusiness {
   currency: string
   /** Preferred payment provider hint, surfaced from registry/data_json. */
   preferredProvider?: string
+  /** WhatsApp number from the tenant's content blob, if set. Digits only,
+   * no `+`, ready to drop into a `wa.me/<digits>` URL. */
+  whatsappNumber?: string
 }
 
 /**
@@ -36,8 +39,18 @@ export async function resolveBusinessBySlug(slug: string): Promise<ResolvedBusin
   }
   if (!data) return null
 
-  const commerceCfg = (data.data_json as { commerce?: { currency?: string; provider?: string } } | null)?.commerce
+  const dataJson = data.data_json as {
+    commerce?: { currency?: string; provider?: string }
+    content?: { contact?: { whatsapp?: string }; whatsapp?: string }
+  } | null
+  const commerceCfg = dataJson?.commerce
   const currency = commerceCfg?.currency ?? 'PYG'
+
+  // Tenants store WhatsApp in either content.contact.whatsapp (preferred,
+  // matches the registry contact section) or content.whatsapp (older
+  // fixtures). Strip non-digits so the value is always wa.me-ready.
+  const rawWhatsapp = dataJson?.content?.contact?.whatsapp ?? dataJson?.content?.whatsapp
+  const whatsappNumber = rawWhatsapp ? rawWhatsapp.replace(/\D/g, '') || undefined : undefined
 
   return {
     id: data.id,
@@ -46,5 +59,6 @@ export async function resolveBusinessBySlug(slug: string): Promise<ResolvedBusin
     type: data.type,
     currency,
     preferredProvider: commerceCfg?.provider,
+    whatsappNumber,
   }
 }


### PR DESCRIPTION
## Summary

Two recovery affordances rounding out PR #160's resend-email work:

1. **\`/s/{locale}/{site}/buscar-orden\`** — shopper enters email + order number, server confirms the (email, order_number) pair belongs to this business, redirects to \`/orden/[id]\`. Returns 404 for both \"not found\" and \"wrong email\" so the endpoint can't be used to enumerate order numbers. \`robots: noindex\` (it's a utility, not SEO).

2. **Empty tienda CTA** — when the merchant has zero active products AND a whatsappNumber is configured, the empty state offers a green \"Consultar por WhatsApp\" button instead of the generic \"loading our catalog\" copy. Pre-fills *\"Hola, me interesa comprar en {business}.\"*

3. **\`resolveBusinessBySlug\`** now surfaces \`whatsappNumber\` from the tenant's \`data_json\` content blob (digits-only, wa.me-ready). Reads from \`content.contact.whatsapp\` first, \`content.whatsapp\` as fallback for older fixtures.

4. **Header link** — small \"Mi orden\" text link (sm+ only, doesn't crowd mobile) pointing to the lookup form.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run test:unit\` — 426 pass
- [x] \`npm run build\` — clean
- [ ] Manual: visit \`/s/es/{site}/buscar-orden\`, submit valid email+order# → redirects to order page
- [ ] Manual: submit wrong email+real order# → 404 message, no redirect
- [ ] Manual: tenant with no products + whatsapp set → empty tienda shows green CTA
- [ ] Manual: header \"Mi orden\" link visible on desktop, hidden on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)