### PR TITLE
fix(api): Calendly webhook signature verification (#476)

### DIFF
--- a/docs/BUG_HUNT_500.md
+++ b/docs/BUG_HUNT_500.md
@@ -9,9 +9,9 @@
 
 | Status | Count | Items |
 |---|---|---|
-| ✅ Closed | 90 | see closure log below |
+| ✅ Closed | 91 | see closure log below |
 | 🟡 In progress | 0 | — |
-| 🔴 Open | 410 | the rest |
+| 🔴 Open | 409 | the rest |
 | 🔴 Blocked on user | ~30 | listed at bottom |
 
 **Lighthouse delta** (post W4):
@@ -214,6 +214,14 @@ Closure log:
   6 tests cover the GET verify-challenge flow + POST signed-inbound + 3
   failure modes. ENV_VARS.md updated. MP webhook half of #476 not needed
   per ADR 0004 (MP removed in favor of Pagopar).
+- **#476 (calendly half) + auth fix** — `/api/calendly-webhook` had a
+  TODO for signature verification — only checked the header EXISTS in
+  production, didn't verify it. Anyone could inject fake bookings.
+  Added Calendly `calendly-webhook-signature` HMAC verification using
+  `CALENDLY_SIGNING_KEY` (format `t=<unix>,v1=<hex>`), 5-minute
+  replay-protection window, fail-closed when unset. 7 tests cover
+  signature verification, replay rejection, and event handling.
+  ENV_VARS.md updated.
 - **#479** — `<SkipToContent>` link in root layout, anchored to `#main-content`;
   added id to `<main>` on landing + 11 high-traffic marketing routes.
 - **#487** — covered by `docs/runbooks/ADD_NEW_TENANT.md` "Promote a demo to a real tenant" section (no separate doc needed).

--- a/docs/runbooks/ENV_VARS.md
+++ b/docs/runbooks/ENV_VARS.md
@@ -84,6 +84,12 @@ it back. The diagnostics route at `/api/diagnostics` reflects current values.
 | `WHATSAPP_APP_SECRET` | Meta App Dashboard → App settings → Basic → "App secret" | Used by POST `/api/whatsapp-webhook` to verify Meta's `x-hub-signature-256` HMAC. **Without this set, every POST is 401-rejected** (fail-closed). |
 | `WHATSAPP_PHONE_SITE_MAP` | Self-managed JSON, e.g. `{"5959810000":"nexa-paraguay"}` | Maps Meta `phone_number_id` to a tenant slug for inbound lead routing. |
 
+### Calendly webhook
+
+| Var | Where to get | Notes |
+|---|---|---|
+| `CALENDLY_SIGNING_KEY` | Calendly account → Webhooks → endpoint detail → "Signing key" | Used by POST `/api/calendly-webhook` to verify the `calendly-webhook-signature` HMAC (format `t=<unix>,v1=<hex>`). **Without this set, every POST is 401-rejected** (fail-closed). 5-minute replay-protection window. |
+
 ### Mailchimp (deferred per Q8.2)
 
 Skip until the newsletter flow becomes a priority. When you wire it:

--- a/web/app/api/calendly-webhook/route.ts
+++ b/web/app/api/calendly-webhook/route.ts
@@ -4,16 +4,56 @@
  * is logged (future: mark the lead row cancelled once we persist the
  * calendly event_uri on the lead).
  *
- * Signature verification: when env.CALENDLY_SIGNING_KEY is set we require
- * the `calendly-webhook-signature` header. In production with no header set,
- * requests are rejected as a safety net.
+ * Signature verification: Calendly signs each webhook with HMAC-SHA256.
+ * The `calendly-webhook-signature` header has the format
+ * `t=<unix-timestamp>,v1=<hex-hmac>`. Signed payload is
+ * `${timestamp}.${rawBody}`. Without `CALENDLY_SIGNING_KEY` configured
+ * the route fail-closes (401) — previously the route accepted any
+ * payload with any header value (TODO had been left open).
  */
 
 import { NextResponse } from 'next/server'
+import { createHmac, timingSafeEqual } from 'crypto'
 import { withRequestLog } from '@/lib/api/with-request-log'
 import { createClient } from '@/lib/supabase/server'
 
 export const runtime = 'nodejs'
+
+/**
+ * Verify Calendly's `calendly-webhook-signature` header.
+ * Header format: `t=<unix-timestamp>,v1=<hex-hmac>`.
+ * Returns true on a valid v1 signature within the freshness window.
+ */
+function verifyCalendlySignature(
+  rawBody: string,
+  header: string | null,
+  secret: string,
+  freshnessSeconds = 300,
+): boolean {
+  if (!header) return false
+  const parts = header.split(',').reduce<Record<string, string>>((acc, kv) => {
+    const [k, v] = kv.split('=')
+    if (k && v) acc[k.trim()] = v.trim()
+    return acc
+  }, {})
+  const t = parts.t
+  const v1 = parts.v1
+  if (!t || !v1) return false
+
+  // Reject replays older than the freshness window.
+  const ts = Number(t)
+  if (!Number.isFinite(ts)) return false
+  const ageSec = Math.abs(Date.now() / 1000 - ts)
+  if (ageSec > freshnessSeconds) return false
+
+  const expected = createHmac('sha256', secret).update(`${t}.${rawBody}`).digest('hex')
+  if (v1.length !== expected.length) return false
+  try {
+    return timingSafeEqual(Buffer.from(v1, 'hex'), Buffer.from(expected, 'hex'))
+  } catch {
+    return false
+  }
+}
 
 interface CalendlyEvent {
   event?: string
@@ -34,13 +74,26 @@ interface CalendlyEvent {
 }
 
 export const POST = withRequestLog(async (req, { log }) => {
-  const signature = req.headers.get('calendly-webhook-signature')
-  if (!signature && process.env.NODE_ENV === 'production') {
-    return NextResponse.json({ error: 'missing_signature' }, { status: 401 })
+  const secret = process.env.CALENDLY_SIGNING_KEY
+  if (!secret) {
+    log.warn('calendly.webhook.not_configured')
+    return NextResponse.json({ error: 'webhook_not_configured' }, { status: 401 })
   }
-  // TODO(calendly): verify signature against env.CALENDLY_SIGNING_KEY once issued.
 
-  const body = (await req.json().catch(() => ({}))) as CalendlyEvent
+  const rawBody = await req.text()
+  const valid = verifyCalendlySignature(rawBody, req.headers.get('calendly-webhook-signature'), secret)
+  if (!valid) {
+    log.warn('calendly.webhook.signature_invalid')
+    return NextResponse.json({ error: 'invalid_signature' }, { status: 401 })
+  }
+
+  let body: CalendlyEvent
+  try {
+    body = JSON.parse(rawBody) as CalendlyEvent
+  } catch (err) {
+    log.warn('calendly.webhook.bad_json', { error: err instanceof Error ? err.message : String(err) })
+    return NextResponse.json({ error: 'bad_json' }, { status: 400 })
+  }
   const kind = body.event
   const invitee = body.payload?.invitee
   log.info('calendly webhook received', {

--- a/web/tests/integration/webhook-calendly.test.ts
+++ b/web/tests/integration/webhook-calendly.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for /api/calendly-webhook. Closes part of BUG_HUNT_500 #476.
+ *
+ * Coverage:
+ *   - 401 when CALENDLY_SIGNING_KEY unset (fail-closed)
+ *   - 401 when calendly-webhook-signature header missing
+ *   - 401 when signature has wrong format
+ *   - 401 when timestamp is too old (replay protection)
+ *   - 401 when v1 signature mismatches
+ *   - 200 + lead inserted on valid signed `invitee.created`
+ *   - 200 + log on valid signed `invitee.canceled` (no lead insert)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createHmac } from 'crypto'
+
+const mockInsert = vi.fn()
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    from: () => ({ insert: (row: unknown) => mockInsert(row) }),
+  })),
+}))
+
+const ORIGINAL_ENV = { ...process.env }
+const SECRET = 'calendly-test-secret'
+
+function signedRequest(rawBody: string, secret = SECRET, ageSec = 0) {
+  const t = String(Math.floor(Date.now() / 1000) - ageSec)
+  const v1 = createHmac('sha256', secret).update(`${t}.${rawBody}`).digest('hex')
+  return new Request('http://localhost/api/calendly-webhook', {
+    method: 'POST',
+    headers: { 'calendly-webhook-signature': `t=${t},v1=${v1}` },
+    body: rawBody,
+  })
+}
+
+describe('/api/calendly-webhook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV, CALENDLY_SIGNING_KEY: SECRET }
+    mockInsert.mockReset()
+    mockInsert.mockResolvedValue({ error: null })
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('returns 401 when CALENDLY_SIGNING_KEY is unset (fail closed)', async () => {
+    delete process.env.CALENDLY_SIGNING_KEY
+    const { POST } = await import('@/app/api/calendly-webhook/route')
+    const req = new Request('http://localhost/api/calendly-webhook', {
+      method: 'POST',
+      body: '{}',
+    })
+    const res = await POST(req as never)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when signature header is missing', async () => {
+    const { POST } = await import('@/app/api/calendly-webhook/route')
+    const req = new Request('http://localhost/api/calendly-webhook', {
+      method: 'POST',
+      body: '{}',
+    })
+    const res = await POST(req as never)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when signature has the wrong format', async () => {
+    const { POST } = await import('@/app/api/calendly-webhook/route')
+    const req = new Request('http://localhost/api/calendly-webhook', {
+      method: 'POST',
+      headers: { 'calendly-webhook-signature': 'not-a-real-signature' },
+      body: '{}',
+    })
+    const res = await POST(req as never)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when timestamp is older than freshness window (replay)', async () => {
+    const { POST } = await import('@/app/api/calendly-webhook/route')
+    // 600s old → outside the 300s default freshness window
+    const req = signedRequest('{}', SECRET, 600)
+    const res = await POST(req as never)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when v1 signature mismatches', async () => {
+    const { POST } = await import('@/app/api/calendly-webhook/route')
+    const t = String(Math.floor(Date.now() / 1000))
+    const req = new Request('http://localhost/api/calendly-webhook', {
+      method: 'POST',
+      headers: {
+        'calendly-webhook-signature': `t=${t},v1=${'a'.repeat(64)}`,
+      },
+      body: '{"event":"invitee.created"}',
+    })
+    const res = await POST(req as never)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 + inserts lead on valid invitee.created', async () => {
+    const { POST } = await import('@/app/api/calendly-webhook/route')
+    const payload = JSON.stringify({
+      event: 'invitee.created',
+      payload: {
+        event: { start_time: '2026-04-30T15:00:00Z', uri: 'https://api.calendly.com/...' },
+        invitee: { email: 'lead@example.com', name: 'Lead Maria', text_reminder_number: '+595981000000' },
+        tracking: { utm_source: 'salon-maria', utm_medium: 'whatsapp' },
+      },
+    })
+    const req = signedRequest(payload)
+    const res = await POST(req as never)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.received).toBe('invitee.created')
+    expect(mockInsert).toHaveBeenCalledTimes(1)
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        site_slug: 'salon-maria',
+        email: 'lead@example.com',
+        name: 'Lead Maria',
+        source: 'calendly',
+      }),
+    )
+  })
+
+  it('returns 200 + does not insert on invitee.canceled', async () => {
+    const { POST } = await import('@/app/api/calendly-webhook/route')
+    const payload = JSON.stringify({
+      event: 'invitee.canceled',
+      payload: { invitee: { email: 'lead@example.com' }, cancellation: { reason: 'no longer needed' } },
+    })
+    const req = signedRequest(payload)
+    const res = await POST(req as never)
+    expect(res.status).toBe(200)
+    expect(mockInsert).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
**Real security bug found.** `/api/calendly-webhook` had a TODO for signature verification — only checked the `calendly-webhook-signature` header EXISTS in production, didn't verify it. Anyone could inject fake bookings into the `leads` table.

## Fix
- Verify Calendly's `calendly-webhook-signature` header (format: `t=<unix-timestamp>,v1=<hex-hmac>`)
- HMAC-SHA256 over `${timestamp}.${rawBody}` using `CALENDLY_SIGNING_KEY`
- 5-minute replay-protection window
- Fail closed when `CALENDLY_SIGNING_KEY` unset (401)
- Constant-time comparison via `crypto.timingSafeEqual`

## Tests
7 integration tests cover all 401 paths (no secret, no header, bad format, replay, mismatch) + 200 paths (valid `invitee.created` → lead inserted; valid `invitee.canceled` → no insert).

## Action required after deploy
Set `CALENDLY_SIGNING_KEY` on the VPS from Calendly account → Webhooks → endpoint detail → "Signing key". Until set, every Calendly POST returns 401.

## Closes
- BUG_HUNT_500 #476 (calendly half — whatsapp half closed in PR #161; MP half not needed per ADR 0004)

🤖 Generated with [Claude Code](https://claude.com/claude-code)