### PR TITLE
feat(storefront): recently-viewed rail on PDP + printable order confirmation

### DIFF
--- a/web/app/s/[locale]/[site]/orden/[id]/page.tsx
+++ b/web/app/s/[locale]/[site]/orden/[id]/page.tsx
@@ -31,9 +31,11 @@ export default async function OrderPage({
   const initial = status === 'success' || status === 'pending' || status === 'failure' ? status : null
 
   return (
-    <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
-      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
-      <OrderConfirmation siteSlug={site} locale={locale} initialOrder={order} initialStatus={initial} />
+    <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)] print:bg-white">
+      <div className="print:hidden">
+        <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+      </div>
+      <OrderConfirmation siteSlug={site} locale={locale} businessName={business.name} initialOrder={order} initialStatus={initial} />
     </div>
   )
 }

--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -11,6 +11,8 @@ import { formatCents } from '@/lib/commerce/compute-totals'
 import { ProductDetailActions } from '@/components/commerce/product-detail-actions'
 import { ProductCard } from '@/components/commerce/product-card'
 import { ProductShare } from '@/components/commerce/product-share'
+import { RecordRecentVisit } from '@/components/commerce/record-recent-visit'
+import { RecentlyViewedRail } from '@/components/commerce/recently-viewed-rail'
 import { PriceDisplay } from '@/components/commerce/price-display'
 import { loadPygRates } from '@/lib/commerce/currency-server'
 import { env } from '@/lib/env'
@@ -139,6 +141,18 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
           </div>
         </div>
       </main>
+
+      <RecordRecentVisit
+        siteSlug={site}
+        productId={product.id}
+        productSlug={product.slug}
+        productName={product.name}
+        priceCents={product.priceCents}
+        currency={product.currency}
+        imageUrl={cover?.url ?? null}
+      />
+
+      <RecentlyViewedRail siteSlug={site} locale={locale} excludeId={product.id} />
 
       {related.length > 0 ? (
         <section aria-labelledby="related-heading" className="mx-auto max-w-5xl px-4 pb-12">

--- a/web/components/commerce/order-confirmation.tsx
+++ b/web/components/commerce/order-confirmation.tsx
@@ -8,11 +8,13 @@ import { formatCents } from '@/lib/commerce/compute-totals'
 interface Props {
   siteSlug: string
   locale: string
+  /** Used as the print-receipt header so the printed copy identifies the seller. */
+  businessName?: string
   initialOrder: Order
   initialStatus?: 'success' | 'pending' | 'failure' | null
 }
 
-export function OrderConfirmation({ siteSlug, locale, initialOrder, initialStatus }: Props) {
+export function OrderConfirmation({ siteSlug, locale, businessName, initialOrder, initialStatus }: Props) {
   const [order, setOrder] = useState(initialOrder)
   const [polling, setPolling] = useState(initialOrder.status === 'awaiting_payment')
   const [resendState, setResendState] = useState<
@@ -64,10 +66,15 @@ export function OrderConfirmation({ siteSlug, locale, initialOrder, initialStatu
   const body = bodyFor(order.status, initialStatus ?? null)
 
   return (
-    <div className="mx-auto max-w-2xl px-4 py-12">
-      <div className="rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-8 text-center">
-        <h1 className="mb-2 text-2xl font-bold text-[color:var(--text,#111)]">{headline}</h1>
-        <p className="mb-6 text-[color:var(--text-muted,#6b7280)]">{body}</p>
+    <div className="mx-auto max-w-2xl px-4 py-12 print:py-4">
+      <div className="rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-8 text-center print:rounded-none print:border-0 print:p-0 print:text-left">
+        {businessName ? (
+          <p className="mb-2 hidden text-sm font-semibold uppercase tracking-wide text-[color:var(--text-muted,#6b7280)] print:block">
+            {businessName} — Comprobante
+          </p>
+        ) : null}
+        <h1 className="mb-2 text-2xl font-bold text-[color:var(--text,#111)] print:text-xl">{headline}</h1>
+        <p className="mb-6 text-[color:var(--text-muted,#6b7280)] print:hidden">{body}</p>
         <p className="mb-1 text-sm text-[color:var(--text-muted,#6b7280)]">Número de orden</p>
         <p className="mb-6 font-mono text-lg font-semibold">{order.orderNumber}</p>
 
@@ -91,7 +98,7 @@ export function OrderConfirmation({ siteSlug, locale, initialOrder, initialStatu
           Enviamos la confirmación a <strong>{order.customerEmail}</strong>.
         </p>
 
-        <div className="mb-6 text-xs">
+        <div className="mb-6 text-xs print:hidden">
           {resendState.kind === 'sent' ? (
             <p className="text-green-700">✓ Te reenviamos el email a {resendState.sentTo}.</p>
           ) : resendState.kind === 'rate_limited' ? (
@@ -110,12 +117,21 @@ export function OrderConfirmation({ siteSlug, locale, initialOrder, initialStatu
           )}
         </div>
 
-        <Link
-          href={`/s/${locale}/${siteSlug}/tienda`}
-          className="inline-block rounded-lg border border-[color:var(--primary,#111)] px-4 py-2 font-medium text-[color:var(--primary,#111)] hover:bg-[color:var(--primary,#111)] hover:text-[color:var(--primary-foreground,#fff)]"
-        >
-          Seguir comprando
-        </Link>
+        <div className="flex flex-wrap justify-center gap-2 print:hidden">
+          <Link
+            href={`/s/${locale}/${siteSlug}/tienda`}
+            className="inline-block rounded-lg border border-[color:var(--primary,#111)] px-4 py-2 font-medium text-[color:var(--primary,#111)] hover:bg-[color:var(--primary,#111)] hover:text-[color:var(--primary-foreground,#fff)]"
+          >
+            Seguir comprando
+          </Link>
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className="inline-block rounded-lg border border-[color:var(--border,#e5e7eb)] px-4 py-2 font-medium text-[color:var(--text-muted,#6b7280)] hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+          >
+            Imprimir comprobante
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/web/components/commerce/recently-viewed-rail.tsx
+++ b/web/components/commerce/recently-viewed-rail.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import Link from 'next/link'
+import { readRecentlyViewed, type RecentlyViewedItem } from '@/lib/stores/recently-viewed'
+import { formatCents } from '@/lib/commerce/compute-totals'
+
+interface Props {
+  siteSlug: string
+  locale: string
+  /** Product id to filter out (e.g., the PDP you're viewing right now). */
+  excludeId?: string
+  /** Max rendered items. Defaults to 6. */
+  limit?: number
+}
+
+// No live updates needed — the rail is read-once on mount. The empty
+// subscribe satisfies useSyncExternalStore so we get a clean
+// SSR-safe load without the "setState in effect" cascading-renders
+// lint warning that the useState+useEffect pattern triggers.
+const noopSubscribe = () => () => {}
+
+/**
+ * Reads recently-viewed items from localStorage and renders a horizontal
+ * rail. SSR returns the empty list (returns null), then on the client
+ * useSyncExternalStore swaps in the real items once mounted.
+ */
+export function RecentlyViewedRail({ siteSlug, locale, excludeId, limit = 6 }: Props) {
+  const all = useSyncExternalStore<RecentlyViewedItem[]>(
+    noopSubscribe,
+    () => readRecentlyViewed(siteSlug),
+    () => [],
+  )
+  const items = all.filter((it) => it.id !== excludeId).slice(0, limit)
+
+  if (items.length === 0) return null
+
+  return (
+    <section aria-labelledby="recent-heading" className="mx-auto max-w-5xl px-4 pb-8">
+      <h2 id="recent-heading" className="mb-3 text-xl font-semibold text-[color:var(--text,#111)]">
+        Vistos recientemente
+      </h2>
+      <ul className="-mx-4 flex snap-x snap-mandatory gap-3 overflow-x-auto px-4 pb-2">
+        {items.map((it) => (
+          <li key={it.id} className="w-32 flex-shrink-0 snap-start">
+            <Link
+              href={`/s/${locale}/${siteSlug}/producto/${it.slug}`}
+              className="block rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-2 hover:border-[color:var(--primary,#111)]"
+            >
+              {it.imageUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={it.imageUrl}
+                  alt=""
+                  loading="lazy"
+                  className="aspect-square w-full rounded object-cover"
+                />
+              ) : (
+                <div className="aspect-square w-full rounded bg-[color:var(--surface-muted,#f3f4f6)]" />
+              )}
+              <p className="mt-2 line-clamp-2 text-xs font-medium text-[color:var(--text,#111)]">{it.name}</p>
+              <p className="mt-1 text-xs font-semibold text-[color:var(--text,#111)]">
+                {formatCents(it.priceCents, it.currency)}
+              </p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/web/components/commerce/record-recent-visit.tsx
+++ b/web/components/commerce/record-recent-visit.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect } from 'react'
+import { recordRecentlyViewed } from '@/lib/stores/recently-viewed'
+
+interface Props {
+  siteSlug: string
+  productId: string
+  productSlug: string
+  productName: string
+  priceCents: number
+  currency: string
+  imageUrl?: string | null
+}
+
+/**
+ * Side-effect-only client component. Renders nothing; on mount adds the
+ * current product to the shopper's localStorage recently-viewed list.
+ * Lives separately from PriceDisplay/etc. so a single PDP visit doesn't
+ * re-record on every render.
+ */
+export function RecordRecentVisit({ siteSlug, productId, productSlug, productName, priceCents, currency, imageUrl }: Props) {
+  useEffect(() => {
+    recordRecentlyViewed(siteSlug, {
+      id: productId,
+      slug: productSlug,
+      name: productName,
+      priceCents,
+      currency,
+      imageUrl: imageUrl ?? null,
+    })
+  }, [siteSlug, productId, productSlug, productName, priceCents, currency, imageUrl])
+  return null
+}

--- a/web/lib/stores/recently-viewed.ts
+++ b/web/lib/stores/recently-viewed.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure-client recently-viewed-products store. localStorage only — no SSR,
+ * no auth required, no backend trip. Shopper-private by design: the merchant
+ * never sees what an individual visitor browsed.
+ */
+
+export interface RecentlyViewedItem {
+  id: string
+  slug: string
+  name: string
+  priceCents: number
+  currency: string
+  imageUrl?: string | null
+  visitedAt: number
+}
+
+const MAX_ITEMS = 8
+
+function storageKey(siteSlug: string): string {
+  return `paragu_recent_${siteSlug}`
+}
+
+export function readRecentlyViewed(siteSlug: string): RecentlyViewedItem[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = window.localStorage.getItem(storageKey(siteSlug))
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    // Defensive: only keep entries with the required fields. Older payloads
+    // from a prior schema get dropped silently rather than blowing up the rail.
+    return parsed
+      .filter((it): it is RecentlyViewedItem =>
+        typeof it === 'object' && it !== null
+        && typeof it.id === 'string'
+        && typeof it.slug === 'string'
+        && typeof it.name === 'string'
+        && typeof it.priceCents === 'number',
+      )
+      .slice(0, MAX_ITEMS)
+  } catch {
+    return []
+  }
+}
+
+export function recordRecentlyViewed(siteSlug: string, item: Omit<RecentlyViewedItem, 'visitedAt'>): void {
+  if (typeof window === 'undefined') return
+  try {
+    const existing = readRecentlyViewed(siteSlug).filter((it) => it.id !== item.id)
+    const next: RecentlyViewedItem[] = [{ ...item, visitedAt: Date.now() }, ...existing].slice(0, MAX_ITEMS)
+    window.localStorage.setItem(storageKey(siteSlug), JSON.stringify(next))
+  } catch {
+    // Storage quota / private mode — silently no-op. The rail just won't appear.
+  }
+}


### PR DESCRIPTION
## Summary

Two more shopper niceties:

1. **Recently-viewed rail on PDP** — visiting a product records it in localStorage (id, slug, name, price, cover URL — capped at 8, deduped, most-recent-first). \`<RecentlyViewedRail>\` renders a horizontal scrollable strip showing up to 6, filtering out the product you're currently viewing. Pure client-side, no schema, no API trip — **shopper-private by design** (the merchant never sees individual browsing history).

   Uses \`useSyncExternalStore\` to avoid the \"setState in effect\" lint warning the obvious \`useState\`+\`useEffect\` pattern triggers (same trick as the currency toggle).

2. **Printable order confirmation** — header, resend block, \"Seguir comprando\" button, and pending body text all hidden under \`print:hidden\`. New \"Imprimir comprobante\" button calls \`window.print()\`. Prints as a clean receipt: business name + order number + items + total only.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean (no setState-in-effect)
- [x] \`npm run test:unit\` — 426 pass
- [x] \`npm run build\` — clean
- [ ] Manual: visit 3 different PDPs, confirm rail shows the previous 2 (not the current)
- [ ] Manual: order confirmation → \"Imprimir comprobante\" → preview shows only business name + order summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)