### PR TITLE
fix(docker): copy CHANGELOG.md so /changelog page builds on VPS

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -43,6 +43,11 @@ COPY --from=deps /app/node_modules ./web/node_modules
 COPY web ./web
 COPY src ./src
 COPY sites ./sites
+# CHANGELOG.md is read at build time by web/app/changelog/page.tsx (via
+# process.cwd() + '..'). Without this file the static-generation step
+# throws ENOENT and the build fails. Keep this copy until the changelog
+# page is refactored to embed content at generate-tenant-data time.
+COPY CHANGELOG.md ./CHANGELOG.md
 
 # Build inside web/
 WORKDIR /app/web


### PR DESCRIPTION
## Summary

VPS deploys have been failing on **every commit since c670026** (the PR that added the public `/changelog` page).

## Root cause

`web/app/changelog/page.tsx:34`:
\`\`\`ts
const path = resolve(process.cwd(), '..', 'CHANGELOG.md')
return readFileSync(path, 'utf-8')
\`\`\`

This runs at Next.js build time (static generation). It expects `CHANGELOG.md` one dir up from cwd.

- **Local / Cloudflare Pages**: cwd = `.../web/`, so `../CHANGELOG.md` = `.../CHANGELOG.md` — exists after git clone. ✅
- **VPS Docker build**: Dockerfile only copies `web/`, `src/`, `sites/` into the build context. `CHANGELOG.md` is not copied. readFileSync throws ENOENT → `npm run build` exits 1 → image build fails → deploy fails. 🔴

## Timeline

VPS deploys went 100% green → 100% red starting at the commit that introduced the changelog page. 7 consecutive failed deploys.

## Fix

One-line addition to `web/Dockerfile` builder stage: `COPY CHANGELOG.md ./CHANGELOG.md`. Comment explains why.

## Test plan

- [x] Verified locally: `docker build -f web/Dockerfile . -t paragu-ai:test` completes end-to-end including `npm run build` step (311 static pages generated).
- [x] Only 2 docker warnings remain (pre-existing SecretsUsedInArgOrEnv for Supabase ARGs — unrelated).
- [ ] After merge: next push to Main should see `Deploy to Hostinger VPS` workflow green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)