### PR TITLE
fix(routing): register fun4me + 3 other real tenants in canonical site list

### DIFF
--- a/web/lib/engine/static-sites.ts
+++ b/web/lib/engine/static-sites.ts
@@ -31,6 +31,42 @@ export const SITES = {
     locales: ['es', 'en', 'pt'],
     pages: ['home', 'propiedades', 'servicios', 'contacto', 'privacidad'],
   },
+  'fun4me': {
+    slug: 'fun4me',
+    vertical: 'retail-local',
+    country: 'Paraguay',
+    domain: '',
+    defaultLocale: 'es',
+    locales: ['es'],
+    pages: ['home', 'store', 'bundles', 'gift-cards', 'subscriptions', 'loyalty', 'size-guide', 'reserva-en-tienda'],
+  },
+  'dayah-litworks': {
+    slug: 'dayah-litworks',
+    vertical: 'portfolio-professional',
+    country: 'Paraguay',
+    domain: 'dayah-litworks.com',
+    defaultLocale: 'es',
+    locales: ['es'],
+    pages: ['home'],
+  },
+  'de-abasto-a-casa': {
+    slug: 'de-abasto-a-casa',
+    vertical: 'food-beverage',
+    country: 'Paraguay',
+    domain: 'deabastoacasa.com.py',
+    defaultLocale: 'es',
+    locales: ['es'],
+    pages: ['home'],
+  },
+  'granja-cabral': {
+    slug: 'granja-cabral',
+    vertical: 'agriculture-agribusiness',
+    country: 'Paraguay',
+    domain: 'granjacabral.com.py',
+    defaultLocale: 'es',
+    locales: ['es'],
+    pages: ['home'],
+  },
 } as const
 
 export type SiteSlug = keyof typeof SITES


### PR DESCRIPTION
## Problem

\`/fun4me\` returns 404 and \`/s/es/fun4me\` returns 500 on production.

## Root cause

\`listSiteSlugs()\` in \`web/lib/engine/site-loader.ts\` returns \`Object.keys(CANONICAL_SITES)\` where \`CANONICAL_SITES\` = \`web/lib/engine/static-sites.ts\`. That file only listed the three Nexa tenants.

Impact on the four real non-Nexa tenants (fun4me, dayah-litworks, de-abasto-a-casa, granja-cabral):

1. The \`/[business]/page.tsx\` flat-URL redirect helper \`siteRedirectPath(slug)\` would not find them → no redirect → falls through to \`loadBusiness()\` → null → \`notFound()\`. Result: 404 on \`/fun4me\`.
2. The \`/s/[locale]/[site]/[[...page]]\` route's \`generateStaticParams\` iterates \`listSiteSlugs()\` → these tenants never pre-rendered. Runtime SSR (\`dynamicParams: true\`) should still kick in, but fails or gets inconsistent caching.

Meanwhile the underlying data was fine — \`sites/fun4me/\`, \`sites/dayah-litworks/\`, \`sites/de-abasto-a-casa/\`, \`sites/granja-cabral/\` all have valid site.json + pages + content.

## Fix

Add the four tenants to \`static-sites.ts\`.

## Verification

\`composeSitePage\` works for every page of every tenant (compose log written):
- fun4me/es: home, store, bundles, gift-cards, subscriptions, loyalty, size-guide, reserva-en-tienda — all OK
- dayah-litworks/es/home — OK
- de-abasto-a-casa/es/home — OK
- granja-cabral/es/home — OK

\`npm run build\` green: 311/311 static pages.

## Why was this ever okay?

PR #154 shipped fun4me as a new tenant but did not register it in \`static-sites.ts\`. Same gap existed for the other three real tenants already shipped. The \`listSiteSlugs\` abstraction made this non-obvious — the data was there but not exposed.

## Follow-up

Consider making \`listSiteSlugs()\` read from the filesystem (\`sites/*\`) or from the auto-generated tenant-data module, so adding a new tenant is a one-file change. Out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)