### PR TITLE
feat(engine): featured-products homepage section (live DB, click-through to PDP)

### DIFF
--- a/web/components/sections/featured-products-section.tsx
+++ b/web/components/sections/featured-products-section.tsx
@@ -1,0 +1,96 @@
+import Link from 'next/link'
+import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
+import { isCommerceEnabled } from '@/lib/commerce/capability'
+import { listActiveProducts } from '@/lib/commerce/products'
+import { formatCents } from '@/lib/commerce/compute-totals'
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+
+export interface FeaturedProductsSectionProps {
+  siteSlug: string
+  businessName: string
+  title: string
+  subtitle?: string
+  viewAllText: string
+  limit: number
+  /** Optional — the URL locale the page was rendered at. Defaults to 'es'. */
+  locale?: string
+}
+
+/**
+ * Server-rendered homepage "featured products" rail. Queries the live
+ * commerce DB at render time so what shoppers see on the landing page
+ * matches tienda. Early-returns null when the business has no active
+ * products or commerce is disabled, so tenants can keep the section in
+ * their page config without worrying about empty states.
+ *
+ * Unlike ProductCatalogSection (static JSON, WhatsApp-to-order), this
+ * links to real PDPs. Add-to-cart happens there — homepage's job is
+ * discovery, not conversion.
+ */
+export async function FeaturedProductsSection({
+  siteSlug,
+  title,
+  subtitle,
+  viewAllText,
+  limit,
+  locale = 'es',
+}: FeaturedProductsSectionProps) {
+  const business = await resolveBusinessBySlug(siteSlug)
+  if (!business || !(await isCommerceEnabled(business.type))) return null
+
+  const products = await listActiveProducts(business.id, { limit, sort: 'newest' })
+  if (products.length === 0) return null
+
+  return (
+    <section className="py-12" aria-labelledby="featured-products-heading">
+      <Container>
+        <div className="mb-6 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <Heading level={2} id="featured-products-heading" className="text-3xl font-bold text-[color:var(--text,#111)]">
+              {title}
+            </Heading>
+            {subtitle ? <p className="mt-1 text-[color:var(--text-muted,#6b7280)]">{subtitle}</p> : null}
+          </div>
+          <Link
+            href={`/s/${locale}/${siteSlug}/tienda`}
+            className="text-sm font-medium text-[color:var(--primary,#111)] underline-offset-4 hover:underline"
+          >
+            {viewAllText} →
+          </Link>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 min-[420px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
+          {products.map((p) => {
+            const cover = p.images.find((i) => i.isCover) ?? p.images[0]
+            return (
+              <Link
+                key={p.id}
+                href={`/s/${locale}/${siteSlug}/producto/${p.slug}`}
+                className="group block overflow-hidden rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] transition hover:border-[color:var(--primary,#111)]"
+              >
+                {cover?.url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={cover.url}
+                    alt={cover.alt ?? p.name}
+                    loading="lazy"
+                    className="aspect-square w-full object-cover transition group-hover:scale-[1.02]"
+                  />
+                ) : (
+                  <div className="aspect-square w-full bg-[color:var(--surface-muted,#f3f4f6)]" />
+                )}
+                <div className="p-3">
+                  <p className="line-clamp-2 text-sm font-medium text-[color:var(--text,#111)]">{p.name}</p>
+                  <p className="mt-1 text-sm font-semibold text-[color:var(--text,#111)]">
+                    {formatCents(p.priceCents, p.currency)}
+                  </p>
+                </div>
+              </Link>
+            )
+          })}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/lib/engine/compose.ts
+++ b/web/lib/engine/compose.ts
@@ -39,6 +39,7 @@ export type SectionType =
   | 'quoteForm'
   | 'emergencyIndicator'
   | 'productCatalog'
+  | 'featuredProducts'
   | 'gallery'
   | 'team'
   | 'testimonials'
@@ -364,6 +365,8 @@ export const SECTION_MAP: Record<string, SectionType> = {
   testimonial: 'testimonials',
   testimonials: 'testimonials',
   productCatalog: 'productCatalog',
+  featuredProducts: 'featuredProducts',
+  'featured-products': 'featuredProducts',
   locationBlock: 'contact',
   contactSplit: 'contact',
   contact: 'contact',

--- a/web/lib/engine/section-builders.ts
+++ b/web/lib/engine/section-builders.ts
@@ -288,6 +288,21 @@ const buildContact: SectionBuilder = ({ business, content }) => {
   }
 }
 
+const buildFeaturedProducts: SectionBuilder = ({ business, content }) => {
+  // Render-time section: the actual products are fetched from the commerce
+  // DB inside the React component, not here. The builder just emits the
+  // slug + display copy so the composer has something to pass down.
+  const cfg = (content as { featuredProducts?: { title?: string; subtitle?: string; viewAllText?: string; limit?: number } }).featuredProducts
+  return {
+    siteSlug: business.slug,
+    businessName: business.name,
+    title: cfg?.title ?? 'Nuestros productos',
+    subtitle: cfg?.subtitle,
+    viewAllText: cfg?.viewAllText ?? 'Ver toda la tienda',
+    limit: typeof cfg?.limit === 'number' ? Math.max(1, Math.min(8, cfg.limit)) : 4,
+  }
+}
+
 const buildProductCatalog: SectionBuilder = ({ business, content, registry }) => {
   const products = business.products || []
   if (products.length === 0) return null
@@ -525,6 +540,7 @@ export const SECTION_BUILDERS: Record<SectionType, SectionBuilder> = {
   quoteForm: buildQuoteForm,
   emergencyIndicator: buildEmergencyIndicator,
   productCatalog: buildProductCatalog,
+  featuredProducts: buildFeaturedProducts,
   gallery: buildGallery,
   team: buildTeam,
   testimonials: buildTestimonials,

--- a/web/lib/engine/section-registry.ts
+++ b/web/lib/engine/section-registry.ts
@@ -106,6 +106,14 @@ export const SECTION_CATALOG: Record<string, SectionManifest> = {
     defaultVariant: 'grid',
     variants: ['grid'],
   },
+  'featured-products': {
+    // Live homepage preview of the first N products from the tenant's
+    // commerce DB. Unlike `product-catalog` (static JSON), this queries
+    // the `products` table at render time and links to the real PDP.
+    id: 'featured-products',
+    defaultVariant: 'grid',
+    variants: ['grid'],
+  },
   footer: {
     id: 'footer',
     defaultVariant: 'standard',

--- a/web/lib/engine/site-renderer.tsx
+++ b/web/lib/engine/site-renderer.tsx
@@ -12,6 +12,7 @@ import { HeaderSection } from '@/components/sections/header-section'
 import { HeroSection } from '@/components/sections/hero-section'
 import { ServicesSection } from '@/components/sections/services-section'
 import { ProductCatalogSection } from '@/components/sections/product-catalog-section'
+import { FeaturedProductsSection } from '@/components/sections/featured-products-section'
 import { GallerySection } from '@/components/sections/gallery-section'
 import { TeamSection } from '@/components/sections/team-section'
 import { TestimonialsSection } from '@/components/sections/testimonials-section'
@@ -49,6 +50,7 @@ const COMPONENTS: Record<string, React.ComponentType<any>> = {
   hero: HeroSection,
   services: ServicesSection,
   'product-catalog': ProductCatalogSection,
+  'featured-products': FeaturedProductsSection,
   gallery: GallerySection,
   team: TeamSection,
   testimonials: TestimonialsSection,
@@ -93,7 +95,11 @@ export function renderPage(page: ResolvedPage): React.ReactNode {
       return null
     }
 
-    const props = s.props as Record<string, unknown>
+    // Thread the page's locale into every section as an optional prop.
+    // Sections that need it (e.g. featured-products, any future section
+    // generating URLs with the locale prefix) pick it up; the rest
+    // ignore the extra key harmlessly.
+    const props = { ...s.props, locale: page.locale } as Record<string, unknown>
     return <C key={`${s.id}-${i}`} {...props} />
   })
 }


### PR DESCRIPTION
## Summary

Bridges **landing → tienda**. Shoppers who land on the homepage via SEO/social now see the first N products from the tenant's commerce DB as image+name+price tiles linking to the real PDP, plus a \"Ver toda la tienda →\" link.

## Why not the existing product-catalog section?

- \`product-catalog\` → static JSON products, WhatsApp-order CTAs, from \`business.products\` in the data blob
- \`featured-products\` (new) → live DB products, real PDP click-through

Different use cases, both kept.

## Mechanics

- \`SECTION_CATALOG\` gains \`featured-products\` manifest
- \`SectionType\` union gains \`featuredProducts\`
- \`SECTION_MAP\` accepts both \`featuredProducts\` and \`featured-products\` identifiers
- \`buildFeaturedProducts\` emits \`{siteSlug, title, subtitle, viewAllText, limit}\` — **no DB hit at build time**. Tenants customise via \`content.featuredProducts.{title,subtitle,viewAllText,limit}\`
- \`FeaturedProductsSection\` is an async RSC: resolves business, checks \`isCommerceEnabled\`, queries \`listActiveProducts\` at render. Returns \`null\` if no products, so tenants can keep the section in page config without an empty-state UI
- \`site-renderer.tsx\` threads \`page.locale\` into every section's props so \`/s/pt/...\` routes don't regress to \`/s/es/...\`

## Tenant opt-in

Add to \`sites/{tenant}/pages/home.json\`:
\`\`\`json
{ \"id\": \"featured-products\", \"variant\": \"grid\" }
\`\`\`
Override copy via content JSON:
\`\`\`json
{ \"featuredProducts\": { \"title\": \"Lo más nuevo\", \"limit\": 6 } }
\`\`\`

No schema migration. Safe to keep in config for tenants that may activate commerce later.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run test:unit\` — 426 pass
- [x] \`npm run build\` — clean
- [ ] Manual: add \`featured-products\` to a commerce-enabled tenant's \`home.json\`, confirm rail renders with real products
- [ ] Manual: add to a tenant without commerce → section returns null, page still loads
- [ ] Manual: visit \`/s/es/{site}/\` vs \`/s/pt/{site}/\` → \"Ver toda la tienda\" respects URL locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)