### PR TITLE
feat(fun4me): legal-index page with all 4 policies

### DIFF
--- a/sites/fun4me/content/es.json
+++ b/sites/fun4me/content/es.json
@@ -249,11 +249,80 @@
       { "icon": "heart", "title": "Atencion Sin Juicios", "text": "Nuestro equipo esta capacitado para asesorarte con respeto y profesionalismo." }
     ]
   },
+  "legal": {
+    "seo": {
+      "title": "Legal Fun4Me | Terminos, Privacidad, Devoluciones, Edad",
+      "description": "Politicas legales de Fun4Me. Terminos y condiciones, privacidad, devoluciones, verificacion de edad segun ley paraguaya."
+    },
+    "hero": {
+      "headline": "Politicas y Legal",
+      "subheadline": "Todo lo que necesitas saber sobre tus derechos al comprar en Fun4Me.",
+      "ctaPrimaryText": "Contactar legal@fun4me.com.py",
+      "ctaPrimaryHref": "mailto:legal@fun4me.com.py"
+    },
+    "terms": {
+      "title": "Terminos y Condiciones",
+      "subtitle": "Ultima actualizacion: 2026-05-01",
+      "items": [
+        { "q": "Aceptacion de los terminos", "a": "Al usar paragu-ai.com/fun4me aceptas estos Terminos y nuestra Politica de Privacidad. Si no estas de acuerdo, no uses el sitio." },
+        { "q": "Edad minima", "a": "Este sitio es EXCLUSIVAMENTE para mayores de 18 anos. Al usarlo, declaras tener 18+ cumplidos y capacidad legal para contratar segun legislacion paraguaya. Proveer informacion falsa sobre edad cancela pedidos sin reembolso." },
+        { "q": "Precios y pagos", "a": "Precios en guaranies (PYG) con IVA incluido. Aceptamos tarjetas Visa/Mastercard via Pagopar, transferencia bancaria, Tigo Money, Personal Pay, y efectivo contra entrega solo en Asuncion. La descripcion en el estado de cuenta sera 'PAGOPAR - F4M COMERCIAL' o similar." },
+        { "q": "Envios", "a": "Asuncion y Gran Asuncion 24-72hs habiles. Interior 3-5 dias habiles. Express mismo dia con cargo adicional. Envio gratis en compras > Gs. 200.000. Empaque 100% discreto sin logos. La entrega requiere persona mayor de edad presente con documento." },
+        { "q": "Limitacion de responsabilidad", "a": "Fun4Me no se responsabiliza por uso indebido de productos (especialmente BDSM), reacciones alergicas no informadas, o daños derivados de no seguir instrucciones de uso. Nuestra responsabilidad maxima se limita al monto pagado por el producto." },
+        { "q": "Ley aplicable", "a": "Estos terminos se rigen por la legislacion de Paraguay. Jurisdiccion: tribunales ordinarios de Asuncion." }
+      ]
+    },
+    "privacy": {
+      "title": "Politica de Privacidad",
+      "subtitle": "Nunca vendemos tus datos. Envio discreto siempre.",
+      "items": [
+        { "q": "Que datos recolectamos", "a": "Datos voluntarios: nombre, email, telefono, direccion de envio, fecha de nacimiento (verificacion de edad), preferencias. Datos tecnicos automaticos: IP truncada a 30 dias, navegador, paginas visitadas. NO recolectamos GPS, contactos del telefono, ni info financiera completa." },
+        { "q": "Para que usamos tus datos", "a": "Procesar tu pedido, facturacion electronica, notificaciones del pedido, atencion al cliente, recomendaciones (opcional), prevencion de fraude, cumplimiento legal. Nunca para publicidad externa ni venta a terceros." },
+        { "q": "Con quien compartimos", "a": "Solo con Pagopar (procesa pagos), transportistas (nombre/direccion/telefono), Google Analytics con IP anonimizada, SendGrid (emails). NUNCA con Facebook Pixel, Google Ads conversion, redes sociales, brokers de datos, otros anunciantes." },
+        { "q": "Tus derechos (Ley 6534/20)", "a": "Acceso a tus datos, rectificacion, borrado (derecho al olvido), oposicion al marketing, portabilidad en formato legible, limitacion del uso. Respondemos en max 15 dias habiles. Email: privacidad@fun4me.com.py" },
+        { "q": "Cuanto tiempo guardamos datos", "a": "Datos de cuenta activa: mientras la mantengas. Pedidos: 5 años (obligacion fiscal). Navegacion: 30 dias en bruto, luego agregados anonimos. Logs de seguridad: 90 dias. Marketing: hasta que te des de baja." },
+        { "q": "Seguridad", "a": "HTTPS en todo el sitio (TLS 1.3+), contraseñas hasheadas, acceso interno con 2FA, auditorias periodicas, backups cifrados. Si hay brecha de seguridad te avisamos en 72hs con que datos se vieron afectados y que medidas tomamos." }
+      ]
+    },
+    "returns": {
+      "title": "Politica de Cambios y Devoluciones",
+      "subtitle": "Que SI se puede cambiar y que no.",
+      "items": [
+        { "q": "Producto defectuoso de fabrica", "a": "Contactanos en 24-48hs desde que recibis con foto/video. Reemplazo gratuito o reembolso completo segun stock. Retiramos el producto defectuoso sin costo." },
+        { "q": "Garantia de fabricante", "a": "Satisfyer: 15 años lineas premium, 2 años entry. LELO: 1 año. We-Vibe: 2 años. Otras marcas: segun empaque. Tiempo tipico de resolucion 30-60 dias." },
+        { "q": "Cambio de lenceria por talle", "a": "SI se puede en 7 dias si: no fue usada, etiquetas intactas, empaque original. Contactanos por WhatsApp, coordinamos retiro, te mandamos nuevo talle o reembolso. NO aplica a bombachas, tangas, medias (por higiene)." },
+        { "q": "Que NO admite devolucion", "a": "Por higiene sanitaria: juguetes sexuales abiertos/usados, lubricantes abiertos, preservativos, bombachas/tangas/medias, mordazas, enemas, gift cards." },
+        { "q": "Reembolsos", "a": "Tarjeta: 7-10 dias habiles. Transferencia: 3-5 dias. Tigo Money/Personal Pay: 1-2 dias. Efectivo contra entrega: devolucion por transferencia (requerimos CBU). Sin comision por reembolso." },
+        { "q": "Envios fallidos", "a": "Si no estas en 3 intentos: paquete vuelve, cargo administrativo Gs. 25.000. Podes pedir re-envio (pagando nuevo envio) o reembolso descontando el cargo administrativo." }
+      ]
+    },
+    "ageCompliance": {
+      "title": "Verificacion de Edad (18+)",
+      "subtitle": "Por que preguntamos tu edad y como la verificamos.",
+      "items": [
+        { "q": "Por que verificamos edad", "a": "Paraguay establece mayoria de edad para contratar a los 18 años (Codigo Civil). Ley 1680/01 prohibe contenido sexualmente explicito dirigido a menores. Aplicamos ademas estandares internacionales 18+ universal." },
+        { "q": "Modal al ingresar", "a": "Primer contacto: modal obligatorio 'Soy mayor de 18' o 'Salir'. Registramos confirmacion por cookie 30 dias. Si borras cookies, aparece nuevamente." },
+        { "q": "Al crear cuenta", "a": "Solicitamos fecha de nacimiento. Si la edad calculada < 18 la cuenta se rechaza automaticamente. Queda registrado para auditoria y regalo de cumpleaños." },
+        { "q": "Al comprar", "a": "Confirmacion adicional de mayoria de edad. Para pedidos > Gs. 500.000 puede solicitarse documento. La entrega requiere firma de persona mayor de edad con documento." },
+        { "q": "Contenido del sitio", "a": "Paginas de producto con imagenes NO explicitas (producto sobre fondo neutro, sin modelo humano en uso). Blog y paginas educativas: contenido informativo, sin imagenes explicitas." },
+        { "q": "Si detectamos un menor", "a": "Cuenta cerrada inmediatamente, datos eliminados, pedidos cancelados con reembolso, notificacion a padre/madre si email familiar detectable. Denuncias: compliance@fun4me.com.py" }
+      ]
+    },
+    "cta": {
+      "title": "Alguna duda legal?",
+      "subtitle": "Contactanos directamente. Respondemos en menos de 48hs habiles.",
+      "buttonText": "Escribir a legal@fun4me.com.py",
+      "buttonHref": "mailto:legal@fun4me.com.py"
+    }
+  },
   "footer": {
     "rights": "Todos los derechos reservados.",
     "privacy": "Politica de Privacidad",
+    "privacyHref": "/fun4me/legal",
     "terms": "Terminos y Condiciones",
-    "legal": "Solo mayores de 18 anos."
+    "termsHref": "/fun4me/legal",
+    "legalText": "Solo mayores de 18 anos.",
+    "legalHref": "/fun4me/legal"
   },
   "whatsapp": {
     "number": "595976569739",

--- a/sites/fun4me/pages/legal.json
+++ b/sites/fun4me/pages/legal.json
@@ -1,0 +1,16 @@
+{
+  "slug": "legal",
+  "titleKey": "legal.seo.title",
+  "descriptionKey": "legal.seo.description",
+  "sections": [
+    { "id": "header", "variant": "standard", "content": "navigation" },
+    { "id": "hero", "variant": "minimal", "content": "legal.hero" },
+    { "id": "faq", "variant": "accordion", "content": "legal.terms" },
+    { "id": "faq", "variant": "accordion", "content": "legal.privacy" },
+    { "id": "faq", "variant": "accordion", "content": "legal.returns" },
+    { "id": "faq", "variant": "accordion", "content": "legal.ageCompliance" },
+    { "id": "cta-banner", "variant": "solid", "content": "legal.cta" },
+    { "id": "footer", "variant": "standard", "content": "footer" },
+    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds \`/fun4me/legal\` — single page rendering all four policies as FAQ accordions:

- **Terms of Service** — acceptance, 18+ min age, prices/payments, shipping, liability, PY jurisdiction
- **Privacy Policy** — data we collect, purpose, third parties, Ley 6534/20 user rights, retention periods, security
- **Returns Policy** — defects, brand warranty windows, lingerie exchanges, what can't be returned, refund timelines
- **Age Verification (18+)** — why we verify, verification mechanisms, content restrictions, enforcement

Content derived from the full markdown docs in \`sites/fun4me/legal/*.md\` (which were written earlier but not routed).

## Paraguay-specific

- Ley 6534/20 data protection rights explicitly enumerated
- Ley 1680/01 compliance referenced
- Código Civil cited for 18+ contracting
- Jurisdiction: Asunción courts

## Footer updated

Now has \`/fun4me/legal\` links for privacy, terms, and 18+ disclaimer. Users can find policies from any page.

## Tested

\`composeSitePage({ siteSlug: 'fun4me', locale: 'es', pageSlug: 'legal' })\` → 9 sections resolve cleanly with all 4 FAQ blocks populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)