### PR TITLE
fix(retail-local): whitelist commerce-catalog + featured-products + trust-signals (unbreaks /fun4me/store)

### DIFF
--- a/src/verticals/retail-local/vertical.json
+++ b/src/verticals/retail-local/vertical.json
@@ -15,7 +15,8 @@
   "allowedSections": [
     "header", "hero", "product-catalog", "product-grid", "services",
     "gallery", "testimonials", "faq", "business-hours", "google-maps",
-    "contact", "cta-banner", "footer", "whatsapp-float"
+    "contact", "cta-banner", "footer", "whatsapp-float",
+    "commerce-catalog", "featured-products", "trust-signals"
   ],
   "defaultStarterKit": "minimal",
   "locales": ["es"]


### PR DESCRIPTION
## Problem

PR #172 added \`commerce-catalog\` and \`trust-signals\` to fun4me's store.json. Deploy succeeded but https://paragu-ai.com/fun4me/store now returns **404** — site composition throws:

\`[compose-site] Section \"commerce-catalog\" not allowed for vertical \"retail-local\"\`

The vertical config at \`src/verticals/retail-local/vertical.json\` has an \`allowedSections\` whitelist that never got updated for the three newer commerce-aware sections.

## Fix

Add \`commerce-catalog\`, \`featured-products\`, and \`trust-signals\` to \`allowedSections\`. Same fix would have hit \`featured-products\` (PR #169) as soon as any retail-local tenant opted in, so patching all three preempts the next bug.

## Test plan
- [ ] After merge+deploy: https://paragu-ai.com/fun4me/store returns 200 and renders the product grid
- [ ] Age-gate-free pages still work
- [ ] Other retail-local tenants unaffected (they don't use these sections in their page config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)