### PR TITLE
fix(fun4me): unbreak /fun4me/store — drop trust-signals + fail-soft commerce-catalog

### DIFF
--- a/sites/fun4me/pages/store.json
+++ b/sites/fun4me/pages/store.json
@@ -7,7 +7,6 @@
     { "id": "hero", "variant": "minimal", "content": "store.hero" },
     { "id": "cta-banner", "variant": "solid", "content": "home.promo" },
     { "id": "commerce-catalog", "variant": "grid", "content": "store.catalog" },
-    { "id": "trust-signals", "variant": "credentials", "content": "store.trust" },
     { "id": "footer", "variant": "standard", "content": "footer" },
     { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
   ]

--- a/web/components/sections/commerce-catalog-section.tsx
+++ b/web/components/sections/commerce-catalog-section.tsx
@@ -3,6 +3,7 @@ import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { listActiveProducts } from '@/lib/commerce/products'
 import { loadPygRates } from '@/lib/commerce/currency-server'
+import { logger } from '@/lib/logger'
 import { Container } from '@/components/ui/container'
 import { Heading } from '@/components/ui/heading'
 import { ProductCard } from '@/components/commerce/product-card'
@@ -41,13 +42,30 @@ export async function CommerceCatalogSection({
   limit = 24,
   locale = 'es',
 }: CommerceCatalogSectionProps) {
-  const business = await resolveBusinessBySlug(siteSlug)
-  if (!business || !(await isCommerceEnabled(business.type))) return null
-
-  const [products, rates] = await Promise.all([
-    listActiveProducts(business.id, { limit: limit + 1, sort: 'newest' }),
-    loadPygRates(),
-  ])
+  // Fail-soft: any crash in the data layer (missing business row, DB down,
+  // env misconfig, registry file not resolvable) returns null rather than
+  // 500ing the whole page. The tenant's store still renders its other
+  // sections, just without the grid.
+  let products: Awaited<ReturnType<typeof listActiveProducts>> = []
+  let rates: Record<string, number> = {}
+  try {
+    if (!siteSlug) return null
+    const business = await resolveBusinessBySlug(siteSlug)
+    if (!business || !(await isCommerceEnabled(business.type))) return null
+    const [fetchedProducts, fetchedRates] = await Promise.all([
+      listActiveProducts(business.id, { limit: limit + 1, sort: 'newest' }),
+      loadPygRates(),
+    ])
+    products = fetchedProducts
+    rates = fetchedRates
+  } catch (err) {
+    logger.error('[commerce-catalog] render failed — falling back to empty', {
+      action: 'commerce.catalog.render_failed',
+      siteSlug,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return null
+  }
   if (products.length === 0) return null
 
   const hasMore = products.length > limit


### PR DESCRIPTION
## Problem

https://paragu-ai.com/fun4me/store returns **500** (not 404) after PR #172 + hotfix #173. Adding commerce-catalog + trust-signals to the page config works for composition (allowedSections updated) but something in the render chain throws.

## Fix

Two moves to stabilise:

1. **Drop trust-signals** from fun4me/store.json. I don't have isolation to know which of the two new sections is the culprit, so minimise the change surface to just commerce-catalog.

2. **Fail-soft the commerce-catalog data chain** — wrap \`resolveBusinessBySlug\` / \`isCommerceEnabled\` / \`listActiveProducts\` / \`loadPygRates\` in try/catch. Any crash logs + returns null so the section silently omits itself instead of 500ing the whole tenant page.

Philosophy: sections whose render depends on external calls should default to fail-soft. A Supabase flake shouldn't take out a marketing page.

## Test plan
- [ ] After merge+deploy: /fun4me/store returns 200
- [ ] If DB fun4me row exists with products → grid renders
- [ ] If no DB row → hero + promo + footer render (no grid, no 500)
- [ ] Logs show commerce.catalog.render_failed on any crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)