### PR TITLE
fix(fun4me): revert store.json to pre-#172 config — stops 500

### DIFF
--- a/sites/fun4me/pages/store.json
+++ b/sites/fun4me/pages/store.json
@@ -6,7 +6,7 @@
     { "id": "header", "variant": "standard", "content": "navigation" },
     { "id": "hero", "variant": "minimal", "content": "store.hero" },
     { "id": "cta-banner", "variant": "solid", "content": "home.promo" },
-    { "id": "commerce-catalog", "variant": "grid", "content": "store.catalog" },
+    { "id": "product-catalog", "variant": "grid" },
     { "id": "footer", "variant": "standard", "content": "footer" },
     { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
   ]


### PR DESCRIPTION
Second hotfix for /fun4me/store. PR #174's fail-soft guard catches data-fetch crashes but the actual error is at render time — something in CommerceCatalogSection → ProductCard throws during SSR that try/catch can't reach.

Full revert of store.json to the exact pre-PR-#172 config. Page will render empty middle (product-catalog returns null with no static JSON products) but return **200**. That's the known-working pre-existing state — not worse than before.

Follow-up debugging: reproduce the crash with a local prod build and inspect the SSR trace. Likely candidates are the client components in the commerce-catalog's children (ProductCard has useCartStore, CartStoreHydrator has zustand setup) misbehaving during initial server render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)