### PR TITLE
feat(fun4me): re-add commerce-catalog to /store now that fail-soft is live

### DIFF
--- a/sites/fun4me/pages/store.json
+++ b/sites/fun4me/pages/store.json
@@ -6,7 +6,7 @@
     { "id": "header", "variant": "standard", "content": "navigation" },
     { "id": "hero", "variant": "minimal", "content": "store.hero" },
     { "id": "cta-banner", "variant": "solid", "content": "home.promo" },
-    { "id": "product-catalog", "variant": "grid" },
+    { "id": "commerce-catalog", "variant": "grid", "content": "store.catalog" },
     { "id": "footer", "variant": "standard", "content": "footer" },
     { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
   ]


### PR DESCRIPTION
## Summary

Re-adds \`commerce-catalog\` to fun4me's \`store.json\` now that PR #174's fail-soft guard is actually shipping — VPS Docker builds had been silently failing through PRs #172→#175, so prod ran a stale image that didn't know the \`commerce-catalog\` section id and threw 500. The rerun on #175 finally got fresh code deployed; /fun4me/store returns 200 cleanly.

With the fail-soft live, the section can safely be re-added:

- \`resolveBusinessBySlug('fun4me')\` returns null (fun4me isn't in the businesses table)
- Section returns null → page renders header + hero + banner + footer as baseline — same UX as before, now with the section wired in

## Next step (separate task)

Seed fun4me as a commerce-enabled business in Supabase + insert products. That's a data task, not code. Once done, the grid populates automatically via the existing section.

## Test plan
- [ ] After merge + deploy: /fun4me/store returns 200
- [ ] Body contains real fun4me hero \"Tu Placer, Nuestra Prioridad\"
- [ ] No \"Internal Server Error\" or NEXT_HTTP_ERROR_FALLBACK in response
- [ ] Logs show commerce.catalog.render_failed — no, because business is null, not an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)