### PR TITLE
fix(commerce-sections): opt out of SSG via noStore() — unblocks /fun4me/store

### DIFF
--- a/web/components/sections/commerce-catalog-section.tsx
+++ b/web/components/sections/commerce-catalog-section.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { unstable_noStore as noStore } from 'next/cache'
 import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { listActiveProducts } from '@/lib/commerce/products'
@@ -42,6 +43,16 @@ export async function CommerceCatalogSection({
   limit = 24,
   locale = 'es',
 }: CommerceCatalogSectionProps) {
+  // Opt the host page out of static generation. The catch-all tenant
+  // route (/s/[locale]/[site]/[[...page]]) is SSG by default via
+  // generateStaticParams, but this section's data-fetch calls use cookies
+  // (via the Supabase admin client), which Next.js forbids at build time
+  // ("Dynamic server usage: ... used `cookies`"). noStore() tells Next.js
+  // to render any page containing this section at request time instead —
+  // fixing the hard 500 without forcing `dynamic = 'force-dynamic'` on
+  // the whole catch-all (which would regress SSG for every other tenant).
+  noStore()
+
   // Fail-soft: any crash in the data layer (missing business row, DB down,
   // env misconfig, registry file not resolvable) returns null rather than
   // 500ing the whole page. The tenant's store still renders its other

--- a/web/components/sections/featured-products-section.tsx
+++ b/web/components/sections/featured-products-section.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link'
+import { unstable_noStore as noStore } from 'next/cache'
 import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { listActiveProducts } from '@/lib/commerce/products'
 import { formatCents } from '@/lib/commerce/compute-totals'
+import { logger } from '@/lib/logger'
 import { Container } from '@/components/ui/container'
 import { Heading } from '@/components/ui/heading'
 
@@ -36,10 +38,26 @@ export async function FeaturedProductsSection({
   limit,
   locale = 'es',
 }: FeaturedProductsSectionProps) {
-  const business = await resolveBusinessBySlug(siteSlug)
-  if (!business || !(await isCommerceEnabled(business.type))) return null
+  // Opt the host page out of static generation — same reason as
+  // CommerceCatalogSection: the data fetches use cookies via the Supabase
+  // admin client, which Next.js forbids during SSG.
+  noStore()
 
-  const products = await listActiveProducts(business.id, { limit, sort: 'newest' })
+  // Fail-soft: any crash in the data layer returns null instead of 500ing
+  // the page. The tenant's landing still renders its other sections.
+  let products: Awaited<ReturnType<typeof listActiveProducts>> = []
+  try {
+    const business = await resolveBusinessBySlug(siteSlug)
+    if (!business || !(await isCommerceEnabled(business.type))) return null
+    products = await listActiveProducts(business.id, { limit, sort: 'newest' })
+  } catch (err) {
+    logger.error('[featured-products] render failed — falling back to empty', {
+      action: 'commerce.featured_products.render_failed',
+      siteSlug,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return null
+  }
   if (products.length === 0) return null
 
   return (


### PR DESCRIPTION
## Root cause (discovered via prod container logs)

The /fun4me/store 500 isn't from my component's render — it's from Next.js's SSG pipeline. The catch-all tenant route \`/s/[locale]/[site]/[[...page]]\` is SSG by default via \`generateStaticParams\`. When Next.js pre-renders fun4me/store at build time, \`CommerceCatalogSection\`'s data fetches hit the Supabase admin client, which calls \`cookies()\` from \`next/headers\`. Next.js forbids cookies during static generation and throws:

\`\`\`
Error: Page changed from static to dynamic at runtime
       /s/es/fun4me/store, reason: cookies
\`\`\`

My fail-soft catch from PR #174 was working — I have a log line firing on each request — but Next.js's own SSG→dynamic transition error is what's bubbling up to the 500.

## Fix

\`unstable_noStore()\` at the top of CommerceCatalogSection (and preemptively FeaturedProductsSection — same pattern, same crash). This tells Next.js: \"this component needs request-time rendering.\" Next.js then skips SSG for any page containing these sections and SSRs them instead. Other sections on the page (hero, cta-banner, footer) still SSG cleanly.

## How I found it

\`\`\`
ssh agentzero docker service logs paragu-ai_web --tail 80
\`\`\`

The 500 body is just \"Internal Server Error\" — no stack in the HTTP response. The real error is three hops deep:

1. My commerce.catalog.render_failed log fires (fail-soft caught the cookies error)
2. Next.js emits: \"Page changed from static to dynamic at runtime\"  
3. Server Components render throws → 500

## Test plan
- [ ] After merge+deploy: /fun4me/store returns 200
- [ ] Body contains fun4me hero content, no \"Internal Server Error\"
- [ ] Other tenant routes still work
- [ ] Follow-up: seed fun4me into \`businesses\` + \`products\` to populate the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)