### PR TITLE
fix(tenant-route): force dynamic on catch-all — stops DYNAMIC_SERVER_USAGE 500

### DIFF
--- a/web/app/s/[locale]/[site]/[[...page]]/page.tsx
+++ b/web/app/s/[locale]/[site]/[[...page]]/page.tsx
@@ -14,6 +14,24 @@ import { logger } from '@/lib/logger'
 
 export const runtime = 'nodejs'
 
+/**
+ * Force dynamic rendering across all tenant pages.
+ *
+ * Why: tenant pages can include sections (commerce-catalog, featured-products)
+ * whose data fetches hit the Supabase admin client, which uses `cookies()`
+ * internally — forbidden during SSG. A section-level `noStore()` isn't
+ * enough because Next.js still logs DYNAMIC_SERVER_USAGE and bubbles a 500
+ * when the route was pre-scheduled for static generation.
+ *
+ * Rather than hunt every transitive dynamic API or gate sections at compose
+ * time, opt the whole catch-all out of static generation. The SSG benefit
+ * for tenant marketing pages was already limited (dynamicParams=true,
+ * frequent content edits), and PRERENDER_SKIP_SITES was growing anyway.
+ * This trade gives unambiguous correctness: no more 500s when a tenant
+ * opts in to a commerce section.
+ */
+export const dynamic = 'force-dynamic'
+
 interface Props {
   params: Promise<{ locale: string; site: string; page?: string[] }>
 }


### PR DESCRIPTION
## Why

Section-level \`noStore()\` (PR #177) wasn't enough. Prod container logs show Next.js still logs \`DYNAMIC_SERVER_USAGE\` and 500s when fun4me/store includes commerce-catalog. The route is scheduled for SSG via \`generateStaticParams\`; the transitive \`cookies()\` call from the Supabase admin client trips the static/dynamic invariant check before \`noStore()\` can take effect.

## What

\`export const dynamic = 'force-dynamic'\` on the catch-all tenant route. Every request now goes through SSR.

## Trade-off

SSG benefit for tenant marketing pages was already marginal:

- \`dynamicParams=true\` already let unknown tenants through
- \`PRERENDER_SKIP_SITES\` was growing (6 entries: nexa-uruguay, nexa-propiedades, fun4me, dayah-litworks, de-abasto-a-casa, granja-cabral) — more tenants broke than worked under SSG
- Tenant content edits invalidate caches anyway

Trade: small perf hit on first-load for marketing pages, **unambiguous correctness** for any section that needs request-time data. Worth it.

## Follow-up

Revisit once Next.js PPR (partial prerendering) stabilises. PPR would let the shell stay static while dynamic sections render at request time — ideal for this use case.

## Test plan
- [ ] After merge+deploy: /fun4me/store returns 200 (not 500)
- [ ] Other tenant pages still work (bundles, suscripciones, etc.)
- [ ] No regression on demo tenants
- [ ] Prod logs no longer show DYNAMIC_SERVER_USAGE for /fun4me/store

🤖 Generated with [Claude Code](https://claude.com/claude-code)