### PR TITLE
fix(sections): localize hero trust-badges + footer rights — drops leaked German

### DIFF
--- a/web/components/sections/footer-section.tsx
+++ b/web/components/sections/footer-section.tsx
@@ -36,12 +36,12 @@ const NETWORK_LABEL: Record<string, string> = {
   pt: 'Rede Nexa',
 }
 
-const FOOTER_LABELS: Record<string, { links: string; contact: string; social: string }> = {
-  de: { links: 'Links', contact: 'Kontakt', social: 'Social Media' },
-  en: { links: 'Links', contact: 'Contact', social: 'Social' },
-  es: { links: 'Enlaces', contact: 'Contacto', social: 'Redes' },
-  nl: { links: 'Links', contact: 'Contact', social: 'Social' },
-  pt: { links: 'Links', contact: 'Contato', social: 'Social' },
+const FOOTER_LABELS: Record<string, { links: string; contact: string; social: string; rights: string }> = {
+  de: { links: 'Links', contact: 'Kontakt', social: 'Social Media', rights: 'Alle Rechte vorbehalten.' },
+  en: { links: 'Links', contact: 'Contact', social: 'Social', rights: 'All rights reserved.' },
+  es: { links: 'Enlaces', contact: 'Contacto', social: 'Redes', rights: 'Todos los derechos reservados.' },
+  nl: { links: 'Links', contact: 'Contact', social: 'Social', rights: 'Alle rechten voorbehouden.' },
+  pt: { links: 'Links', contact: 'Contato', social: 'Social', rights: 'Todos os direitos reservados.' },
 }
 
 /**
@@ -264,7 +264,7 @@ export function FooterSection({
             color: 'rgba(255,255,255,0.5)',
           }}
         >
-          © {year} {businessName}. Alle Rechte vorbehalten.
+          © {year} {businessName}. {labels.rights}
         </div>
       </Container>
     </footer>

--- a/web/components/sections/hero-section.tsx
+++ b/web/components/sections/hero-section.tsx
@@ -21,6 +21,23 @@ export interface HeroSectionProps {
   floatingHeadline?: boolean
   glassCard?: boolean
   eyebrow?: string
+  /** URL locale — used to pick trust-badge labels when `enhanced` is on. */
+  __locale?: string
+  /** Opt-out of the enhanced trust-badges row (some tenants prefer a clean hero). */
+  trustBadgesEnabled?: boolean
+}
+
+// The enhanced hero optionally shows three small trust-badges (shield +
+// label) below the CTAs. Labels are locale-aware — previously hardcoded
+// as German ("Professionell / Transparent / Vertrauenswürdig"), which
+// bled into every non-Nexa tenant. Set trustBadgesEnabled=false on a
+// hero to drop them entirely.
+const TRUST_BADGE_LABELS: Record<string, [string, string, string]> = {
+  de: ['Professionell', 'Transparent', 'Vertrauenswürdig'],
+  en: ['Professional', 'Transparent', 'Trustworthy'],
+  es: ['Profesional', 'Transparente', 'De confianza'],
+  nl: ['Professioneel', 'Transparant', 'Betrouwbaar'],
+  pt: ['Profissional', 'Transparente', 'Confiável'],
 }
 
 export function HeroSection({
@@ -37,7 +54,10 @@ export function HeroSection({
   floatingHeadline = false,
   glassCard = true,
   eyebrow,
+  __locale,
+  trustBadgesEnabled = true,
 }: HeroSectionProps) {
+  const trustBadges = TRUST_BADGE_LABELS[__locale ?? 'es'] ?? TRUST_BADGE_LABELS.es
   const content = (
     <Container className="relative z-10 py-16 sm:py-24 lg:py-32">
       <div className={cn("max-w-4xl mx-auto text-center", enhanced && "hero-content-animate")}>
@@ -83,21 +103,15 @@ export function HeroSection({
           )}
         </div>
 
-        {enhanced && (
+        {enhanced && trustBadgesEnabled && (
           <div className="mt-12 sm:mt-16 hero-animate-delay-4">
             <div className="flex flex-wrap items-center justify-center gap-6 text-sm" style={{ color: 'rgba(255,255,255,0.7)' }}>
-              <div className="flex items-center gap-2">
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>
-                <span>Professionell</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>
-                <span>Transparent</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>
-                <span>Vertrauenswürdig</span>
-              </div>
+              {trustBadges.map((label) => (
+                <div key={label} className="flex items-center gap-2">
+                  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>
+                  <span>{label}</span>
+                </div>
+              ))}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Problem

Hero and footer had German strings hardcoded in the component source:

- **hero-section.tsx**: \`<span>Professionell</span>\`, \`<span>Transparent</span>\`, \`<span>Vertrauenswürdig</span>\`
- **footer-section.tsx**: \`© {year} {businessName}. Alle Rechte vorbehalten.\`

These rendered on every tenant, including fun4me (Spanish-only sex_shop). Confirmed live on https://paragu-ai.com/fun4me/store — German text between hero and catalog, and German footer copyright.

## Fix

- **Hero**: new \`TRUST_BADGE_LABELS\` map keyed by locale (de/en/es/nl/pt), default 'es'. Component reads \`__locale\` from the compose-site pipeline and picks the matching triplet. Added \`trustBadgesEnabled\` prop so tenants can opt out entirely.
- **Footer**: extends the existing \`FOOTER_LABELS\` map with a \`rights\` string per locale. Hardcoded German line becomes \`{labels.rights}\` driven by the same locale lookup that already localised Links/Contact/Social.

Spanish strings chosen for PY feel (\"De confianza\" > \"Confiable\"; \"Todos los derechos reservados\" matches the tenant's footer copy).

## Test plan
- [x] \`npm run typecheck\` — clean
- [ ] Post-deploy: /fun4me/store hero shows \"Profesional / Transparente / De confianza\", footer says \"Todos los derechos reservados\"
- [ ] /s/de/nexa-paraguay/ still shows German trust-badges + footer (those tenants genuinely ARE German-first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)