### PR TITLE
feat(fun4me): age-gate modal on every page — 18+ self-declaration

### DIFF
--- a/sites/fun4me/pages/blog.json
+++ b/sites/fun4me/pages/blog.json
@@ -3,12 +3,45 @@
   "titleKey": "blog.seo.title",
   "descriptionKey": "blog.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "minimal", "content": "blog.hero" },
-    { "id": "services", "variant": "cards", "content": "blog.categories" },
-    { "id": "services", "variant": "cards", "content": "blog.posts" },
-    { "id": "cta-banner", "variant": "gradient", "content": "blog.cta" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "home.ageGate"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "blog.hero"
+    },
+    {
+      "id": "services",
+      "variant": "cards",
+      "content": "blog.categories"
+    },
+    {
+      "id": "services",
+      "variant": "cards",
+      "content": "blog.posts"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "gradient",
+      "content": "blog.cta"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/fun4me/pages/bundles.json
+++ b/sites/fun4me/pages/bundles.json
@@ -3,10 +3,35 @@
   "titleKey": "bundles.seo.title",
   "descriptionKey": "bundles.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "minimal", "content": "bundles.hero" },
-    { "id": "cta-banner", "variant": "gradient", "content": "home.cta" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "home.ageGate"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "bundles.hero"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "gradient",
+      "content": "home.cta"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/fun4me/pages/gift-cards.json
+++ b/sites/fun4me/pages/gift-cards.json
@@ -3,12 +3,45 @@
   "titleKey": "giftCards.seo.title",
   "descriptionKey": "giftCards.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "split", "content": "giftCards.hero" },
-    { "id": "gallery", "variant": "grid", "content": "giftCards.designs" },
-    { "id": "faq", "variant": "accordion", "content": "giftCards.faq" },
-    { "id": "cta-banner", "variant": "gradient", "content": "giftCards.cta" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "home.ageGate"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "split",
+      "content": "giftCards.hero"
+    },
+    {
+      "id": "gallery",
+      "variant": "grid",
+      "content": "giftCards.designs"
+    },
+    {
+      "id": "faq",
+      "variant": "accordion",
+      "content": "giftCards.faq"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "gradient",
+      "content": "giftCards.cta"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/fun4me/pages/home.json
+++ b/sites/fun4me/pages/home.json
@@ -3,15 +3,60 @@
   "titleKey": "home.seo.title",
   "descriptionKey": "home.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "image", "content": "home.hero" },
-    { "id": "services", "variant": "cards", "content": "home.features" },
-    { "id": "services", "variant": "cards", "content": "home.categories" },
-    { "id": "testimonials", "variant": "carousel", "content": "home.testimonials" },
-    { "id": "gallery", "variant": "grid", "content": "home.partners" },
-    { "id": "faq", "variant": "accordion", "content": "home.faq" },
-    { "id": "contact", "variant": "split", "content": "home.contact" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "home.ageGate"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "image",
+      "content": "home.hero"
+    },
+    {
+      "id": "services",
+      "variant": "cards",
+      "content": "home.features"
+    },
+    {
+      "id": "services",
+      "variant": "cards",
+      "content": "home.categories"
+    },
+    {
+      "id": "testimonials",
+      "variant": "carousel",
+      "content": "home.testimonials"
+    },
+    {
+      "id": "gallery",
+      "variant": "grid",
+      "content": "home.partners"
+    },
+    {
+      "id": "faq",
+      "variant": "accordion",
+      "content": "home.faq"
+    },
+    {
+      "id": "contact",
+      "variant": "split",
+      "content": "home.contact"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/fun4me/pages/legal.json
+++ b/sites/fun4me/pages/legal.json
@@ -3,14 +3,55 @@
   "titleKey": "legal.seo.title",
   "descriptionKey": "legal.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "minimal", "content": "legal.hero" },
-    { "id": "faq", "variant": "accordion", "content": "legal.terms" },
-    { "id": "faq", "variant": "accordion", "content": "legal.privacy" },
-    { "id": "faq", "variant": "accordion", "content": "legal.returns" },
-    { "id": "faq", "variant": "accordion", "content": "legal.ageCompliance" },
-    { "id": "cta-banner", "variant": "solid", "content": "legal.cta" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "home.ageGate"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "legal.hero"
+    },
+    {
+      "id": "faq",
+      "variant": "accordion",
+      "content": "legal.terms"
+    },
+    {
+      "id": "faq",
+      "variant": "accordion",
+      "content": "legal.privacy"
+    },
+    {
+      "id": "faq",
+      "variant": "accordion",
+      "content": "legal.returns"
+    },
+    {
+      "id": "faq",
+      "variant": "accordion",
+      "content": "legal.ageCompliance"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "solid",
+      "content": "legal.cta"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/fun4me/pages/loyalty.json
+++ b/sites/fun4me/pages/loyalty.json
@@ -3,11 +3,40 @@
   "titleKey": "loyalty.seo.title",
   "descriptionKey": "loyalty.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "minimal", "content": "loyalty.hero" },
-    { "id": "faq", "variant": "accordion", "content": "loyalty.faq" },
-    { "id": "cta-banner", "variant": "gradient", "content": "loyalty.cta" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "home.ageGate"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "loyalty.hero"
+    },
+    {
+      "id": "faq",
+      "variant": "accordion",
+      "content": "loyalty.faq"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "gradient",
+      "content": "loyalty.cta"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/fun4me/pages/placer-plus.json
+++ b/sites/fun4me/pages/placer-plus.json
@@ -3,10 +3,35 @@
   "titleKey": "loyalty.seo.title",
   "descriptionKey": "loyalty.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "minimal", "content": "home.hero" },
-    { "id": "cta-banner", "variant": "gradient", "content": "home.cta" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "home.ageGate"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "home.hero"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "gradient",
+      "content": "home.cta"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/fun4me/pages/reserva-en-tienda.json
+++ b/sites/fun4me/pages/reserva-en-tienda.json
@@ -3,12 +3,45 @@
   "titleKey": "storeReserve.seo.title",
   "descriptionKey": "storeReserve.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "split", "content": "storeReserve.hero" },
-    { "id": "services", "variant": "cards", "content": "storeReserve.howItWorks" },
-    { "id": "contact", "variant": "split", "content": "storeReserve.location" },
-    { "id": "cta-banner", "variant": "gradient", "content": "storeReserve.cta" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "home.ageGate"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "split",
+      "content": "storeReserve.hero"
+    },
+    {
+      "id": "services",
+      "variant": "cards",
+      "content": "storeReserve.howItWorks"
+    },
+    {
+      "id": "contact",
+      "variant": "split",
+      "content": "storeReserve.location"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "gradient",
+      "content": "storeReserve.cta"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/fun4me/pages/size-guide.json
+++ b/sites/fun4me/pages/size-guide.json
@@ -3,13 +3,50 @@
   "titleKey": "sizeGuide.seo.title",
   "descriptionKey": "sizeGuide.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "minimal", "content": "sizeGuide.hero" },
-    { "id": "services", "variant": "cards", "content": "sizeGuide.instructions" },
-    { "id": "services", "variant": "cards", "content": "sizeGuide.charts" },
-    { "id": "faq", "variant": "accordion", "content": "sizeGuide.brandNotes" },
-    { "id": "cta-banner", "variant": "solid", "content": "sizeGuide.returnPolicy" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "home.ageGate"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "sizeGuide.hero"
+    },
+    {
+      "id": "services",
+      "variant": "cards",
+      "content": "sizeGuide.instructions"
+    },
+    {
+      "id": "services",
+      "variant": "cards",
+      "content": "sizeGuide.charts"
+    },
+    {
+      "id": "faq",
+      "variant": "accordion",
+      "content": "sizeGuide.brandNotes"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "solid",
+      "content": "sizeGuide.returnPolicy"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/fun4me/pages/store.json
+++ b/sites/fun4me/pages/store.json
@@ -3,11 +3,40 @@
   "titleKey": "store.seo.title",
   "descriptionKey": "store.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "minimal", "content": "store.hero" },
-    { "id": "cta-banner", "variant": "solid", "content": "home.promo" },
-    { "id": "commerce-catalog", "variant": "grid", "content": "store.catalog" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "home.ageGate"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "store.hero"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "solid",
+      "content": "home.promo"
+    },
+    {
+      "id": "commerce-catalog",
+      "variant": "grid",
+      "content": "store.catalog"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/fun4me/pages/suscripciones.json
+++ b/sites/fun4me/pages/suscripciones.json
@@ -3,14 +3,55 @@
   "titleKey": "subscriptions.seo.title",
   "descriptionKey": "subscriptions.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "image", "content": "subscriptions.hero" },
-    { "id": "services", "variant": "cards", "content": "subscriptions.boxes" },
-    { "id": "services", "variant": "cards", "content": "subscriptions.howItWorks" },
-    { "id": "testimonials", "variant": "carousel", "content": "subscriptions.testimonials" },
-    { "id": "faq", "variant": "accordion", "content": "subscriptions.faq" },
-    { "id": "cta-banner", "variant": "gradient", "content": "subscriptions.cta" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "home.ageGate"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "image",
+      "content": "subscriptions.hero"
+    },
+    {
+      "id": "services",
+      "variant": "cards",
+      "content": "subscriptions.boxes"
+    },
+    {
+      "id": "services",
+      "variant": "cards",
+      "content": "subscriptions.howItWorks"
+    },
+    {
+      "id": "testimonials",
+      "variant": "carousel",
+      "content": "subscriptions.testimonials"
+    },
+    {
+      "id": "faq",
+      "variant": "accordion",
+      "content": "subscriptions.faq"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "gradient",
+      "content": "subscriptions.cta"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/src/verticals/retail-local/vertical.json
+++ b/src/verticals/retail-local/vertical.json
@@ -16,7 +16,7 @@
     "header", "hero", "product-catalog", "product-grid", "services",
     "gallery", "testimonials", "faq", "business-hours", "google-maps",
     "contact", "cta-banner", "footer", "whatsapp-float",
-    "commerce-catalog", "featured-products", "trust-signals"
+    "commerce-catalog", "featured-products", "trust-signals", "age-gate"
   ],
   "defaultStarterKit": "minimal",
   "locales": ["es"]

--- a/web/components/sections/age-gate-section.tsx
+++ b/web/components/sections/age-gate-section.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useState, useSyncExternalStore } from 'react'
+
+export interface AgeGateSectionProps {
+  title?: string
+  message?: string
+  confirmText?: string
+  denyText?: string
+  /** Where to send the user when they decline — typically a safe external URL. */
+  denyHref?: string
+  /** Storage key; default is site-wide. Override per tenant if needed. */
+  storageKey?: string
+  /** Minimum age declared (used only for default copy). */
+  minAge?: number
+}
+
+const DEFAULT_KEY = 'paragu_age_gate_confirmed'
+
+const SERVER_SNAPSHOT: string | null = null
+const subscribe = () => () => {}
+
+function readStoredFlag(key: string): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Self-declared age gate for adult-content tenants. The registry flags
+ * `features.ageGate.enabled: true, minAge: 18` for sex_shop,
+ * cigar_lounge_shop, onlyfans_creator_studio, etc.; this component
+ * enforces it at render time.
+ *
+ * Not a legal substitute for identity verification. Matches what
+ * similar storefronts do locally: show a modal, require the visitor to
+ * self-declare 18+, remember the choice in localStorage. Decline sends
+ * them to a neutral external URL (defaults to google.com).
+ *
+ * Renders on the server too so bots and cached HTML still carry the
+ * gate; the client swaps to hidden the moment localStorage says
+ * confirmed=yes. Uses useSyncExternalStore so the read doesn't trigger
+ * the "setState in effect" lint warning the naive useEffect pattern
+ * would.
+ */
+export function AgeGateSection({
+  title = 'Verificación de edad',
+  message,
+  confirmText,
+  denyText = 'Salir',
+  denyHref = 'https://google.com',
+  storageKey = DEFAULT_KEY,
+  minAge = 18,
+}: AgeGateSectionProps) {
+  const stored = useSyncExternalStore(
+    subscribe,
+    () => readStoredFlag(storageKey),
+    () => SERVER_SNAPSHOT,
+  )
+  // Local toggle so confirm() hides the modal synchronously without a
+  // full reload — useSyncExternalStore alone won't re-fire here because
+  // we're not listening to storage events.
+  const [dismissed, setDismissed] = useState(false)
+
+  if (stored === 'yes' || dismissed) return null
+
+  const resolvedMessage =
+    message ??
+    `Este sitio contiene contenido para adultos. Debés ser mayor de ${minAge} años para continuar.`
+  const resolvedConfirm = confirmText ?? `Soy mayor de ${minAge}`
+
+  function confirm() {
+    try {
+      window.localStorage.setItem(storageKey, 'yes')
+    } catch {
+      /* private mode or quota — still hide on this tab */
+    }
+    setDismissed(true)
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="agegate-title"
+      aria-describedby="agegate-message"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 px-4"
+    >
+      <div className="max-w-md rounded-lg bg-[color:var(--surface,#fff)] p-6 text-center shadow-xl">
+        <h2 id="agegate-title" className="mb-2 text-xl font-bold text-[color:var(--text,#111)]">
+          {title}
+        </h2>
+        <p id="agegate-message" className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">
+          {resolvedMessage}
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
+          <button
+            type="button"
+            onClick={confirm}
+            className="rounded-lg bg-[color:var(--primary,#111)] px-5 py-2.5 text-sm font-semibold text-[color:var(--primary-foreground,#fff)] hover:opacity-90"
+          >
+            {resolvedConfirm}
+          </button>
+          <a
+            href={denyHref}
+            className="rounded-lg border border-[color:var(--border,#e5e7eb)] px-5 py-2.5 text-sm font-medium text-[color:var(--text-muted,#6b7280)] hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+          >
+            {denyText}
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/lib/engine/compose.ts
+++ b/web/lib/engine/compose.ts
@@ -41,6 +41,7 @@ export type SectionType =
   | 'productCatalog'
   | 'featuredProducts'
   | 'commerceCatalog'
+  | 'ageGate'
   | 'gallery'
   | 'team'
   | 'testimonials'
@@ -370,6 +371,8 @@ export const SECTION_MAP: Record<string, SectionType> = {
   'featured-products': 'featuredProducts',
   commerceCatalog: 'commerceCatalog',
   'commerce-catalog': 'commerceCatalog',
+  ageGate: 'ageGate',
+  'age-gate': 'ageGate',
   locationBlock: 'contact',
   contactSplit: 'contact',
   contact: 'contact',

--- a/web/lib/engine/section-builders.ts
+++ b/web/lib/engine/section-builders.ts
@@ -288,6 +288,23 @@ const buildContact: SectionBuilder = ({ business, content }) => {
   }
 }
 
+const buildAgeGate: SectionBuilder = ({ content, registry }) => {
+  // Opt-in via registry.features.ageGate.enabled. Returns null when the
+  // feature is off so a stray `age-gate` section in page config doesn't
+  // render the modal on verticals that don't need it.
+  const feat = (registry.features as { ageGate?: { enabled?: boolean; minAge?: number } } | undefined)?.ageGate
+  if (!feat?.enabled) return null
+  const cfg = (content as { home?: { ageGate?: { title?: string; message?: string; confirmText?: string; denyText?: string; denyHref?: string } } }).home?.ageGate
+  return {
+    title: cfg?.title,
+    message: cfg?.message,
+    confirmText: cfg?.confirmText,
+    denyText: cfg?.denyText,
+    denyHref: cfg?.denyHref,
+    minAge: feat.minAge ?? 18,
+  }
+}
+
 const buildCommerceCatalog: SectionBuilder = ({ business, content }) => {
   // Full DB-backed grid for path-based tenant routes that want the tienda
   // experience inline on a marketing page. The component fetches products
@@ -557,6 +574,7 @@ export const SECTION_BUILDERS: Record<SectionType, SectionBuilder> = {
   productCatalog: buildProductCatalog,
   featuredProducts: buildFeaturedProducts,
   commerceCatalog: buildCommerceCatalog,
+  ageGate: buildAgeGate,
   gallery: buildGallery,
   team: buildTeam,
   testimonials: buildTestimonials,

--- a/web/lib/engine/section-registry.ts
+++ b/web/lib/engine/section-registry.ts
@@ -124,6 +124,15 @@ export const SECTION_CATALOG: Record<string, SectionManifest> = {
     defaultVariant: 'grid',
     variants: ['grid'],
   },
+  'age-gate': {
+    // Self-declared 18+ modal for adult-content tenants. Registry flags
+    // `features.ageGate.enabled: true, minAge: N` on sex_shop,
+    // cigar_lounge_shop, onlyfans_creator_studio, etc. Returns null
+    // when the visitor has already confirmed (localStorage flag).
+    id: 'age-gate',
+    defaultVariant: 'modal',
+    variants: ['modal'],
+  },
   footer: {
     id: 'footer',
     defaultVariant: 'standard',

--- a/web/lib/engine/site-renderer.tsx
+++ b/web/lib/engine/site-renderer.tsx
@@ -14,6 +14,7 @@ import { ServicesSection } from '@/components/sections/services-section'
 import { ProductCatalogSection } from '@/components/sections/product-catalog-section'
 import { FeaturedProductsSection } from '@/components/sections/featured-products-section'
 import { CommerceCatalogSection } from '@/components/sections/commerce-catalog-section'
+import { AgeGateSection } from '@/components/sections/age-gate-section'
 import { GallerySection } from '@/components/sections/gallery-section'
 import { TeamSection } from '@/components/sections/team-section'
 import { TestimonialsSection } from '@/components/sections/testimonials-section'
@@ -53,6 +54,7 @@ const COMPONENTS: Record<string, React.ComponentType<any>> = {
   'product-catalog': ProductCatalogSection,
   'featured-products': FeaturedProductsSection,
   'commerce-catalog': CommerceCatalogSection,
+  'age-gate': AgeGateSection,
   gallery: GallerySection,
   team: TeamSection,
   testimonials: TestimonialsSection,


### PR DESCRIPTION
## Summary

Adult-content tenants (sex_shop, cigar_lounge_shop, onlyfans_creator_studio, etc.) declare \`features.ageGate.enabled: true, minAge: N\` in their registry, but the React component didn't exist — shoppers walked straight into the catalog without a self-declaration. Closes the last legal/policy gap before fun4me's store is launch-ready.

## What ships

1. **\`<AgeGateSection>\`** — 'use client' modal. \`useSyncExternalStore\` reads localStorage key \`paragu_age_gate_confirmed\`; SSR snapshot is null so bots and cached HTML still carry the gate. \`useState\` toggle hides synchronously on confirm. Decline sends to a neutral external URL (default \`google.com\`). Self-declared 18+ — **not** identity verification; matches local PY norms.

2. **Engine wiring**:
   - \`SECTION_CATALOG\` → adds \`age-gate\` manifest
   - \`SectionType\` union → adds \`ageGate\`
   - \`SECTION_MAP\` → accepts \`ageGate\` and \`age-gate\`
   - \`site-renderer\` → binds \`age-gate\` → \`AgeGateSection\`
   - \`SECTION_BUILDERS\` → \`buildAgeGate\` gates on \`registry.features.ageGate.enabled\` so stray config on non-adult tenants is a no-op

3. **Vertical whitelist**: \`retail-local/vertical.json\` adds \`age-gate\` to \`allowedSections\` — avoids the same bug class as PR #173 (missed whitelist → cryptic composition 404).

4. **fun4me opt-in**: age-gate prepended to every page config (11 files: blog, bundles, gift-cards, home, legal, loyalty, placer-plus, reserva-en-tienda, size-guide, store, suscripciones). localStorage persistence means shoppers see it once regardless of landing page.

Content \`home.ageGate\` already exists in \`content/es.json\` with Spanish copy — no content changes needed.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run test:unit\` — 426 pass
- [x] \`npm run build\` — clean
- [ ] After deploy: first visit to any /fun4me/* page shows modal
- [ ] Confirm → modal dismisses, doesn't reappear (localStorage)
- [ ] Decline → redirects to google.com
- [ ] Clear localStorage + reload → modal returns
- [ ] Other retail-local tenants (no ageGate config) unaffected

## Compliance note

This is self-declaration, not identity verification. Matches what similar storefronts do in PY. If legal wants stronger gating later (ID upload, age-verify provider) the component has a clean prop surface to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)