### PR TITLE
fix(nexa-paraguay): client feedback — 7 UX fixes from staging walkthrough

### DIFF
--- a/sites/nexa-paraguay/blog/es/apertura-cuenta-bancaria-paraguay.mdx
+++ b/sites/nexa-paraguay/blog/es/apertura-cuenta-bancaria-paraguay.mdx
@@ -1,0 +1,161 @@
+---
+title: "Apertura de Cuenta Bancaria en Paraguay para Extranjeros"
+date: 2024-03-20
+author: "Nexa Paraguay"
+category: "Banca"
+excerpt: "Guía práctica para abrir cuentas bancarias personales y empresariales en Paraguay. Requisitos, bancos recomendados y consejos prácticos."
+coverImage: "/sites/nexa-paraguay/images/blog/banca.jpg"
+---
+
+# Apertura de Cuenta Bancaria en Paraguay para Extranjeros
+
+El sistema bancario paraguayo ha evolucionado significativamente en los últimos años, ofreciendo servicios modernos y competitivos para residentes y no residentes. Abrir una cuenta bancaria es un paso esencial para establecerse en el país.
+
+## Tipos de Cuentas Disponibles
+
+### Cuentas en Guaraníes (PYG)
+- Moneda local
+- Menores costos de transacción nacional
+- Ideal para operaciones locales
+
+### Cuentas en Dólares (USD)
+- Protección contra inflación
+- Ideal para ahorro e inversión
+- Recomendada para extranjeros
+
+### Cuentas en Reales (BRL)
+- Útil para comercio con Brasil
+- Menor costo de cambio
+
+## Bancos Principales en Paraguay
+
+### Banco Continental
+- Mayor banco privado del país
+- Excelente plataforma digital
+- Buena atención a empresas
+
+### Banco Itaú Paraguay
+- Parte del grupo brasileño
+- Fuerte en comercio internacional
+- Buena red de sucursales
+
+### Banco Basa
+- Tradicional y conservador
+- Excelente para grandes empresas
+- Servicios de private banking
+
+### Banco Atlas
+- Enfocado en pymes
+- Innovador en productos digitales
+- Buena opción para startups
+
+### Banco Sudameris
+- Creciente presencia internacional
+- Fuerte en comercio exterior
+
+## Requisitos para Abrir Cuenta
+
+### Cuenta Personal (con Residencia)
+1. Cédula de identidad paraguaya
+2. RUC (Registro Único de Contribuyente)
+3. Comprobante de domicilio
+4. Referencias comerciales o laborales
+5. Carta de trabajo o declaración de renta
+
+### Cuenta Empresarial
+1. Escritura de constitución de sociedad
+2. RUC de la empresa
+3. Cédulas de socios/directores
+4. Acta de asamblea autorizando apertura
+5. Contrato social vigente
+6. Estados financieros (empresas existentes)
+
+### Cuenta para No Residentes
+- Pasaporte vigente
+- Referencias bancarias internacionales
+- Comprobante de origen de fondos
+- Entrevista personal obligatoria
+- Depósito inicial más alto
+
+## Proceso de Apertura
+
+### Paso 1: Elegir el Banco
+Considera:
+- Tarifas de mantenimiento
+- Costos de transferencias internacionales
+- Calidad de banca digital
+- Proximidad de sucursales
+
+### Paso 2: Reunir Documentación
+Revisa los requisitos específicos del banco elegido.
+
+### Paso 3: Entrevista Bancaria
+- Evaluación de perfil de riesgo
+- Conocimiento del cliente (KYC)
+- Verificación de documentos
+
+### Paso 4: Firma de Contratos
+- Contrato de cuenta
+- Reglamento de operaciones
+- Términos de servicios digitales
+
+### Paso 5: Depósito Inicial y Activación
+- Depósito inicial (varía según tipo de cuenta)
+- Recibo de tarjeta de débito
+- Activación de banca en línea
+
+## Tiempos de Apertura
+
+| Tipo de Cuenta | Tiempo Estimado |
+|----------------|------------------|
+| Personal (residente) | 24-72 horas |
+| Empresarial | 3-7 días hábiles |
+| No residente | 1-2 semanas |
+| Cuenta VIP/Empresarial | 1-2 días |
+
+## Costos Típicos
+
+| Concepto | Costo Aproximado |
+|----------|-------------------|
+| Apertura de cuenta | Gratis - USD 50 |
+| Mantenimiento mensual | USD 3 - 15 |
+| Transferencias nacionales | USD 1 - 5 |
+| Transferencias internacionales | USD 25 - 75 |
+| Tarjeta de débito | USD 5 - 15/año |
+| Tarjeta de crédito | USD 20 - 100/año |
+
+## Consideraciones para Extranjeros
+
+### Ventajas
+- Banca estable y regulada
+- Depósitos asegurados (hasta cierto monto)
+- Posibilidad de cuentas en dólares
+- Transferencias SWIFT disponibles
+
+### Desafíos
+- Proceso más complejo sin residencia
+- Requiere presencia personal
+- Límites en montos según perfil
+
+## Recomendación Nexa Paraguay
+
+Para una apertura exitosa:
+
+1. **Obtén tu residencia primero**: Facilita enormemente el proceso
+2. **Prepara documentación completa**: Evita retrasos
+3. **Evalúa múltiples bancos**: Compara servicios y costos
+4. **Considera cuentas en dólares**: Mejor para extranjeros
+5. **Activa todos los servicios digitales**: Banca online, app móvil
+
+## Nuestro Servicio de Acompañamiento
+
+Incluimos en nuestros programas:
+- Preparación de documentación
+- Agendamiento de entrevistas bancarias
+- Acompañamiento en firma de documentos
+- Coordinación con oficiales de cuenta
+- Activación de servicios digitales
+
+---
+
+*¿Necesitas ayuda con la apertura de tu cuenta bancaria? Es parte de nuestro servicio integral.*

--- a/sites/nexa-paraguay/blog/es/comparativa-fiscal-paraguay-vs-uruguay.mdx
+++ b/sites/nexa-paraguay/blog/es/comparativa-fiscal-paraguay-vs-uruguay.mdx
@@ -1,0 +1,105 @@
+---
+title: "Comparativa Fiscal 2024: Paraguay vs Uruguay para Empresas"
+date: 2024-04-08
+author: "Nexa Paraguay"
+category: "Fiscalidad"
+excerpt: "Análisis detallado de las diferencias fiscales entre Paraguay y Uruguay para empresas e inversores. Descubre cuál es la mejor opción para tu negocio."
+coverImage: "/sites/nexa-paraguay/images/blog/comparativa-fiscal.jpg"
+---
+
+# Comparativa Fiscal 2024: Paraguay vs Uruguay para Empresas
+
+La elección del país para establecer una empresa es una decisión crucial que impacta directamente en la rentabilidad y crecimiento del negocio. Dos de los destinos más atractivos de Sudamérica son Paraguay y Uruguay, cada uno con sus propias ventajas fiscales.
+
+## Resumen Comparativo Rápido
+
+| Aspecto | Paraguay | Uruguay |
+|---------|----------|---------|
+| IRP (Impuesto a la Renta Empresaria) | 10% | 25% |
+| IVA | 10% | 22% |
+| Patrimonio | 0% | 0.7% - 1.5% |
+| Dividendos | 0% (si reinvertidos) | 7% - 12% |
+| Maquila (Zona Franca) | Exención total | Beneficios parciales|
+
+## Paraguay: El Paraíso Fiscal Legal de Sudamérica
+
+### Ventajas Fiscales Paraguay
+
+1. **IRP del 10%**: Una de las tasas más bajas del continente
+2. **IVA del 10%**: Menor carga impositiva al consumo
+3. **Zona Franca Paraguay**: Exención total para empresas exportadoras
+4. **No cobro de impuesto al patrimonio**: Tus activos no generan carga fiscal
+5. **Exención de dividendos**: Si reinviertes utilidades, no pagas impuestos adicionales
+
+### Caso de Éxito Paraguay
+
+Una empresa de software que factura USD 1 millón anual:
+- Impuesto a la renta: USD 100,000
+- Dividendos reinvertidos: USD 0
+- IVA (si aplica): 10% sobre consumo
+
+## Uruguay: Estabilidad con Mayor Carga Fiscal
+
+### Ventajas Fiscales Uruguay
+
+1. **Estabilidad jurídica**: Sistema legal robusto y predecible
+2. **Residencia fiscal fácil**: Requisitos claros y accesibles
+3. **Zona Franca Uruguay**: Beneficios para operaciones offshore
+4. **Convenios de doble tributación**: Más extensos que Paraguay
+
+### Caso de Éxito Uruguay
+
+Misma empresa de software (USD 1 millón):
+- Impuesto a la renta: USD 250,000
+- Dividendos: USD 70,000 - 120,000 adicionales
+- IVA: 22% sobre consumo
+
+## Análisis por Tipo de Negocio
+
+### Empresas de Tecnología y Servicios
+**Ganador: Paraguay**
+
+La combinación de IRP del 10% y exención de dividendos hace que Paraguay sea ideal para startups y empresas tech.
+
+### Trading y E-commerce
+**Ganador: Paraguay (Zona Franca)**
+
+La Zona Franca paraguaya ofrece beneficios superiores para empresas de comercio internacional.
+
+### Consultoría Profesional
+**Ganador: Paraguay**
+
+Menor carga fiscal y facilidades para facturación internacional.
+
+## Consideraciones No Fiscales
+
+### Paraguay
+- ✅ Menor costo de vida
+- ✅ Mercado laboral en crecimiento
+- ✅ Ubicación estratégica (centro de Sudamérica)
+- ⚠️ Menor desarrollo financiero que Uruguay
+
+### Uruguay
+- ✅ Sistema bancario más desarrollado
+- ✅ Mayor aceptación internacional
+- ✅ Educación y salud de alta calidad
+- ⚠️ Costo de vida 40-60% mayor que Paraguay
+
+## Conclusión
+
+Para la mayoría de empresas, **Paraguay ofrece ventajas fiscales significativas** que pueden representar ahorros de 50-70% comparado con Uruguay. Sin embargo, la elección debe considerar también factores como:
+
+- Mercado objetivo
+- Proveedores y cadena de valor
+- Necesidades de talento humano
+- Proyección de crecimiento
+
+## Recomendación de Nexa Paraguay
+
+Si tu prioridad es **optimización fiscal y costos operativos**, Paraguay es la opción clara.
+
+Si necesitas **máxima estabilidad jurídica y reconocimiento internacional inmediato**, considera Uruguay.
+
+---
+
+*¿Necesitas ayuda para decidir? Agenda una consulta estratégica gratuita con nuestros asesores.*

--- a/sites/nexa-paraguay/blog/es/comprar-propiedades-paraguay-extranjeros.mdx
+++ b/sites/nexa-paraguay/blog/es/comprar-propiedades-paraguay-extranjeros.mdx
@@ -1,0 +1,123 @@
+---
+title: "Guía para Extranjeros: Cómo Comprar Propiedades en Paraguay"
+date: 2024-03-28
+author: "Nexa Paraguay"
+category: "Inversión Inmobiliaria"
+excerpt: "Todo el proceso legal y práctico para adquirir inmuebles en Paraguay siendo extranjero. Desde la búsqueda hasta la escrituración."
+coverImage: "/sites/nexa-paraguay/images/blog/propiedades.jpg"
+---
+
+# Guía para Extranjeros: Cómo Comprar Propiedades en Paraguay
+
+El mercado inmobiliario paraguayo se ha posicionado como uno de los más atractivos de Sudamérica para inversores extranjeros. Con precios competitivos, alta rentabilidad y un marco legal favorable, comprar propiedades en Paraguay es más simple de lo que imaginas.
+
+## ¿Pueden los Extranjeros Comprar Propiedad en Paraguay?
+
+**Sí, absolutamente.** La Constitución paraguaya garantiza a extranjeros los mismos derechos de propiedad que a nacionales, con una sola excepción: la propiedad rural en zonas de frontera (50km), que requiere autorización especial.
+
+## Requisitos para Comprar
+
+### Si ya tienes Residencia Paraguaya
+- Cédula de identidad vigente
+- RUC (Registro Único de Contribuyente)
+- Solvencia fiscal
+
+### Si no tienes Residencia
+- Pasaporte vigente
+- Representante legal local (recomendado)
+- Poder notarial (si compras a distancia)
+
+## El Proceso de Compra
+
+### Paso 1: Búsqueda y Due Diligence
+- Identificación de propiedades según objetivo (inversión, vivienda, comercial)
+- Verificación de títulos de propiedad
+- Confirmación de no existencia de gravámenes
+- Revisión de impuestos municipales al día
+
+### Paso 2: Negociación y Reserva
+- Negociación de precio y condiciones
+- Firma de pre-contrato o reserva
+- Depósito de garantía (típicamente 10%)
+
+### Paso 3: Escrituración
+- Firma de escritura pública ante escribano
+- Transferencia de fondos
+- Registro de la propiedad
+
+### Paso 4: Posescrituración
+- Registro en Dirección General de Registros Públicos
+- Cambio de titularidad en servicios
+- Obtención de plano aprobado (si aplica)
+
+## Costos Asociados
+
+| Concepto | Porcentaje | Notas |
+|----------|------------|-------|
+| Impuesto Inmobiliario | 0.5% - 1% anual | Sobre valor fiscal |
+| Impuesto a la Renta (venta) | 10% | Solo sobre ganancia de capital |
+| Impuesto de Sellos | 0.5% - 2% | En escrituración |
+| Honorarios Escribano | 1% - 1.5% | Negociable |
+| Registro de Propiedad | 0.5% - 1% | Sobre valor de escritura |
+| Comisión Corretaje | 3% - 5% | Típicamente paga vendedor |
+
+## Zonas Más Atractivas para Inversión
+
+### Asunción y Gran Asunción
+- **Villa Morra**: Barrio premium, alta valorización
+- **Las Carmelitas**: Seguridad y exclusividad
+- **Mburucuyá**: Zona residencial en crecimiento
+- **San Lorenzo**: Precios accesibles con buena rentabilidad
+
+### Zonas Turísticas
+- **San Bernardino**: Lago Ypacaraí, alta demanda turística
+- **Areguá**: Capital del artesanato, creciente interés
+- **Ciudad del Este**: Centro comercial binacional
+
+### Agro
+- **Alto Paraná**: Tierra productiva para soja
+- **San Pedro**: Precios competitivos, alto rendimiento
+- **Caaguazú**: Creciente demanda agropecuaria
+
+## Rentabilidad Esperada
+
+### Inversión Residencial (Alquiler)
+- **Retorno anual**: 6% - 10% en dólares
+- **Plusvalía**: 8% - 12% anual en zonas premium
+- **Payback**: 10-15 años
+
+### Inversión Comercial
+- **Retorno anual**: 8% - 15%
+- **Más alto riesgo, más alta rentabilidad**
+
+### Inversión Agropecuaria
+- **Retorno anual**: 10% - 20%
+- **Requiere conocimiento técnico**
+
+## Errores Comunes a Evitar
+
+### 1. No Verificar Títulos
+Siempre contrata un abogado para hacer due diligence completa.
+
+### 2. Ignorar Impuestos Municipales
+Verifica que no haya deudas acumuladas que puedan afectar la compra.
+
+### 3. Comprar sin Ver el Inmueble
+Si no puedes viajar, contrata un representante de confianza.
+
+### 4. No Considerar Costos de Mantenimiento
+Los costos de mantenimiento pueden representar 1-3% del valor anual.
+
+## Servicios de Nexa Paraguay
+
+Ofrecemos acompañamiento integral en la compra de propiedades:
+
+1. **Búsqueda estratégica** según tu perfil de inversión
+2. **Due diligence legal completa**
+3. **Negociación** con vendedores y corredores
+4. **Acompañamiento en escrituración**
+5. **Gestión post-compra** (servicios, alquileres, etc.)
+
+---
+
+*¿Interesado en invertir en propiedades paraguayas? Agenda una consulta con nuestro equipo inmobiliario.*

--- a/sites/nexa-paraguay/blog/es/emprender-paraguay-oportunidades-2024.mdx
+++ b/sites/nexa-paraguay/blog/es/emprender-paraguay-oportunidades-2024.mdx
@@ -1,0 +1,219 @@
+---
+title: "Emprender en Paraguay: Oportunidades de Negocio 2024"
+date: 2024-03-10
+author: "Nexa Paraguay"
+category: "Emprendimiento"
+excerpt: "Descubre las sectores más prometedores para emprender en Paraguay. Análisis de mercado, oportunidades y casos de éxito."
+coverImage: "/sites/nexa-paraguay/images/blog/emprender.jpg"
+---
+
+# Emprender en Paraguay: Oportunidades de Negocio 2024
+
+Paraguay se ha convertido en un destino emergente para emprendedores de toda Latinoamérica. Con un ambiente de negocios favorable, costos competitivos y una economía en crecimiento, las oportunidades son abundantes para quienes saben dónde buscar.
+
+## Por Qué Emprender en Paraguay
+
+### Ventajas del Ecosistema Paraguayo
+
+1. **Régimen Fiscal Competitivo**
+   - 10% de impuesto a la renta empresarial
+   - 10% de IVA
+   - Exenciones para zonas francas
+
+2. **Costos Operativos Bajos**
+   - 40-60% más barato que Buenos Aires o Montevideo
+   - Mano de obra calificada a costos competitivos
+   - Alquileres accesibles
+
+3. **Ubicación Estratégica**
+   - Centro de Sudamérica
+   - Acceso a MERCOSUR (mercado de 300M personas)
+   - Cercanía a Brasil y Argentina
+
+4. **Estabilidad Macroeconómica**
+   - Crecimiento sostenido del PBI
+   - Inflación controlada
+   - Sistema cambiario estable
+
+## Sectores Más Prometedores
+
+### 1. Tecnología y Software
+**Oportunidad: ★★★★★**
+
+Paraguay está viviendo un boom tecnológico:
+- Desarrollo de software para exportación
+- Fintech y servicios financieros digitales
+- E-commerce y logística
+- Agrotech
+
+**Caso de Éxito**: Una startup de software paraguaya fue adquirida por USD 10M en 2023.
+
+### 2. Agroindustria y Agrotech
+**Oportunidad: ★★★★★**
+
+Paraguay es potencia agrícola:
+- 4to exportador mundial de soja
+- Producción de carne de calidad
+- Tecnificación del campo
+- Exportación de alimentos procesados
+
+**Oportunidades específicas**:
+- Sistemas de riego inteligente
+- Logística agrícola
+- Procesamiento de granos
+- Agricultura orgánica
+
+### 3. Energías Renovables
+**Oportunidad: ★★★★☆**
+
+100% de energía eléctrica es renovable (Itaipú + Yacyretá):
+- Venta de energía limpia
+- Instalación de paneles solares
+- Consultoría energética
+- Minería de Bitcoin (energía barata)
+
+### 4. Turismo y Hospitalidad
+**Oportunidad: ★★★★☆**
+
+Turismo en crecimiento acelerado:
+- Ecoturismo
+- Turismo de eventos
+- Hoteles boutique
+- Experiencias locales únicas
+
+Destinos emergentes:
+- Saltos del Monday
+- Lago Ypacaraí
+- Misiones Jesuíticas
+- Chaco paraguayo
+
+### 5. Sector Inmobiliario
+**Oportunidad: ★★★★☆**
+
+Mercado inmobiliario dinámico:
+- Construcción residencial
+- Desarrollo de oficinas
+- Propiedades industriales
+- Coworking spaces
+
+Rentabilidades atractivas:
+- 6-10% anual en alquileres
+- Plusvalía de 8-12% anual
+
+### 6. Servicios Profesionales B2B
+**Oportunidad: ★★★★☆**
+
+Demanda creciente de:
+- Consultoría de negocios
+- Marketing digital
+- Servicios legales especializados
+- Contabilidad internacional
+- Recursos humanos
+
+### 7. Salud y Bienestar
+**Oportunidad: ★★★☆☆**
+
+Sector con alto potencial:
+- Medicina prepaga
+- Centros de bienestar
+- Nutrición deportiva
+- Turismo médico
+
+### 8. Educación y Capacitación
+**Oportunidad: ★★★☆☆**
+
+Demanda constante:
+- Institutos de inglés
+- Cursos técnicos
+- Capacitación corporativa
+- Edtech
+
+## Inversión Requerida por Sector
+
+| Sector | Inversión Mínima | ROI Esperado |
+|--------|-------------------|----------------|
+| Tecnología | USD 5,000 - 20,000 | 30-50% |
+| Agroindustria | USD 50,000 - 200,000 | 15-25% |
+| Turismo | USD 30,000 - 100,000 | 20-30% |
+| Inmobiliario | USD 100,000+ | 12-20% |
+| Servicios B2B | USD 2,000 - 10,000 | 40-60% |
+
+## Pasos para Emprender en Paraguay
+
+### 1. Investigación de Mercado
+- Análisis de competencia
+- Estudio de demanda
+- Identificación de nicho
+
+### 2. Constitución Legal
+- Elección de tipo de sociedad
+- Trámites de registro
+- Obtención de RUC
+
+### 3. Apertura de Cuenta Bancaria
+- Selección de banco
+- Gestión de documentación
+- Activación de servicios
+
+### 4. Cumplimiento Fiscal
+- Inscripción en SET
+- Configuración de facturación
+- Planificación fiscal
+
+### 5. Operaciones
+- Contratación de personal
+- Locación de oficinas/instalaciones
+- Marketing y lanzamiento
+
+## Apoyo Gubernamental
+
+### Incentivos Disponibles
+- **Zona Franca Paraguay**: Exención fiscal total
+- **Maquila**: Beneficios para exportadores
+- **Sistema de drawback**: Devolución de impuestos
+- **Inversiones en turismo**: Beneficios específicos
+
+### Instituciones de Apoyo
+- **REDIEX**: Promoción de exportaciones
+- **MIC**: Ministerio de Industria y Comercio
+- **Banco Central**: Regulación y estabilidad
+- **Cámara de Comercio**: Networking y apoyo
+
+## Casos de Éxito Recientes
+
+### Startup Tech (SaaS)
+Inversión inicial: USD 15,000
+Facturación año 3: USD 500,000
+Empleados: 25 personas
+
+### Exportadora Agropecuaria
+Inversión inicial: USD 80,000
+Exportación anual: USD 2M
+Mercados: 8 países
+
+### Hotel Boutique
+Inversión inicial: USD 120,000
+Ocupación: 75% promedio anual
+ROI: 22% anual
+
+## Recomendaciones de Nexa Paraguay
+
+1. **Comienza con residencia**: Facilita todos los trámites empresariales
+2. **Asesórate desde el inicio**: Un buen contador y abogado valen su peso en oro
+3. **Entiende la cultura**: Las relaciones personales son fundamentales
+4. **Sé paciente**: Los trámites pueden ser lentos, pero son seguros
+5. **Piensa en grande**: Paraguay es una plataforma para Sudamérica
+
+## Nuestros Servicios para Emprendedores
+
+- Asesoría en elección de sector
+- Constitución de sociedades
+- Planificación fiscal
+- Apertura de cuentas bancarias
+- Permisos y licencias
+- Contratación de personal
+- Networking y contactos
+
+---
+
+*¿Tienes una idea de negocio? Agenda una consulta estratégica gratuita.*

--- a/sites/nexa-paraguay/blog/es/guia-completa-residencia-paraguay-2024.mdx
+++ b/sites/nexa-paraguay/blog/es/guia-completa-residencia-paraguay-2024.mdx
@@ -1,0 +1,69 @@
+---
+title: "Guía Completa: Cómo Obtener la Residencia en Paraguay en 2024"
+date: 2024-04-15
+author: "Nexa Paraguay"
+category: "Inmigración"
+excerpt: "Todo lo que necesitas saber sobre el proceso de radicación en Paraguay, requisitos, plazos y consejos prácticos para una transición exitosa."
+coverImage: "/sites/nexa-paraguay/images/blog/residencia-2024.jpg"
+---
+
+# Guía Completa: Cómo Obtener la Residencia en Paraguay en 2024
+
+Paraguay se ha convertido en uno de los destinos más atractivos para expatriados, emprendedores e inversores de toda Latinoamérica y el mundo. Su crecimiento económico sostenido, régimen fiscal favorable y calidad de vida hacen de este país una opción ideal para establecer una nueva base de operaciones.
+
+## Requisitos Principales
+
+Para obtener la residencia en Paraguay, necesitarás:
+
+1. **Pasaporte vigente** con al menos 6 meses de validez
+2. **Certificado de antecedentes penales** de tu país de origen
+3. **Certificado de nacimiento** apostillado
+4. **Comprobante de solvencia económica**
+5. **Certificado médico** expedido en Paraguay
+
+## El Proceso Paso a Paso
+
+### Paso 1: Preparación Documental
+El primer paso es reunir todos los documentos necesarios. Es crucial que estos documentos estén correctamente apostillados según el Convenio de La Haya.
+
+### Paso 2: Ingreso a Paraguay
+Deberás ingresar al país como turista y comenzar el proceso de radicación. Durante esta etapa, te recomendamos asesoría legal especializada.
+
+### Paso 3: Presentación de Expediente
+Con todos los documentos en orden, se presenta el expediente ante la Dirección General de Migraciones.
+
+### Paso 4: Aprobación y Cédula
+Una vez aprobada la residencia, podrás tramitar tu cédula de identidad paraguaya.
+
+## Tiempos Estimados
+
+- Preparación documental: 2-4 semanas
+- Tramitación en Paraguay: 4-8 semanas
+- Obtención de cédula: 1-2 semanas
+
+**Tiempo total estimado: 8-12 semanas**
+
+## Beneficios de la Residencia Paraguaya
+
+1. **Acceso al MERCOSUR** y libre circulación en países miembros
+2. **Régimen fiscal favorable** con impuestos competitivos
+3. **Posibilidad de constitución de sociedades** con facilidades únicas
+4. **Apertura de cuentas bancarias** sin complicaciones
+5. **Compra de propiedades** con los mismos derechos que nacionales
+
+## Consejos de Nexa Paraguay
+
+Basándonos en nuestra experiencia con más de 250 clientes:
+
+- **Planifica con anticipación**: El proceso requiere tiempo y preparación
+- **Asesórate con expertos**: Un error documental puede retrasar meses el proceso
+- **Conoce la cultura local**: Paraguay tiene una cultura empresarial única basada en relaciones personales
+- **Evalúa opciones de inversión**: El mercado inmobiliario paraguayo ofrece excelentes oportunidades
+
+## Próximos Pasos
+
+¿Listo para comenzar tu proceso de radicación? Agenda una consulta gratuita con nuestro equipo y descubre qué programa de Nexa Paraguay se adapta mejor a tus necesidades.
+
+---
+
+*Este artículo es informativo. Las regulaciones migratorias pueden cambiar. Consulta siempre con profesionales actualizados.*

--- a/sites/nexa-paraguay/content/de.json
+++ b/sites/nexa-paraguay/content/de.json
@@ -116,7 +116,7 @@
           "name": "Paraguay Business",
           "description": "Aufenthalt + Gesellschaft + Bankkonto.",
           "price": "USD 4.400+",
-          "priceNote": "LEALTIS-Basispreis. Nexa-Endpreis in Festlegung.",
+          "priceNote": "Ab-Preis. Endgültiges Angebot je nach Anforderungen.",
           "badge": "Am beliebtesten",
           "highlighted": true,
           "included": [
@@ -135,7 +135,7 @@
           "name": "Paraguay Investor Program",
           "description": "Alles aus Business + 12 Monate Begleitung.",
           "price": "USD 6.900+",
-          "priceNote": "LEALTIS-Basispreis. Nexa-Endpreis in Festlegung.",
+          "priceNote": "Ab-Preis. Endgültiges Angebot je nach Anforderungen.",
           "included": [
             "Alles aus Business",
             "Buchhaltung (12 Monate)",
@@ -159,7 +159,7 @@
             "Verhandlung und Beurkundung",
             "Registereintragung"
           ],
-          "ctaLabel": "Sondierungsgespräch",
+          "ctaLabel": "Anfragen",
           "ctaHref": "/s/de/nexa-paraguay/contacto?programa=tierras"
         }
       ]
@@ -289,7 +289,7 @@
           "name": "Paraguay Business",
           "description": "Aufenthalt + Gesellschaft + Bankkonto.",
           "price": "USD 4.400+",
-          "priceNote": "LEALTIS-Basispreis. Nexa-Endpreis in Festlegung.",
+          "priceNote": "Ab-Preis. Endgültiges Angebot je nach Anforderungen.",
           "badge": "Am beliebtesten",
           "highlighted": true,
           "included": [
@@ -308,7 +308,7 @@
           "name": "Paraguay Investor Program",
           "description": "Alles aus Business + 12 Monate Begleitung.",
           "price": "USD 6.900+",
-          "priceNote": "LEALTIS-Basispreis. Nexa-Endpreis in Festlegung.",
+          "priceNote": "Ab-Preis. Endgültiges Angebot je nach Anforderungen.",
           "included": [
             "Alles aus Business",
             "Buchhaltung (12 Monate)",
@@ -332,7 +332,7 @@
             "Verhandlung und Beurkundung",
             "Registereintragung"
           ],
-          "ctaLabel": "Sondierungsgespräch",
+          "ctaLabel": "Anfragen",
           "ctaHref": "/s/de/nexa-paraguay/contacto?programa=tierras"
         }
       ]
@@ -363,7 +363,7 @@
           "name": "Paraguay Business",
           "description": "Aufenthalt + Gesellschaft + Bankkonto.",
           "price": "USD 4.400+",
-          "priceNote": "LEALTIS-Basispreis. Nexa-Endpreis in Festlegung.",
+          "priceNote": "Ab-Preis. Endgültiges Angebot je nach Anforderungen.",
           "badge": "Am beliebtesten",
           "highlighted": true,
           "included": [
@@ -382,7 +382,7 @@
           "name": "Paraguay Investor Program",
           "description": "Alles aus Business + 12 Monate Begleitung.",
           "price": "USD 6.900+",
-          "priceNote": "LEALTIS-Basispreis. Nexa-Endpreis in Festlegung.",
+          "priceNote": "Ab-Preis. Endgültiges Angebot je nach Anforderungen.",
           "included": [
             "Alles aus Business",
             "Buchhaltung (12 Monate)",
@@ -406,7 +406,7 @@
             "Verhandlung und Beurkundung",
             "Registereintragung"
           ],
-          "ctaLabel": "Sondierungsgespräch",
+          "ctaLabel": "Anfragen",
           "ctaHref": "/s/de/nexa-paraguay/contacto?programa=tierras"
         }
       ]
@@ -769,7 +769,9 @@
       "subtitle": "Wählen Sie einen passenden Termin.",
       "bookingUrl": "https://calendly.com/nexaparaguay/consulta",
       "provider": "calendly",
-      "ctaLabel": "Kalender öffnen"
+      "ctaLabel": "Kalender öffnen",
+      "fallbackWhatsapp": "595982515138",
+      "fallbackEmail": "hola@nexaparaguay.com"
     },
     "contact": {
       "title": "Oder schreiben Sie uns direkt",
@@ -847,6 +849,22 @@
       {
         "label": "Datenschutz",
         "href": "/s/de/nexa-paraguay/privacidad"
+      },
+      {
+        "label": "FAQ",
+        "href": "/s/de/nexa-paraguay/faq"
+      },
+      {
+        "label": "Blog",
+        "href": "/s/de/nexa-paraguay/blog"
+      },
+      {
+        "label": "Kontakt",
+        "href": "/s/de/nexa-paraguay/contacto"
+      },
+      {
+        "label": "Warum Paraguay",
+        "href": "/s/de/nexa-paraguay/por-que-paraguay"
       }
     ]
   },
@@ -857,7 +875,10 @@
       "Die Ergebnisse hängen von der individuellen Erfüllung der Anforderungen ab und können variieren. Informationen unterliegen regulatorischen Änderungen."
     ],
     "licenseNumbers": [
-      { "label": "SEPRELAD", "number": "Registrierung ausstehend" }
+      {
+        "label": "SEPRELAD",
+        "number": "Registrierung ausstehend"
+      }
     ],
     "linkText": "Vollständige AML-Erklärung",
     "linkHref": "/s/de/nexa-paraguay/privacidad#aml"
@@ -870,27 +891,101 @@
     "whatsappPhone": "595982515138",
     "whatsappFallbackLabel": "Fragen? Kontaktieren Sie uns über WhatsApp",
     "questions": [
-      { "id": "fullName", "kind": "text", "label": "Vollständiger Name (laut Ausweis)", "required": true },
-      { "id": "nationality", "kind": "text", "label": "Staatsangehörigkeit", "required": true },
-      { "id": "documentType", "kind": "radio", "label": "Ausweisart", "required": true, "options": [
-        { "value": "passport", "label": "Reisepass" },
-        { "value": "id", "label": "Personalausweis" },
-        { "value": "other", "label": "Andere" }
-      ]},
-      { "id": "economicActivity", "kind": "textarea", "label": "Hauptberufliche Tätigkeit", "helpText": "Beschreiben Sie Ihren Beruf oder Ihre Haupteinkommensquelle", "required": true },
-      { "id": "fundsOrigin", "kind": "radio", "label": "Mittelherkunft", "required": true, "options": [
-        { "value": "salary", "label": "Gehalt / Honorare" },
-        { "value": "business", "label": "Geschäftstätigkeit" },
-        { "value": "investment", "label": "Anlagen / passives Einkommen" },
-        { "value": "inheritance", "label": "Erbschaft oder Schenkung" },
-        { "value": "other", "label": "Sonstige (unten beschreiben)" }
-      ]},
-      { "id": "fundsOriginDetail", "kind": "textarea", "label": "Details zur Mittelherkunft", "helpText": "Ergänzen Sie die obige Auswahl. Nexa fordert Belege im formellen KYC-Prozess an." },
-      { "id": "pep", "kind": "radio", "label": "Sind Sie eine politisch exponierte Person (PEP) oder direktes Familienmitglied einer PEP?", "required": true, "options": [
-        { "value": "no", "label": "Nein" },
-        { "value": "yes", "label": "Ja" }
-      ]},
-      { "id": "truthfulDeclaration", "kind": "checkbox", "label": "Ich erkläre eidesstattlich, dass die Angaben wahrheitsgemäß sind, und autorisiere Nexa Paraguay, die erforderlichen Überprüfungen durchzuführen.", "required": true }
+      {
+        "id": "fullName",
+        "kind": "text",
+        "label": "Vollständiger Name (laut Ausweis)",
+        "required": true
+      },
+      {
+        "id": "nationality",
+        "kind": "text",
+        "label": "Staatsangehörigkeit",
+        "required": true
+      },
+      {
+        "id": "documentType",
+        "kind": "radio",
+        "label": "Ausweisart",
+        "required": true,
+        "options": [
+          {
+            "value": "passport",
+            "label": "Reisepass"
+          },
+          {
+            "value": "id",
+            "label": "Personalausweis"
+          },
+          {
+            "value": "other",
+            "label": "Andere"
+          }
+        ]
+      },
+      {
+        "id": "economicActivity",
+        "kind": "textarea",
+        "label": "Hauptberufliche Tätigkeit",
+        "helpText": "Beschreiben Sie Ihren Beruf oder Ihre Haupteinkommensquelle",
+        "required": true
+      },
+      {
+        "id": "fundsOrigin",
+        "kind": "radio",
+        "label": "Mittelherkunft",
+        "required": true,
+        "options": [
+          {
+            "value": "salary",
+            "label": "Gehalt / Honorare"
+          },
+          {
+            "value": "business",
+            "label": "Geschäftstätigkeit"
+          },
+          {
+            "value": "investment",
+            "label": "Anlagen / passives Einkommen"
+          },
+          {
+            "value": "inheritance",
+            "label": "Erbschaft oder Schenkung"
+          },
+          {
+            "value": "other",
+            "label": "Sonstige (unten beschreiben)"
+          }
+        ]
+      },
+      {
+        "id": "fundsOriginDetail",
+        "kind": "textarea",
+        "label": "Details zur Mittelherkunft",
+        "helpText": "Ergänzen Sie die obige Auswahl. Nexa fordert Belege im formellen KYC-Prozess an."
+      },
+      {
+        "id": "pep",
+        "kind": "radio",
+        "label": "Sind Sie eine politisch exponierte Person (PEP) oder direktes Familienmitglied einer PEP?",
+        "required": true,
+        "options": [
+          {
+            "value": "no",
+            "label": "Nein"
+          },
+          {
+            "value": "yes",
+            "label": "Ja"
+          }
+        ]
+      },
+      {
+        "id": "truthfulDeclaration",
+        "kind": "checkbox",
+        "label": "Ich erkläre eidesstattlich, dass die Angaben wahrheitsgemäß sind, und autorisiere Nexa Paraguay, die erforderlichen Überprüfungen durchzuführen.",
+        "required": true
+      }
     ]
   },
   "whatsapp": {

--- a/sites/nexa-paraguay/content/de.json
+++ b/sites/nexa-paraguay/content/de.json
@@ -621,19 +621,23 @@
       "members": [
         {
           "name": "Leitung Operations (Paraguay)",
-          "role": "Operatives Leadership, institutionelle Beziehungen"
+          "role": "Operatives Leadership, institutionelle Beziehungen",
+          "icon": "Briefcase"
         },
         {
           "name": "Leitung Commercial (Europa)",
-          "role": "Kundengewinnung, kulturelle Brücke"
+          "role": "Kundengewinnung, kulturelle Brücke",
+          "icon": "Globe"
         },
         {
           "name": "Juristisches Team",
-          "role": "Migrationsakten, Gesellschaftsgründung"
+          "role": "Migrationsakten, Gesellschaftsgründung",
+          "icon": "Scale"
         },
         {
           "name": "Steuerteam",
-          "role": "Steuerliches Management, Compliance"
+          "role": "Steuerliches Management, Compliance",
+          "icon": "Calculator"
         }
       ]
     },

--- a/sites/nexa-paraguay/content/en.json
+++ b/sites/nexa-paraguay/content/en.json
@@ -587,19 +587,23 @@
       "members": [
         {
           "name": "Operations Director (Paraguay)",
-          "role": "Operational leadership, institutional relationships"
+          "role": "Operational leadership, institutional relationships",
+          "icon": "Briefcase"
         },
         {
           "name": "Commercial Director (Europe)",
-          "role": "Client acquisition, cultural bridge"
+          "role": "Client acquisition, cultural bridge",
+          "icon": "Globe"
         },
         {
           "name": "Legal team",
-          "role": "Immigration files, company incorporation"
+          "role": "Immigration files, company incorporation",
+          "icon": "Scale"
         },
         {
           "name": "Accounting team",
-          "role": "Tax management, compliance"
+          "role": "Tax management, compliance",
+          "icon": "Calculator"
         }
       ]
     },

--- a/sites/nexa-paraguay/content/en.json
+++ b/sites/nexa-paraguay/content/en.json
@@ -113,7 +113,7 @@
           "name": "Paraguay Business",
           "description": "Residency + company + bank account.",
           "price": "USD 4,400+",
-          "priceNote": "LEALTIS base cost. Final Nexa price TBD.",
+          "priceNote": "Starting price. Final quote depends on case requirements.",
           "badge": "Most chosen",
           "highlighted": true,
           "included": [
@@ -132,7 +132,7 @@
           "name": "Paraguay Investor Program",
           "description": "Everything in Business + 12-month support.",
           "price": "USD 6,900+",
-          "priceNote": "LEALTIS base cost. Final Nexa price TBD.",
+          "priceNote": "Starting price. Final quote depends on case requirements.",
           "included": [
             "Everything in Business",
             "Accounting (12 months)",
@@ -156,7 +156,7 @@
             "Negotiation and notarization",
             "Land registry inscription"
           ],
-          "ctaLabel": "Exploratory call",
+          "ctaLabel": "Inquire",
           "ctaHref": "/s/en/nexa-paraguay/contacto?programa=tierras"
         }
       ]
@@ -270,7 +270,7 @@
           "name": "Paraguay Base",
           "description": "Residency and Paraguayan ID card.",
           "price": "To be defined",
-          "priceNote": "Wholesale cost pending from LEALTIS + Nexa margin",
+          "priceNote": "Starting price. Final quote depends on case requirements.",
           "included": [
             "Paraguayan Residency",
             "ID Card",
@@ -286,7 +286,7 @@
           "name": "Paraguay Business",
           "description": "Residency + company + bank account.",
           "price": "USD 4,400+",
-          "priceNote": "Base LEALTIS cost. Final Nexa price to be defined.",
+          "priceNote": "Starting price. Final quote depends on case requirements.",
           "highlighted": true,
           "badge": "Most chosen",
           "included": [
@@ -305,7 +305,7 @@
           "name": "Paraguay Investor Program",
           "description": "Everything in Business + 12 months of support.",
           "price": "USD 6,900+",
-          "priceNote": "Base LEALTIS cost. Final Nexa price to be defined.",
+          "priceNote": "Starting price. Final quote depends on case requirements.",
           "included": [
             "Everything in Business",
             "Corporate accounting (12 months)",
@@ -735,7 +735,9 @@
       "subtitle": "Pick a time that works for you.",
       "bookingUrl": "https://calendly.com/nexaparaguay/consulta",
       "provider": "calendly",
-      "ctaLabel": "Open calendar"
+      "ctaLabel": "Open calendar",
+      "fallbackWhatsapp": "595982515138",
+      "fallbackEmail": "hola@nexaparaguay.com"
     },
     "contact": {
       "title": "Or write to us directly",
@@ -813,6 +815,22 @@
       {
         "label": "Privacy",
         "href": "/s/en/nexa-paraguay/privacidad"
+      },
+      {
+        "label": "FAQ",
+        "href": "/s/en/nexa-paraguay/faq"
+      },
+      {
+        "label": "Blog",
+        "href": "/s/en/nexa-paraguay/blog"
+      },
+      {
+        "label": "Contact",
+        "href": "/s/en/nexa-paraguay/contacto"
+      },
+      {
+        "label": "Why Paraguay",
+        "href": "/s/en/nexa-paraguay/por-que-paraguay"
       }
     ]
   },
@@ -823,7 +841,10 @@
       "Results depend on individual compliance with requirements and may vary. Information subject to regulatory change."
     ],
     "licenseNumbers": [
-      { "label": "SEPRELAD", "number": "Pending registration" }
+      {
+        "label": "SEPRELAD",
+        "number": "Pending registration"
+      }
     ],
     "linkText": "Read full AML disclosure",
     "linkHref": "/s/en/nexa-paraguay/privacidad#aml"
@@ -836,27 +857,101 @@
     "whatsappPhone": "595982515138",
     "whatsappFallbackLabel": "Questions? Reach us on WhatsApp",
     "questions": [
-      { "id": "fullName", "kind": "text", "label": "Full legal name (as on ID)", "required": true },
-      { "id": "nationality", "kind": "text", "label": "Nationality", "required": true },
-      { "id": "documentType", "kind": "radio", "label": "Document type", "required": true, "options": [
-        { "value": "passport", "label": "Passport" },
-        { "value": "id", "label": "National ID" },
-        { "value": "other", "label": "Other" }
-      ]},
-      { "id": "economicActivity", "kind": "textarea", "label": "Primary economic activity", "helpText": "Describe your profession or main source of income", "required": true },
-      { "id": "fundsOrigin", "kind": "radio", "label": "Source of funds", "required": true, "options": [
-        { "value": "salary", "label": "Salary / professional fees" },
-        { "value": "business", "label": "Business activity" },
-        { "value": "investment", "label": "Investments / passive income" },
-        { "value": "inheritance", "label": "Inheritance or gift" },
-        { "value": "other", "label": "Other (describe below)" }
-      ]},
-      { "id": "fundsOriginDetail", "kind": "textarea", "label": "Details on source of funds", "helpText": "Expand on the selection above. Nexa will request supporting documents during formal KYC." },
-      { "id": "pep", "kind": "radio", "label": "Are you a Politically Exposed Person (PEP) or a direct family member of one?", "required": true, "options": [
-        { "value": "no", "label": "No" },
-        { "value": "yes", "label": "Yes" }
-      ]},
-      { "id": "truthfulDeclaration", "kind": "checkbox", "label": "I declare under oath that the information is true and authorise Nexa Paraguay to perform the necessary verifications.", "required": true }
+      {
+        "id": "fullName",
+        "kind": "text",
+        "label": "Full legal name (as on ID)",
+        "required": true
+      },
+      {
+        "id": "nationality",
+        "kind": "text",
+        "label": "Nationality",
+        "required": true
+      },
+      {
+        "id": "documentType",
+        "kind": "radio",
+        "label": "Document type",
+        "required": true,
+        "options": [
+          {
+            "value": "passport",
+            "label": "Passport"
+          },
+          {
+            "value": "id",
+            "label": "National ID"
+          },
+          {
+            "value": "other",
+            "label": "Other"
+          }
+        ]
+      },
+      {
+        "id": "economicActivity",
+        "kind": "textarea",
+        "label": "Primary economic activity",
+        "helpText": "Describe your profession or main source of income",
+        "required": true
+      },
+      {
+        "id": "fundsOrigin",
+        "kind": "radio",
+        "label": "Source of funds",
+        "required": true,
+        "options": [
+          {
+            "value": "salary",
+            "label": "Salary / professional fees"
+          },
+          {
+            "value": "business",
+            "label": "Business activity"
+          },
+          {
+            "value": "investment",
+            "label": "Investments / passive income"
+          },
+          {
+            "value": "inheritance",
+            "label": "Inheritance or gift"
+          },
+          {
+            "value": "other",
+            "label": "Other (describe below)"
+          }
+        ]
+      },
+      {
+        "id": "fundsOriginDetail",
+        "kind": "textarea",
+        "label": "Details on source of funds",
+        "helpText": "Expand on the selection above. Nexa will request supporting documents during formal KYC."
+      },
+      {
+        "id": "pep",
+        "kind": "radio",
+        "label": "Are you a Politically Exposed Person (PEP) or a direct family member of one?",
+        "required": true,
+        "options": [
+          {
+            "value": "no",
+            "label": "No"
+          },
+          {
+            "value": "yes",
+            "label": "Yes"
+          }
+        ]
+      },
+      {
+        "id": "truthfulDeclaration",
+        "kind": "checkbox",
+        "label": "I declare under oath that the information is true and authorise Nexa Paraguay to perform the necessary verifications.",
+        "required": true
+      }
     ]
   },
   "whatsapp": {

--- a/sites/nexa-paraguay/content/es.json
+++ b/sites/nexa-paraguay/content/es.json
@@ -148,11 +148,11 @@
           "name": "Compra de Tierras",
           "description": "Servicio propio de Nexa. Asesoría integral.",
           "price": "Desde USD 3.500",
-          "priceNote": "Según alcance de búsqueda y due diligence.",
+          "priceNote": "Según alcance de búsqueda y auditoría legal.",
           "included": [
             "Definición de perfil y criterios",
             "Búsqueda y short-list",
-            "Due diligence legal y técnica",
+            "Auditoría legal y técnica",
             "Negociación y escrituración",
             "Inscripción registral"
           ],
@@ -321,11 +321,11 @@
           "name": "Compra de Tierras",
           "description": "Servicio propio de Nexa. Asesoría integral.",
           "price": "Desde USD 3.500",
-          "priceNote": "Según alcance de búsqueda y due diligence.",
+          "priceNote": "Según alcance de búsqueda y auditoría legal.",
           "included": [
             "Definición de perfil y criterios",
             "Búsqueda y short-list",
-            "Due diligence legal y técnica",
+            "Auditoría legal y técnica",
             "Negociación y escrituración",
             "Inscripción registral"
           ],
@@ -447,15 +447,15 @@
       "items": [
         {
           "q": "¿Qué incluye el precio?",
-          "a": "Honorarios profesionales, IVA, tasas oficiales, coordinación bancaria y asesoramiento integral."
+          "a": "Honorarios profesionales de nuestro equipo multidisciplinario (legal, contable, notarial), IVA, tasas oficiales de Migraciones y del Registro Público, coordinación bancaria, tour estratégico inmobiliario y asesoramiento integral durante todo el trámite. No hay cargos adicionales en el proceso regular."
         },
         {
           "q": "¿Qué no está incluido?",
-          "a": "Vuelos, alojamiento, apostillas en país de origen, gastos personales."
+          "a": "Vuelos internacionales, alojamiento en Asunción, gastos personales, traducciones juradas y apostillas de documentos en su país de origen. Si requiere servicios adicionales —por ejemplo tramitación de título de conducir paraguayo, apoyo en búsqueda de vivienda definitiva, o consultas fiscales fuera del alcance del programa contratado— se cotizan por separado y siempre con presupuesto previo."
         },
         {
           "q": "¿Cómo se paga?",
-          "a": "Anticipado por transferencia. Sin cargos adicionales en el trámite regular."
+          "a": "Pago anticipado por transferencia bancaria internacional. Aceptamos USD o EUR. Sin cargos ocultos ni adicionales durante el trámite regular. Emitimos factura formal desde nuestra entidad paraguaya al momento del pago."
         }
       ]
     },
@@ -651,19 +651,23 @@
       "members": [
         {
           "name": "Dirección de Operaciones (Paraguay)",
-          "role": "Liderazgo operativo, relaciones institucionales"
+          "role": "Liderazgo operativo, relaciones institucionales",
+          "icon": "Briefcase"
         },
         {
           "name": "Dirección Comercial (Europa)",
-          "role": "Adquisición de clientes, puente cultural"
+          "role": "Adquisición de clientes, puente cultural",
+          "icon": "Globe"
         },
         {
           "name": "Equipo Legal",
-          "role": "Expedientes migratorios, constitución societaria"
+          "role": "Expedientes migratorios, constitución societaria",
+          "icon": "Scale"
         },
         {
           "name": "Equipo Contable",
-          "role": "Gestión fiscal, cumplimiento tributario"
+          "role": "Gestión fiscal, cumplimiento tributario",
+          "icon": "Calculator"
         }
       ]
     },

--- a/sites/nexa-paraguay/content/es.json
+++ b/sites/nexa-paraguay/content/es.json
@@ -113,7 +113,7 @@
           "name": "Paraguay Business",
           "description": "Residencia + sociedad + cuenta bancaria.",
           "price": "USD 4.400+",
-          "priceNote": "Costo base LEALTIS. Precio final Nexa pendiente de definir.",
+          "priceNote": "Precio desde. Cotización final según requisitos del caso.",
           "badge": "Más elegido",
           "highlighted": true,
           "included": [
@@ -132,7 +132,7 @@
           "name": "Paraguay Investor Program",
           "description": "Todo lo de Business + 12 meses de acompañamiento.",
           "price": "USD 6.900+",
-          "priceNote": "Costo base LEALTIS. Precio final Nexa pendiente de definir.",
+          "priceNote": "Precio desde. Cotización final según requisitos del caso.",
           "included": [
             "Todo lo de Business",
             "Contabilidad empresarial (12 meses)",
@@ -156,7 +156,7 @@
             "Negociación y escrituración",
             "Inscripción registral"
           ],
-          "ctaLabel": "Conversación exploratoria",
+          "ctaLabel": "Consultar",
           "ctaHref": "/s/es/nexa-paraguay/contacto?programa=tierras"
         }
       ]
@@ -286,7 +286,7 @@
           "name": "Paraguay Business",
           "description": "Residencia + sociedad + cuenta bancaria.",
           "price": "USD 4.400+",
-          "priceNote": "Costo base LEALTIS. Precio final Nexa pendiente de definir.",
+          "priceNote": "Precio desde. Cotización final según requisitos del caso.",
           "badge": "Más elegido",
           "highlighted": true,
           "included": [
@@ -305,7 +305,7 @@
           "name": "Paraguay Investor Program",
           "description": "Todo lo de Business + 12 meses de acompañamiento.",
           "price": "USD 6.900+",
-          "priceNote": "Costo base LEALTIS. Precio final Nexa pendiente de definir.",
+          "priceNote": "Precio desde. Cotización final según requisitos del caso.",
           "included": [
             "Todo lo de Business",
             "Contabilidad empresarial (12 meses)",
@@ -329,7 +329,7 @@
             "Negociación y escrituración",
             "Inscripción registral"
           ],
-          "ctaLabel": "Conversación exploratoria",
+          "ctaLabel": "Consultar",
           "ctaHref": "/s/es/nexa-paraguay/contacto?programa=tierras"
         }
       ]
@@ -432,12 +432,12 @@
           ]
         },
         {
-          "feature": "Costo LEALTIS (USD)",
+          "feature": "Precio desde (USD)",
           "values": [
-            "Pendiente",
+            "A definir",
             "4.400",
             "6.900",
-            "No aplica"
+            "3.500"
           ]
         }
       ]
@@ -799,7 +799,9 @@
       "subtitle": "Elija el horario que mejor le convenga.",
       "bookingUrl": "https://calendly.com/nexaparaguay/consulta",
       "provider": "calendly",
-      "ctaLabel": "Abrir calendario"
+      "ctaLabel": "Abrir calendario",
+      "fallbackWhatsapp": "595982515138",
+      "fallbackEmail": "hola@nexaparaguay.com"
     },
     "contact": {
       "title": "O escríbanos directamente",
@@ -878,6 +880,22 @@
       {
         "label": "Privacidad",
         "href": "/s/es/nexa-paraguay/privacidad"
+      },
+      {
+        "label": "FAQ",
+        "href": "/s/es/nexa-paraguay/faq"
+      },
+      {
+        "label": "Blog",
+        "href": "/s/es/nexa-paraguay/blog"
+      },
+      {
+        "label": "Contacto",
+        "href": "/s/es/nexa-paraguay/contacto"
+      },
+      {
+        "label": "Por qué Paraguay",
+        "href": "/s/es/nexa-paraguay/por-que-paraguay"
       }
     ]
   },
@@ -888,7 +906,10 @@
       "Los resultados dependen del cumplimiento individual de requisitos y pueden variar. Información sujeta a cambios regulatorios."
     ],
     "licenseNumbers": [
-      { "label": "SEPRELAD", "number": "Pendiente de asignación" }
+      {
+        "label": "SEPRELAD",
+        "number": "Pendiente de asignación"
+      }
     ],
     "linkText": "Ver declaración AML completa",
     "linkHref": "/s/es/nexa-paraguay/privacidad#aml"
@@ -919,9 +940,18 @@
         "label": "Tipo de documento",
         "required": true,
         "options": [
-          { "value": "passport", "label": "Pasaporte" },
-          { "value": "id", "label": "Documento nacional" },
-          { "value": "other", "label": "Otro" }
+          {
+            "value": "passport",
+            "label": "Pasaporte"
+          },
+          {
+            "value": "id",
+            "label": "Documento nacional"
+          },
+          {
+            "value": "other",
+            "label": "Otro"
+          }
         ]
       },
       {
@@ -937,11 +967,26 @@
         "label": "Origen de los fondos",
         "required": true,
         "options": [
-          { "value": "salary", "label": "Salario / honorarios profesionales" },
-          { "value": "business", "label": "Actividad empresarial" },
-          { "value": "investment", "label": "Inversiones / rentas" },
-          { "value": "inheritance", "label": "Herencia o donación" },
-          { "value": "other", "label": "Otro (describir abajo)" }
+          {
+            "value": "salary",
+            "label": "Salario / honorarios profesionales"
+          },
+          {
+            "value": "business",
+            "label": "Actividad empresarial"
+          },
+          {
+            "value": "investment",
+            "label": "Inversiones / rentas"
+          },
+          {
+            "value": "inheritance",
+            "label": "Herencia o donación"
+          },
+          {
+            "value": "other",
+            "label": "Otro (describir abajo)"
+          }
         ]
       },
       {
@@ -956,8 +1001,14 @@
         "label": "¿Sos Persona Expuesta Políticamente (PEP) o familiar directo de una PEP?",
         "required": true,
         "options": [
-          { "value": "no", "label": "No" },
-          { "value": "yes", "label": "Sí" }
+          {
+            "value": "no",
+            "label": "No"
+          },
+          {
+            "value": "yes",
+            "label": "Sí"
+          }
         ]
       },
       {

--- a/sites/nexa-paraguay/content/nl.json
+++ b/sites/nexa-paraguay/content/nl.json
@@ -618,19 +618,23 @@
       "members": [
         {
           "name": "Operationele directie (Paraguay)",
-          "role": "Operationeel leiderschap, institutionele relaties"
+          "role": "Operationeel leiderschap, institutionele relaties",
+          "icon": "Briefcase"
         },
         {
           "name": "Commerciële directie (Europa)",
-          "role": "Klantacquisitie, culturele brug"
+          "role": "Klantacquisitie, culturele brug",
+          "icon": "Globe"
         },
         {
           "name": "Juridisch team",
-          "role": "Migratiedossiers, oprichting vennootschap"
+          "role": "Migratiedossiers, oprichting vennootschap",
+          "icon": "Scale"
         },
         {
           "name": "Boekhoudteam",
-          "role": "Fiscaal beheer, compliance"
+          "role": "Fiscaal beheer, compliance",
+          "icon": "Calculator"
         }
       ]
     },

--- a/sites/nexa-paraguay/content/nl.json
+++ b/sites/nexa-paraguay/content/nl.json
@@ -113,7 +113,7 @@
           "name": "Paraguay Business",
           "description": "Verblijfsvergunning + vennootschap + bankrekening.",
           "price": "USD 4.400+",
-          "priceNote": "LEALTIS-basisprijs. Definitieve Nexa-prijs nog te bepalen.",
+          "priceNote": "Vanaf-prijs. Definitieve offerte afhankelijk van de vereisten.",
           "badge": "Meest gekozen",
           "highlighted": true,
           "included": [
@@ -132,7 +132,7 @@
           "name": "Paraguay Investor Program",
           "description": "Alles van Business + 12 maanden begeleiding.",
           "price": "USD 6.900+",
-          "priceNote": "LEALTIS-basisprijs. Definitieve Nexa-prijs nog te bepalen.",
+          "priceNote": "Vanaf-prijs. Definitieve offerte afhankelijk van de vereisten.",
           "included": [
             "Alles van Business",
             "Boekhouding (12 maanden)",
@@ -156,7 +156,7 @@
             "Onderhandeling en notariële akte",
             "Registratie in het kadaster"
           ],
-          "ctaLabel": "Verkennend gesprek",
+          "ctaLabel": "Informeer",
           "ctaHref": "/s/nl/nexa-paraguay/contacto?programa=tierras"
         }
       ]
@@ -286,7 +286,7 @@
           "name": "Paraguay Business",
           "description": "Verblijfsvergunning + vennootschap + bankrekening.",
           "price": "USD 4.400+",
-          "priceNote": "LEALTIS-basisprijs. Definitieve Nexa-prijs nog te bepalen.",
+          "priceNote": "Vanaf-prijs. Definitieve offerte afhankelijk van de vereisten.",
           "badge": "Meest gekozen",
           "highlighted": true,
           "included": [
@@ -305,7 +305,7 @@
           "name": "Paraguay Investor Program",
           "description": "Alles van Business + 12 maanden begeleiding.",
           "price": "USD 6.900+",
-          "priceNote": "LEALTIS-basisprijs. Definitieve Nexa-prijs nog te bepalen.",
+          "priceNote": "Vanaf-prijs. Definitieve offerte afhankelijk van de vereisten.",
           "included": [
             "Alles van Business",
             "Boekhouding (12 maanden)",
@@ -329,7 +329,7 @@
             "Onderhandeling en notariële akte",
             "Registratie in het kadaster"
           ],
-          "ctaLabel": "Verkennend gesprek",
+          "ctaLabel": "Informeer",
           "ctaHref": "/s/nl/nexa-paraguay/contacto?programa=tierras"
         }
       ]
@@ -360,7 +360,7 @@
           "name": "Paraguay Business",
           "description": "Verblijfsvergunning + vennootschap + bankrekening.",
           "price": "USD 4.400+",
-          "priceNote": "LEALTIS-basisprijs. Definitieve Nexa-prijs nog te bepalen.",
+          "priceNote": "Vanaf-prijs. Definitieve offerte afhankelijk van de vereisten.",
           "badge": "Meest gekozen",
           "highlighted": true,
           "included": [
@@ -379,7 +379,7 @@
           "name": "Paraguay Investor Program",
           "description": "Alles van Business + 12 maanden begeleiding.",
           "price": "USD 6.900+",
-          "priceNote": "LEALTIS-basisprijs. Definitieve Nexa-prijs nog te bepalen.",
+          "priceNote": "Vanaf-prijs. Definitieve offerte afhankelijk van de vereisten.",
           "included": [
             "Alles van Business",
             "Boekhouding (12 maanden)",
@@ -403,7 +403,7 @@
             "Onderhandeling en notariële akte",
             "Registratie in het kadaster"
           ],
-          "ctaLabel": "Verkennend gesprek",
+          "ctaLabel": "Informeer",
           "ctaHref": "/s/nl/nexa-paraguay/contacto?programa=tierras"
         }
       ]
@@ -766,7 +766,9 @@
       "subtitle": "Kies een moment dat u schikt.",
       "bookingUrl": "https://calendly.com/nexaparaguay/consulta",
       "provider": "calendly",
-      "ctaLabel": "Open agenda"
+      "ctaLabel": "Open agenda",
+      "fallbackWhatsapp": "595982515138",
+      "fallbackEmail": "hola@nexaparaguay.com"
     },
     "contact": {
       "title": "Of mail ons direct",
@@ -844,6 +846,22 @@
       {
         "label": "Privacy",
         "href": "/s/nl/nexa-paraguay/privacidad"
+      },
+      {
+        "label": "FAQ",
+        "href": "/s/nl/nexa-paraguay/faq"
+      },
+      {
+        "label": "Blog",
+        "href": "/s/nl/nexa-paraguay/blog"
+      },
+      {
+        "label": "Contact",
+        "href": "/s/nl/nexa-paraguay/contacto"
+      },
+      {
+        "label": "Waarom Paraguay",
+        "href": "/s/nl/nexa-paraguay/por-que-paraguay"
       }
     ]
   },
@@ -854,7 +872,10 @@
       "Resultaten zijn afhankelijk van de individuele naleving van vereisten en kunnen variëren. Informatie onder voorbehoud van wijzigingen in regelgeving."
     ],
     "licenseNumbers": [
-      { "label": "SEPRELAD", "number": "Registratie in behandeling" }
+      {
+        "label": "SEPRELAD",
+        "number": "Registratie in behandeling"
+      }
     ],
     "linkText": "Volledige AML-verklaring bekijken",
     "linkHref": "/s/nl/nexa-paraguay/privacidad#aml"
@@ -867,27 +888,101 @@
     "whatsappPhone": "595982515138",
     "whatsappFallbackLabel": "Vragen? Neem contact op via WhatsApp",
     "questions": [
-      { "id": "fullName", "kind": "text", "label": "Volledige naam (volgens identiteitsbewijs)", "required": true },
-      { "id": "nationality", "kind": "text", "label": "Nationaliteit", "required": true },
-      { "id": "documentType", "kind": "radio", "label": "Type identiteitsbewijs", "required": true, "options": [
-        { "value": "passport", "label": "Paspoort" },
-        { "value": "id", "label": "Nationale ID" },
-        { "value": "other", "label": "Andere" }
-      ]},
-      { "id": "economicActivity", "kind": "textarea", "label": "Belangrijkste beroepsactiviteit", "helpText": "Beschrijf uw beroep of belangrijkste inkomstenbron", "required": true },
-      { "id": "fundsOrigin", "kind": "radio", "label": "Herkomst van middelen", "required": true, "options": [
-        { "value": "salary", "label": "Salaris / honoraria" },
-        { "value": "business", "label": "Ondernemingsactiviteit" },
-        { "value": "investment", "label": "Beleggingen / passief inkomen" },
-        { "value": "inheritance", "label": "Erfenis of schenking" },
-        { "value": "other", "label": "Anders (hieronder beschrijven)" }
-      ]},
-      { "id": "fundsOriginDetail", "kind": "textarea", "label": "Details herkomst van middelen", "helpText": "Licht de bovenstaande keuze toe. Nexa vraagt bewijsstukken op in het formele KYC-traject." },
-      { "id": "pep", "kind": "radio", "label": "Bent u een politiek prominent persoon (PEP) of direct familielid van een PEP?", "required": true, "options": [
-        { "value": "no", "label": "Nee" },
-        { "value": "yes", "label": "Ja" }
-      ]},
-      { "id": "truthfulDeclaration", "kind": "checkbox", "label": "Ik verklaar onder ede dat de informatie waar is en autoriseer Nexa Paraguay om de nodige verificaties uit te voeren.", "required": true }
+      {
+        "id": "fullName",
+        "kind": "text",
+        "label": "Volledige naam (volgens identiteitsbewijs)",
+        "required": true
+      },
+      {
+        "id": "nationality",
+        "kind": "text",
+        "label": "Nationaliteit",
+        "required": true
+      },
+      {
+        "id": "documentType",
+        "kind": "radio",
+        "label": "Type identiteitsbewijs",
+        "required": true,
+        "options": [
+          {
+            "value": "passport",
+            "label": "Paspoort"
+          },
+          {
+            "value": "id",
+            "label": "Nationale ID"
+          },
+          {
+            "value": "other",
+            "label": "Andere"
+          }
+        ]
+      },
+      {
+        "id": "economicActivity",
+        "kind": "textarea",
+        "label": "Belangrijkste beroepsactiviteit",
+        "helpText": "Beschrijf uw beroep of belangrijkste inkomstenbron",
+        "required": true
+      },
+      {
+        "id": "fundsOrigin",
+        "kind": "radio",
+        "label": "Herkomst van middelen",
+        "required": true,
+        "options": [
+          {
+            "value": "salary",
+            "label": "Salaris / honoraria"
+          },
+          {
+            "value": "business",
+            "label": "Ondernemingsactiviteit"
+          },
+          {
+            "value": "investment",
+            "label": "Beleggingen / passief inkomen"
+          },
+          {
+            "value": "inheritance",
+            "label": "Erfenis of schenking"
+          },
+          {
+            "value": "other",
+            "label": "Anders (hieronder beschrijven)"
+          }
+        ]
+      },
+      {
+        "id": "fundsOriginDetail",
+        "kind": "textarea",
+        "label": "Details herkomst van middelen",
+        "helpText": "Licht de bovenstaande keuze toe. Nexa vraagt bewijsstukken op in het formele KYC-traject."
+      },
+      {
+        "id": "pep",
+        "kind": "radio",
+        "label": "Bent u een politiek prominent persoon (PEP) of direct familielid van een PEP?",
+        "required": true,
+        "options": [
+          {
+            "value": "no",
+            "label": "Nee"
+          },
+          {
+            "value": "yes",
+            "label": "Ja"
+          }
+        ]
+      },
+      {
+        "id": "truthfulDeclaration",
+        "kind": "checkbox",
+        "label": "Ik verklaar onder ede dat de informatie waar is en autoriseer Nexa Paraguay om de nodige verificaties uit te voeren.",
+        "required": true
+      }
     ]
   },
   "whatsapp": {

--- a/web/app/api/booking/availability/route.ts
+++ b/web/app/api/booking/availability/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { logger } from '@/lib/logger'
 
 export async function GET(request: NextRequest) {
   try {
@@ -25,16 +26,16 @@ export async function GET(request: NextRequest) {
     })
     
     if (error) {
-      console.error('Error fetching availability:', error)
+      logger.error('booking/availability: rpc failed', { error: String(error) })
       return NextResponse.json(
         { error: 'Failed to fetch availability' },
         { status: 500 }
       )
     }
-    
+
     return NextResponse.json({ slots })
   } catch (error) {
-    console.error('Error in availability API:', error)
+    logger.error('booking/availability: unexpected', { error: error instanceof Error ? error.message : String(error) })
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/web/components/consent/cookie-banner.tsx
+++ b/web/components/consent/cookie-banner.tsx
@@ -57,11 +57,11 @@ export function CookieBanner({ copy }: { copy: CookieBannerCopy }) {
     <div
       role="region"
       aria-label={copy.title}
-      className="fixed bottom-4 left-4 right-4 z-[60] mx-auto max-w-3xl rounded-lg bg-[var(--surface)] p-5 shadow-card-hover md:bottom-6 md:left-6 md:right-6"
+      className="fixed bottom-3 left-3 z-[60] w-[min(22rem,calc(100vw-1.5rem))] rounded-lg bg-[var(--surface)] p-4 shadow-card-hover md:bottom-4 md:left-4"
       style={{ border: '1px solid var(--border)' }}
     >
       <p className="mb-1 text-sm font-semibold text-[var(--text)]">{copy.title}</p>
-      <p className="mb-4 text-sm text-[var(--text-light)]">
+      <p className="mb-3 text-xs leading-relaxed text-[var(--text-light)]">
         {copy.body}{' '}
         <a href={copy.privacyHref} className="underline">
           {copy.privacyLabel}
@@ -72,14 +72,14 @@ export function CookieBanner({ copy }: { copy: CookieBannerCopy }) {
         <button
           type="button"
           onClick={acceptAll}
-          className="rounded-md bg-[var(--secondary)] px-4 py-2 text-sm font-medium text-[var(--secondary-foreground)] shadow-button"
+          className="rounded-md bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--secondary-foreground)] shadow-button"
         >
           {copy.acceptAll}
         </button>
         <button
           type="button"
           onClick={acceptEssential}
-          className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-4 py-2 text-sm font-medium text-[var(--text)]"
+          className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-1.5 text-xs font-medium text-[var(--text)]"
         >
           {copy.acceptEssential}
         </button>

--- a/web/components/sections/age-gate-section.tsx
+++ b/web/components/sections/age-gate-section.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useSyncExternalStore } from 'react'
+import { Heading } from '@/components/ui/heading'
 
 export interface AgeGateSectionProps {
   title?: string
@@ -90,9 +91,9 @@ export function AgeGateSection({
       className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 px-4"
     >
       <div className="max-w-md rounded-lg bg-[color:var(--surface,#fff)] p-6 text-center shadow-xl">
-        <h2 id="agegate-title" className="mb-2 text-xl font-bold text-[color:var(--text,#111)]">
+        <Heading level={2} id="agegate-title" className="mb-2 text-xl font-bold text-[color:var(--text,#111)]">
           {title}
-        </h2>
+        </Heading>
         <p id="agegate-message" className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">
           {resolvedMessage}
         </p>

--- a/web/components/sections/booking-embed-section.tsx
+++ b/web/components/sections/booking-embed-section.tsx
@@ -8,9 +8,70 @@ export interface BookingEmbedSectionProps {
   variant?: BookingEmbedVariant
   title?: string
   subtitle?: string
-  bookingUrl: string
+  bookingUrl?: string
   provider?: string
   ctaLabel?: string
+  /** Contact fallback when booking is not yet configured. */
+  fallbackWhatsapp?: string
+  fallbackEmail?: string
+  /** Active URL locale — picks localized default labels. */
+  __locale?: string
+}
+
+type BookingLabels = {
+  unavailableTitle: string
+  unavailableBody: string
+  whatsappCta: string
+  emailCta: string
+}
+
+const BOOKING_LABELS: Record<string, BookingLabels> = {
+  de: {
+    unavailableTitle: 'Online-Buchung demnächst verfügbar',
+    unavailableBody: 'Bis dahin erreichen Sie uns direkt über WhatsApp oder E-Mail — wir antworten innerhalb eines Werktages.',
+    whatsappCta: 'Über WhatsApp schreiben',
+    emailCta: 'E-Mail senden',
+  },
+  en: {
+    unavailableTitle: 'Online booking coming soon',
+    unavailableBody: 'Reach us directly via WhatsApp or email in the meantime — we reply within one business day.',
+    whatsappCta: 'Message on WhatsApp',
+    emailCta: 'Send email',
+  },
+  es: {
+    unavailableTitle: 'Reservas en línea próximamente',
+    unavailableBody: 'Mientras tanto, contáctenos directamente por WhatsApp o email — respondemos dentro de un día hábil.',
+    whatsappCta: 'Escribir por WhatsApp',
+    emailCta: 'Enviar email',
+  },
+  nl: {
+    unavailableTitle: 'Online afspraken binnenkort beschikbaar',
+    unavailableBody: 'Neem in de tussentijd rechtstreeks contact op via WhatsApp of e-mail — we reageren binnen één werkdag.',
+    whatsappCta: 'Bericht via WhatsApp',
+    emailCta: 'E-mail sturen',
+  },
+  pt: {
+    unavailableTitle: 'Agendamento online em breve',
+    unavailableBody: 'Entretanto, fale conosco diretamente por WhatsApp ou email — respondemos em até um dia útil.',
+    whatsappCta: 'Mensagem no WhatsApp',
+    emailCta: 'Enviar email',
+  },
+}
+
+/**
+ * Treat a booking URL as "not yet configured" when it's missing or still
+ * pointing at the documented placeholder account. Calendly renders a 404
+ * page inside the iframe for non-existent accounts, leaving a huge blank
+ * white block — the fallback UI is a better experience.
+ */
+function isPlaceholderUrl(url: string | undefined): boolean {
+  if (!url || url.trim() === '' || url === '#') return true
+  const placeholders = [
+    'calendly.com/nexaparaguay/consulta', // documented placeholder in LAUNCH.md
+    'calendly.com/your-account',
+    'example.com',
+  ]
+  return placeholders.some((p) => url.includes(p))
 }
 
 export function BookingEmbedSection({
@@ -20,7 +81,13 @@ export function BookingEmbedSection({
   bookingUrl,
   provider = 'calendly',
   ctaLabel = 'Schedule a consultation',
+  fallbackWhatsapp,
+  fallbackEmail,
+  __locale,
 }: BookingEmbedSectionProps) {
+  const L = BOOKING_LABELS[__locale ?? 'es'] || BOOKING_LABELS.es
+  const unavailable = isPlaceholderUrl(bookingUrl)
+
   return (
     <section id="agendar" className="bg-[var(--background)] py-16 sm:py-20">
       <Container>
@@ -34,7 +101,34 @@ export function BookingEmbedSection({
         )}
 
         <div className="mt-10 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-card">
-          {variant === 'iframe' ? (
+          {unavailable ? (
+            <div className="p-10 text-center">
+              <Heading level={3} className="mb-3 text-xl font-semibold text-[var(--primary)]">
+                {L.unavailableTitle}
+              </Heading>
+              <p className="mx-auto mb-6 max-w-md text-[var(--text-light)]">{L.unavailableBody}</p>
+              <div className="flex flex-wrap items-center justify-center gap-3">
+                {fallbackWhatsapp && (
+                  <a
+                    href={`https://wa.me/${fallbackWhatsapp.replace(/\D/g, '')}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 rounded-md bg-[#25D366] px-5 py-2.5 text-sm font-medium text-white shadow-sm hover:opacity-90"
+                  >
+                    {L.whatsappCta}
+                  </a>
+                )}
+                {fallbackEmail && (
+                  <a
+                    href={`mailto:${fallbackEmail}`}
+                    className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] bg-[var(--surface)] px-5 py-2.5 text-sm font-medium text-[var(--text)] hover:bg-[var(--surface-light)]"
+                  >
+                    {L.emailCta}
+                  </a>
+                )}
+              </div>
+            </div>
+          ) : variant === 'iframe' ? (
             <iframe
               src={bookingUrl}
               width="100%"

--- a/web/components/sections/contact-section.tsx
+++ b/web/components/sections/contact-section.tsx
@@ -14,6 +14,54 @@ export interface ContactSectionProps {
   whatsapp?: string
   googleMapsUrl?: string
   hours?: Record<string, string>
+  /** Active URL locale — picks localized default labels for Address/Phone/Hours/WhatsApp CTA. */
+  __locale?: string
+}
+
+type ContactLabels = {
+  address: string
+  phone: string
+  hours: string
+  whatsappCta: string
+  mapFallback: (city: string) => string
+}
+
+const CONTACT_LABELS: Record<string, ContactLabels> = {
+  de: {
+    address: 'Adresse',
+    phone: 'Telefon',
+    hours: 'Öffnungszeiten',
+    whatsappCta: 'Auf WhatsApp schreiben',
+    mapFallback: (c) => `Karte von ${c}`,
+  },
+  en: {
+    address: 'Address',
+    phone: 'Phone',
+    hours: 'Hours',
+    whatsappCta: 'Message on WhatsApp',
+    mapFallback: (c) => `Map of ${c}`,
+  },
+  es: {
+    address: 'Dirección',
+    phone: 'Teléfono',
+    hours: 'Horarios',
+    whatsappCta: 'Escribir por WhatsApp',
+    mapFallback: (c) => `Mapa de ${c}`,
+  },
+  nl: {
+    address: 'Adres',
+    phone: 'Telefoon',
+    hours: 'Openingstijden',
+    whatsappCta: 'Bericht via WhatsApp',
+    mapFallback: (c) => `Kaart van ${c}`,
+  },
+  pt: {
+    address: 'Endereço',
+    phone: 'Telefone',
+    hours: 'Horários',
+    whatsappCta: 'Mensagem no WhatsApp',
+    mapFallback: (c) => `Mapa de ${c}`,
+  },
 }
 
 export function ContactSection({
@@ -26,7 +74,9 @@ export function ContactSection({
   whatsapp,
   googleMapsUrl,
   hours,
+  __locale,
 }: ContactSectionProps) {
+  const L = CONTACT_LABELS[__locale ?? 'es'] || CONTACT_LABELS.es
   return (
     <section id="contacto" className="bg-[var(--surface)] py-16 sm:py-20">
       <Container>
@@ -42,7 +92,7 @@ export function ContactSection({
               <div className="flex gap-3">
                 <MapPin size={20} className="mt-0.5 flex-shrink-0 text-[var(--secondary)]" />
                 <div>
-                  <Heading level={3} className="mb-1 text-lg font-semibold text-[var(--text)]">Direccion</Heading>
+                  <Heading level={3} className="mb-1 text-lg font-semibold text-[var(--text)]">{L.address}</Heading>
                   <p className="text-[var(--text-muted)]">
                     {address && <span>{address}<br /></span>}
                     {neighborhood && <span>{neighborhood}, </span>}
@@ -56,7 +106,7 @@ export function ContactSection({
                 <div className="flex gap-3">
                   <Phone size={20} className="mt-0.5 flex-shrink-0 text-[var(--secondary)]" />
                   <div>
-                    <Heading level={3} className="mb-1 text-lg font-semibold text-[var(--text)]">Telefono</Heading>
+                    <Heading level={3} className="mb-1 text-lg font-semibold text-[var(--text)]">{L.phone}</Heading>
                     {phone && (
                       <a href={`tel:${phone}`} className="block text-[var(--secondary)] hover:underline">
                         {phone}
@@ -69,7 +119,7 @@ export function ContactSection({
                         href={`https://wa.me/${whatsapp.replace(/\D/g, '')}`}
                         className="mt-2"
                       >
-                        Escribir por WhatsApp
+                        {L.whatsappCta}
                       </Button>
                     )}
                   </div>
@@ -94,7 +144,7 @@ export function ContactSection({
                 <div className="flex gap-3">
                   <Clock size={20} className="mt-0.5 flex-shrink-0 text-[var(--secondary)]" />
                   <div>
-                    <Heading level={3} className="mb-2 text-lg font-semibold text-[var(--text)]">Horarios</Heading>
+                    <Heading level={3} className="mb-2 text-lg font-semibold text-[var(--text)]">{L.hours}</Heading>
                     <dl className="space-y-1">
                       {Object.entries(hours).map(([day, time]) => (
                         <div key={day} className="flex justify-between gap-4 text-sm">
@@ -121,7 +171,7 @@ export function ContactSection({
                   allowFullScreen
                   loading="lazy"
                   referrerPolicy="no-referrer-when-downgrade"
-                  title={`Mapa de ${city}`}
+                  title={L.mapFallback(city)}
                 />
               ) : (
                 <div className="flex h-full min-h-[300px] flex-col items-center justify-center gap-2 text-[var(--text-muted)]">

--- a/web/components/sections/features-section.tsx
+++ b/web/components/sections/features-section.tsx
@@ -14,14 +14,26 @@ interface FeaturesSectionProps {
   subtitle?: string
   features: Feature[]
   columns?: 2 | 3 | 4
+  /** Active URL locale — picks a localized default for `title` when caller omits it. */
+  __locale?: string
+}
+
+const FEATURES_DEFAULT_TITLE: Record<string, string> = {
+  de: 'Warum uns wählen',
+  en: 'Why choose us',
+  es: 'Por qué elegirnos',
+  nl: 'Waarom ons kiezen',
+  pt: 'Por que nos escolher',
 }
 
 export function FeaturesSection({
-  title = 'Por qué elegirnos',
+  title,
   subtitle,
   features = [],
   columns = 3,
+  __locale,
 }: FeaturesSectionProps) {
+  const resolvedTitle = title || FEATURES_DEFAULT_TITLE[__locale ?? 'es'] || FEATURES_DEFAULT_TITLE.es
   const gridCols = {
     2: 'md:grid-cols-2',
     3: 'md:grid-cols-3',
@@ -35,9 +47,9 @@ export function FeaturesSection({
   return (
     <section className="bg-[var(--background)] py-16 sm:py-20">
       <Container>
-        {title && (
+        {resolvedTitle && (
           <div className="text-center mb-12">
-            <Heading level={2}>{title}</Heading>
+            <Heading level={2}>{resolvedTitle}</Heading>
             {subtitle && (
               <p className="mx-auto mt-4 max-w-2xl text-[var(--text-muted)]">{subtitle}</p>
             )}

--- a/web/components/sections/header-section.tsx
+++ b/web/components/sections/header-section.tsx
@@ -101,10 +101,10 @@ export function HeaderSection({
     <header
       className={cn(
         'fixed top-0 left-0 right-0 z-50 transition-shadow duration-300 bg-[var(--surface)]',
-        scrolled && 'shadow-md'
+        scrolled ? 'shadow-md' : 'shadow-sm'
       )}
       style={{
-        borderBottom: scrolled ? '1px solid rgba(0,0,0,0.08)' : '1px solid transparent',
+        borderBottom: '1px solid rgba(0,0,0,0.08)',
       }}
     >
       <Container>
@@ -113,9 +113,9 @@ export function HeaderSection({
           <a
             href="#"
             className="text-lg sm:text-xl font-bold transition-colors hover:opacity-80"
-            style={{ 
+            style={{
               fontFamily: 'var(--font-heading)',
-              color: 'var(--text)',
+              color: 'var(--primary)',
             }}
           >
             {businessName}
@@ -128,12 +128,12 @@ export function HeaderSection({
                 key={item.href}
                 href={item.href}
                 className="px-3 py-2 rounded-md text-sm font-medium transition-all duration-200 hover:bg-[var(--surface-light)]"
-                style={{ color: 'var(--text-muted)' }}
+                style={{ color: 'var(--text)' }}
                 onMouseEnter={(e) => {
                   e.currentTarget.style.color = 'var(--secondary)'
                 }}
                 onMouseLeave={(e) => {
-                  e.currentTarget.style.color = 'var(--text-muted)'
+                  e.currentTarget.style.color = 'var(--text)'
                 }}
               >
                 {item.label}

--- a/web/components/sections/header-section.tsx
+++ b/web/components/sections/header-section.tsx
@@ -98,15 +98,13 @@ export function HeaderSection({
   }
 
   return (
-    <header 
+    <header
       className={cn(
-        'fixed top-0 left-0 right-0 z-50 transition-all duration-300',
-        scrolled 
-          ? 'bg-[var(--surface)]/95 backdrop-blur-md shadow-lg' 
-          : 'bg-[var(--surface)]'
+        'fixed top-0 left-0 right-0 z-50 transition-shadow duration-300 bg-[var(--surface)]',
+        scrolled && 'shadow-md'
       )}
       style={{
-        borderBottom: scrolled ? '1px solid rgba(0,0,0,0.06)' : 'none',
+        borderBottom: scrolled ? '1px solid rgba(0,0,0,0.08)' : '1px solid transparent',
       }}
     >
       <Container>

--- a/web/components/sections/hero-section.tsx
+++ b/web/components/sections/hero-section.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils'
 export interface HeroSectionProps {
   headline: string
   subheadline: string
-  ctaPrimaryText: string
+  ctaPrimaryText?: string
   ctaPrimaryHref?: string
   ctaSecondaryText?: string
   ctaSecondaryHref?: string
@@ -89,19 +89,23 @@ export function HeroSection({
           {subheadline}
         </p>
         
-        <div className={cn("flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6", enhanced && "hero-animate-delay-3")}>
-          <Button variant="primary" size="lg" href={ctaPrimaryHref}
-            className={cn("w-full sm:w-auto min-h-[56px] px-8 text-base font-semibold tracking-wide", enhanced && "hero-btn-primary hover:scale-[1.02] transition-transform duration-300")}
-            style={{ backgroundColor: 'var(--secondary)', color: '#ffffff', boxShadow: '0 8px 24px rgba(184, 134, 11, 0.35)' }}>
-            {ctaPrimaryText}
-          </Button>
-          {ctaSecondaryText && (
-            <Button variant="secondary" size="lg" href={ctaSecondaryHref}
-              className={cn("w-full sm:w-auto min-h-[56px] px-8 text-base font-semibold tracking-wide", useGradient && "border-2 border-white/40 text-white hover:bg-white/10 hover:border-white/60", enhanced && "hero-btn-secondary transition-all duration-300")}>
-              {ctaSecondaryText}
-            </Button>
-          )}
-        </div>
+        {(ctaPrimaryText || ctaSecondaryText) && (
+          <div className={cn("flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6", enhanced && "hero-animate-delay-3")}>
+            {ctaPrimaryText && (
+              <Button variant="primary" size="lg" href={ctaPrimaryHref}
+                className={cn("w-full sm:w-auto min-h-[56px] px-8 text-base font-semibold tracking-wide", enhanced && "hero-btn-primary hover:scale-[1.02] transition-transform duration-300")}
+                style={{ backgroundColor: 'var(--secondary)', color: '#ffffff', boxShadow: '0 8px 24px rgba(184, 134, 11, 0.35)' }}>
+                {ctaPrimaryText}
+              </Button>
+            )}
+            {ctaSecondaryText && (
+              <Button variant="secondary" size="lg" href={ctaSecondaryHref}
+                className={cn("w-full sm:w-auto min-h-[56px] px-8 text-base font-semibold tracking-wide", useGradient && "border-2 border-white/40 text-white hover:bg-white/10 hover:border-white/60", enhanced && "hero-btn-secondary transition-all duration-300")}>
+                {ctaSecondaryText}
+              </Button>
+            )}
+          </div>
+        )}
 
         {enhanced && trustBadgesEnabled && (
           <div className="mt-12 sm:mt-16 hero-animate-delay-4">

--- a/web/components/sections/hero-section.tsx
+++ b/web/components/sections/hero-section.tsx
@@ -109,10 +109,10 @@ export function HeroSection({
 
         {enhanced && trustBadgesEnabled && (
           <div className="mt-12 sm:mt-16 hero-animate-delay-4">
-            <div className="flex flex-wrap items-center justify-center gap-6 text-sm" style={{ color: 'rgba(255,255,255,0.7)' }}>
+            <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-3 text-sm font-medium" style={{ color: 'rgba(255,255,255,0.95)' }}>
               {trustBadges.map((label) => (
                 <div key={label} className="flex items-center gap-2">
-                  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>
+                  <svg className="w-5 h-5" fill="var(--secondary)" viewBox="0 0 20 20" aria-hidden="true"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>
                   <span>{label}</span>
                 </div>
               ))}
@@ -135,7 +135,7 @@ export function HeroSection({
     : undefined
 
   return (
-    <section className={cn("relative flex min-h-[80vh] sm:min-h-[85vh] items-center justify-center overflow-hidden", !backgroundImage && !useGradient && "bg-[var(--primary)]")} style={backgroundStyle}>
+    <section className={cn("relative flex min-h-[80vh] sm:min-h-[85vh] items-center justify-center overflow-hidden pt-20 sm:pt-24", !backgroundImage && !useGradient && "bg-[var(--primary)]")} style={backgroundStyle}>
       {useGradient && !backgroundImage && (
         <GradientBackground variant={gradientVariant} animated={enhanced} className="absolute inset-0" />
       )}

--- a/web/components/sections/lead-form-section.tsx
+++ b/web/components/sections/lead-form-section.tsx
@@ -33,6 +33,14 @@ export interface LeadFormSectionProps {
   __locale?: string
 }
 
+const LOADING_LABELS: Record<string, string> = {
+  de: 'Senden…',
+  en: 'Sending…',
+  es: 'Enviando…',
+  nl: 'Verzenden…',
+  pt: 'Enviando…',
+}
+
 const DEFAULT_FIELDS: LeadFormField[] = [
   { name: 'name', label: 'Name', type: 'text', required: true },
   { name: 'email', label: 'Email', type: 'email', required: true },
@@ -227,7 +235,7 @@ export function LeadFormSection({
                 size="lg"
                 type="submit"
                 isLoading={status === 'sending'}
-                loadingText="Enviando…"
+                loadingText={LOADING_LABELS[__locale ?? 'es'] || LOADING_LABELS.es}
                 className="w-full sm:w-auto"
               >
                 {submitLabel}

--- a/web/components/sections/packages-section.tsx
+++ b/web/components/sections/packages-section.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -54,7 +55,7 @@ export function PackagesSection({
       <Container>
         {/* Header */}
         <div className="text-center mb-12">
-          <h2 className="text-3xl font-bold mb-4">Promociones Especiales</h2>
+          <Heading level={2} className="text-3xl font-bold mb-4">Promociones Especiales</Heading>
           
           {/* Tabs */}
           {showGiftCards && giftCards && (
@@ -105,7 +106,7 @@ export function PackagesSection({
                 )}
                 
                 <CardHeader className="pb-4">
-                  <h3 className="text-xl font-bold">{pkg.name}</h3>
+                  <Heading level={3} className="text-xl font-bold">{pkg.name}</Heading>
                   <p className="text-sm text-[var(--muted-foreground)]">{pkg.description}</p>
                 </CardHeader>
                 

--- a/web/components/sections/process-timeline-section.tsx
+++ b/web/components/sections/process-timeline-section.tsx
@@ -87,32 +87,71 @@ export function ProcessTimelineSection({
 }
 
 function Horizontal({ steps }: { steps: ProcessStep[] }) {
+  const cols = Math.min(Math.max(steps.length, 2), 6)
+  const gridColsClass = (
+    cols === 2 ? 'md:grid-cols-2'
+    : cols === 3 ? 'md:grid-cols-3'
+    : cols === 4 ? 'md:grid-cols-4'
+    : cols === 5 ? 'md:grid-cols-5'
+    : 'md:grid-cols-6'
+  )
   return (
-    <div className="mt-12 grid gap-8 md:grid-cols-5">
-      {steps.map((step, i) => (
-        <AnimateOnScroll key={i} stagger={((i % 5) + 1) as 1 | 2 | 3 | 4 | 5}>
-          <div className="relative text-center">
-            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full border-2 border-[var(--secondary)] bg-[var(--surface)]">
-              <IconByName name={step.icon} />
-              {!step.icon && (
-                <span className="text-xl font-bold text-[var(--secondary)]">{step.number ?? i + 1}</span>
+    <div className={`mt-12 grid gap-x-4 gap-y-10 ${gridColsClass} items-start`}>
+      {steps.map((step, i) => {
+        const isLast = i === steps.length - 1
+        return (
+          <AnimateOnScroll
+            key={i}
+            stagger={((i % 5) + 1) as 1 | 2 | 3 | 4 | 5}
+            className="relative"
+          >
+            {!isLast && (
+              <>
+                {/* Desktop connector: right-pointing arrow between columns */}
+                <Icons.ArrowRight
+                  aria-hidden="true"
+                  className="pointer-events-none absolute top-9 right-[-20px] hidden h-6 w-6 text-[var(--secondary)]/60 md:block"
+                />
+                {/* Mobile connector: down-pointing arrow below the card */}
+                <Icons.ArrowDown
+                  aria-hidden="true"
+                  className="pointer-events-none mx-auto mt-6 h-6 w-6 text-[var(--secondary)]/60 md:hidden"
+                />
+              </>
+            )}
+            <div className="text-center">
+              <div className="relative mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-[var(--secondary)] text-[var(--secondary-foreground)] shadow-[0_8px_24px_rgba(201,169,110,0.35)] ring-4 ring-[var(--surface)]">
+                {step.icon ? (
+                  <div className="text-[var(--secondary-foreground)]">
+                    <IconByName name={step.icon} size={28} />
+                  </div>
+                ) : (
+                  <span className="text-2xl font-bold">{step.number ?? i + 1}</span>
+                )}
+                <span
+                  aria-hidden="true"
+                  className="absolute -top-2 -right-2 flex h-7 w-7 items-center justify-center rounded-full bg-[var(--primary)] text-xs font-bold text-white shadow-md"
+                >
+                  {step.number ?? i + 1}
+                </span>
+              </div>
+              <Heading
+                level={3}
+                className="mb-2 text-lg font-semibold text-[var(--primary)]"
+                style={{ fontFamily: 'var(--font-heading)' }}
+              >
+                {step.title}
+              </Heading>
+              <p className="text-sm text-[var(--text-light)]">{step.description}</p>
+              {step.duration && (
+                <p className="mt-2 text-xs uppercase tracking-wider text-[var(--text-muted)]">
+                  {step.duration}
+                </p>
               )}
             </div>
-            <Heading level={3}
-              className="mb-2 text-lg font-semibold text-[var(--primary)]"
-              style={{ fontFamily: 'var(--font-heading)' }}
-            >
-              {step.title}
-            </Heading>
-            <p className="text-sm text-[var(--text-light)]">{step.description}</p>
-            {step.duration && (
-              <p className="mt-2 text-xs uppercase tracking-wider text-[var(--text-muted)]">
-                {step.duration}
-              </p>
-            )}
-          </div>
-        </AnimateOnScroll>
-      ))}
+          </AnimateOnScroll>
+        )
+      })}
     </div>
   )
 }

--- a/web/components/sections/product-catalog-section.tsx
+++ b/web/components/sections/product-catalog-section.tsx
@@ -135,6 +135,12 @@ export function ProductCatalogSection({
   emailAddress,
 }: ProductCatalogSectionProps) {
   const products = productsProp || items || []
+
+  // Hooks must be called before any early return — conditional hook calls
+  // break React's ordering invariant. Derive a stable category set even
+  // when there are zero products, then early-return just the render.
+  const [activeCategory, setActiveCategory] = useState<string | null>(null)
+
   if (products.length === 0) return null
 
   // Build categories list from products if not explicitly provided
@@ -142,8 +148,6 @@ export function ProductCatalogSection({
     ...new Set(products.filter((p) => p.category).map((p) => p.category!)),
   ]
   const hasCategories = allCategories.length > 0
-
-  const [activeCategory, setActiveCategory] = useState<string | null>(null)
 
   const filteredProducts = activeCategory
     ? products.filter((p) => p.category === activeCategory)

--- a/web/components/sections/programs-comparison-section.tsx
+++ b/web/components/sections/programs-comparison-section.tsx
@@ -92,7 +92,7 @@ function TierCards({ tiers }: { tiers: ProgramTier[] }) {
       {tiers.map((tier, idx) => (
         <AnimateOnScroll key={tier.id} stagger={((idx % 4) + 1) as 1 | 2 | 3 | 4}>
           <article className={cn('relative flex h-full flex-col rounded-2xl transition-all duration-300',
-              tier.highlighted ? 'bg-[var(--surface)] shadow-xl scale-[1.02] lg:scale-[1.03] ring-2 ring-[var(--secondary)]' : 'bg-[var(--surface)] shadow-md hover:shadow-lg border border-[var(--surface-light)]'
+              tier.highlighted ? 'bg-[var(--surface)] shadow-xl ring-2 ring-[var(--secondary)]' : 'bg-[var(--surface)] shadow-md hover:shadow-lg border border-[var(--surface-light)]'
             )} style={{ boxShadow: tier.highlighted ? '0 20px 50px -12px rgba(184, 134, 11, 0.25)' : undefined }}>
             {tier.badge && (
               <div className="absolute -top-4 left-1/2 -translate-x-1/2">

--- a/web/components/sections/programs-comparison-section.tsx
+++ b/web/components/sections/programs-comparison-section.tsx
@@ -28,6 +28,18 @@ export interface ProgramsComparisonSectionProps {
   subtitle?: string
   tiers?: ProgramTier[]
   comparisonRows?: Array<{ feature: string; values: Array<string | boolean> }>
+  /** Header label for the left column of the matrix variant. Locale-aware when omitted. */
+  featureColumnLabel?: string
+  /** Active URL locale — lets us pick a localized default for `featureColumnLabel`. */
+  __locale?: string
+}
+
+const FEATURE_COLUMN_LABELS: Record<string, string> = {
+  de: 'Merkmale',
+  en: 'Features',
+  es: 'Características',
+  nl: 'Kenmerken',
+  pt: 'Características',
 }
 
 export function ProgramsComparisonSection({
@@ -37,9 +49,14 @@ export function ProgramsComparisonSection({
   subtitle,
   tiers = [],
   comparisonRows,
+  featureColumnLabel,
+  __locale,
 }: ProgramsComparisonSectionProps) {
   if (tiers.length === 0) return null
-  
+
+  const resolvedFeatureLabel =
+    featureColumnLabel || FEATURE_COLUMN_LABELS[__locale ?? 'es'] || FEATURE_COLUMN_LABELS.es
+
   return (
     <section id="programas" className="bg-[var(--background)] py-20 sm:py-28 lg:py-32">
       <Container>
@@ -60,7 +77,7 @@ export function ProgramsComparisonSection({
         </AnimatedSectionHeader>
 
         {variant === 'matrix' && comparisonRows && comparisonRows.length > 0 ? (
-          <MatrixTable tiers={tiers} rows={comparisonRows} />
+          <MatrixTable tiers={tiers} rows={comparisonRows} featureLabel={resolvedFeatureLabel} />
         ) : (
           <TierCards tiers={tiers} />
         )}
@@ -139,13 +156,13 @@ function TierCards({ tiers }: { tiers: ProgramTier[] }) {
   )
 }
 
-function MatrixTable({ tiers, rows }: { tiers: ProgramTier[]; rows: Array<{ feature: string; values: Array<string | boolean> }> }) {
+function MatrixTable({ tiers, rows, featureLabel }: { tiers: ProgramTier[]; rows: Array<{ feature: string; values: Array<string | boolean> }>; featureLabel: string }) {
   return (
     <div className="mt-12 overflow-x-auto rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-lg">
       <table className="w-full border-collapse text-sm sm:text-base">
         <thead>
           <tr style={{ backgroundColor: 'var(--surface-light)' }}>
-            <th className="p-4 sm:p-6 text-left font-semibold" style={{ color: 'var(--text)' }}>Merkmale</th>
+            <th className="p-4 sm:p-6 text-left font-semibold" style={{ color: 'var(--text)' }}>{featureLabel}</th>
             {tiers.map((t) => (
               <th key={t.id} className="p-4 sm:p-6 text-left font-bold" style={{ color: 'var(--primary)', minWidth: '180px' }}>{t.name}</th>
             ))}

--- a/web/components/sections/promo-banner-section.tsx
+++ b/web/components/sections/promo-banner-section.tsx
@@ -55,6 +55,10 @@ export function PromoBannerSection({
   useEffect(() => {
     if (!autoRotate || promotions.length <= 1) return
 
+    // Reset progress when currentIndex changes — intentional cascading
+    // render: the new promo starts with an empty progress bar before the
+    // interval below begins incrementing it.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setProgress(0)
     const step = 100 / (rotateInterval / 100)
     

--- a/web/components/sections/services-section.tsx
+++ b/web/components/sections/services-section.tsx
@@ -32,6 +32,16 @@ export interface ServicesSectionProps {
   cardStyle?: 'default' | 'glass' | 'gradient' | 'outline'
   /** Enable hover lift effect on cards */
   hoverEffect?: boolean
+  /** Active URL locale — picks localized defaults for "From" price prefix and "Other" category fallback. */
+  __locale?: string
+}
+
+const SERVICE_LABELS: Record<string, { from: string; otherCategory: string }> = {
+  de: { from: 'Ab', otherCategory: 'Sonstige' },
+  en: { from: 'From', otherCategory: 'Other' },
+  es: { from: 'Desde', otherCategory: 'Otros' },
+  nl: { from: 'Vanaf', otherCategory: 'Overig' },
+  pt: { from: 'Desde', otherCategory: 'Outros' },
 }
 
 /**
@@ -66,15 +76,18 @@ export function ServicesSection({
   enhanced = false,
   cardStyle = 'default',
   hoverEffect = true,
+  __locale,
 }: ServicesSectionProps) {
   const services = servicesProp || items || []
   if (services.length === 0) return null
+
+  const L = SERVICE_LABELS[__locale ?? 'es'] || SERVICE_LABELS.es
 
   // Group services by category if categories exist
   const hasCategories = services.some((s) => s.category)
   const grouped = hasCategories
     ? services.reduce<Record<string, ServiceItem[]>>((acc, s) => {
-        const cat = s.category || 'Otros'
+        const cat = s.category || L.otherCategory
         if (!acc[cat]) acc[cat] = []
         acc[cat].push(s)
         return acc
@@ -115,7 +128,7 @@ export function ServicesSection({
             </Heading>
             {showPrices && (service.price || service.priceFrom) && (
               <Badge variant="outline">
-                {service.priceFrom ? `Desde ${service.priceFrom}` : service.price}
+                {service.priceFrom ? `${L.from} ${service.priceFrom}` : service.price}
               </Badge>
             )}
           </div>

--- a/web/components/sections/team-section.tsx
+++ b/web/components/sections/team-section.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import * as Icons from 'lucide-react'
 import { Container } from '@/components/ui/container'
 import { Heading } from '@/components/ui/heading'
 import { Card, CardContent } from '@/components/ui/card'
@@ -8,6 +9,7 @@ export interface TeamMember {
   role?: string
   bio?: string
   imageUrl?: string
+  icon?: string
   instagram?: string
 }
 
@@ -15,6 +17,21 @@ export interface TeamSectionProps {
   title: string
   subtitle?: string
   members: TeamMember[]
+}
+
+function IconByName({ name, size = 40 }: { name?: string; size?: number }) {
+  const fallback = 'Users'
+  const key = name || fallback
+  const Icon = (Icons as unknown as Record<string, React.ComponentType<{ size?: number; className?: string }>>)[key]
+  if (!Icon) return null
+  return <Icon size={size} className="text-[var(--secondary)]" />
+}
+
+function gridColsClass(n: number): string {
+  if (n <= 2) return 'sm:grid-cols-2'
+  if (n === 3) return 'sm:grid-cols-2 lg:grid-cols-3'
+  if (n === 4) return 'sm:grid-cols-2 lg:grid-cols-4'
+  return 'sm:grid-cols-2 lg:grid-cols-3'
 }
 
 export function TeamSection({ title, subtitle, members }: TeamSectionProps) {
@@ -28,47 +45,58 @@ export function TeamSection({ title, subtitle, members }: TeamSectionProps) {
           )}
         </div>
 
-        <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
-          {members.map((member, index) => (
-            <Card key={index} className="text-center">
-              <CardContent className="pt-8">
-                {/* Avatar */}
-                <div className="mx-auto mb-4 h-32 w-32 overflow-hidden rounded-full bg-[var(--surface-light)]">
-                  {member.imageUrl ? (
-                    <Image
-                      src={member.imageUrl}
-                      alt={member.name}
-                      width={128}
-                      height={128}
-                      className="h-full w-full object-cover"
-                    />
+        <div className={`grid gap-8 items-stretch ${gridColsClass(members.length)}`}>
+          {members.map((member, index) => {
+            const hasImage = !!member.imageUrl
+            const hasDetails = !!member.role || !!member.bio
+            return (
+              <Card key={index} className="text-center group h-full">
+                <CardContent className="flex h-full flex-col pt-8">
+                  {/* Avatar: real photo, or icon (no letter-only fallback) */}
+                  {hasImage ? (
+                    <div className="mx-auto mb-4 h-32 w-32 overflow-hidden rounded-full bg-[var(--surface-light)]">
+                      <Image
+                        src={member.imageUrl!}
+                        alt={member.name}
+                        width={128}
+                        height={128}
+                        className="h-full w-full object-cover"
+                      />
+                    </div>
                   ) : (
-                    <div className="flex h-full w-full items-center justify-center text-3xl font-bold text-[var(--text-muted)]">
-                      {member.name.charAt(0)}
+                    <div className="mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-[var(--secondary)]/10">
+                      <IconByName name={member.icon} />
                     </div>
                   )}
-                </div>
 
-                <Heading level={3} className="text-lg font-semibold text-[var(--text)]">{member.name}</Heading>
-                {member.role && (
-                  <p className="mt-1 text-sm font-medium text-[var(--secondary)]">{member.role}</p>
-                )}
-                {member.bio && (
-                  <p className="mt-3 text-sm text-[var(--text-muted)]">{member.bio}</p>
-                )}
-                {member.instagram && (
-                  <a
-                    href={`https://instagram.com/${member.instagram.replace('@', '')}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="mt-3 inline-block text-sm text-[var(--secondary)] hover:underline"
-                  >
-                    @{member.instagram.replace('@', '')}
-                  </a>
-                )}
-              </CardContent>
-            </Card>
-          ))}
+                  <Heading level={3} className="text-lg font-semibold text-[var(--text)]">{member.name}</Heading>
+
+                  {hasDetails && (
+                    <div className="grid grid-rows-[0fr] opacity-0 transition-all duration-300 ease-out group-hover:grid-rows-[1fr] group-hover:opacity-100 focus-within:grid-rows-[1fr] focus-within:opacity-100 motion-reduce:grid-rows-[1fr] motion-reduce:opacity-100">
+                      <div className="overflow-hidden">
+                        {member.role && (
+                          <p className="mt-2 text-sm font-medium text-[var(--secondary)]">{member.role}</p>
+                        )}
+                        {member.bio && (
+                          <p className="mt-3 text-sm text-[var(--text-muted)]">{member.bio}</p>
+                        )}
+                        {member.instagram && (
+                          <a
+                            href={`https://instagram.com/${member.instagram.replace('@', '')}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-3 inline-block text-sm text-[var(--secondary)] hover:underline"
+                          >
+                            @{member.instagram.replace('@', '')}
+                          </a>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            )
+          })}
         </div>
       </Container>
     </section>

--- a/web/components/sections/trust-signals-section.tsx
+++ b/web/components/sections/trust-signals-section.tsx
@@ -65,11 +65,11 @@ export function TrustSignalsSection({
 
 function Credentials({ items }: { items: TrustItem[] }) {
   return (
-    <div className="mt-10 grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+    <div className="mt-10 grid gap-6 md:grid-cols-2 lg:grid-cols-4 items-stretch">
       {items.map((item, i) => (
-        <AnimateOnScroll key={i} stagger={((i % 4) + 1) as 1 | 2 | 3 | 4}>
-          <div className="rounded-lg bg-[var(--surface)] p-6 text-center shadow-card">
-            <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-[var(--secondary)]/10">
+        <AnimateOnScroll key={i} stagger={((i % 4) + 1) as 1 | 2 | 3 | 4} className="h-full">
+          <div className="flex h-full flex-col rounded-lg bg-[var(--surface)] p-6 text-center shadow-card">
+            <div className="mx-auto mb-3 flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[var(--secondary)]/10">
               <IconByName name={item.icon} />
             </div>
             {item.value && (

--- a/web/components/sections/weekly-schedule-section.tsx
+++ b/web/components/sections/weekly-schedule-section.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -89,7 +90,7 @@ export function WeeklySchedule({ classes, onBookClass }: WeeklyScheduleProps) {
       {/* Header */}
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-8">
         <div>
-          <h2 className="text-3xl font-bold">Horario de Clases</h2>
+          <Heading level={2} className="text-3xl font-bold">Horario de Clases</Heading>
           <p className="text-[var(--muted-foreground)] mt-1">
             Reserva tu lugar en nuestras clases grupales
           </p>

--- a/web/components/sections/whatsapp-float.tsx
+++ b/web/components/sections/whatsapp-float.tsx
@@ -1,14 +1,22 @@
 export interface WhatsAppFloatProps {
   phone: string
   message?: string
+  /** Active URL locale — picks a localized default message + aria-label when caller omits `message`. */
+  __locale?: string
 }
 
-export function WhatsAppFloat({
-  phone,
-  message = 'Hola! Quisiera mas informacion',
-}: WhatsAppFloatProps) {
+const WHATSAPP_DEFAULTS: Record<string, { message: string; ariaLabel: string }> = {
+  de: { message: 'Hallo! Ich hätte gerne mehr Informationen.', ariaLabel: 'Über WhatsApp kontaktieren' },
+  en: { message: 'Hi! I would like more information.', ariaLabel: 'Contact on WhatsApp' },
+  es: { message: '¡Hola! Me gustaría más información.', ariaLabel: 'Contactar por WhatsApp' },
+  nl: { message: 'Hallo! Ik zou graag meer informatie willen.', ariaLabel: 'Contact via WhatsApp' },
+  pt: { message: 'Olá! Gostaria de mais informações.', ariaLabel: 'Contactar pelo WhatsApp' },
+}
+
+export function WhatsAppFloat({ phone, message, __locale }: WhatsAppFloatProps) {
+  const L = WHATSAPP_DEFAULTS[__locale ?? 'es'] || WHATSAPP_DEFAULTS.es
   const cleanPhone = phone.replace(/\D/g, '')
-  const encodedMessage = encodeURIComponent(message)
+  const encodedMessage = encodeURIComponent(message || L.message)
 
   return (
     <a
@@ -16,7 +24,7 @@ export function WhatsAppFloat({
       target="_blank"
       rel="noopener noreferrer"
       className="fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-[#25D366] text-white shadow-lg transition-transform hover:scale-110"
-      aria-label="Contactar por WhatsApp"
+      aria-label={L.ariaLabel}
     >
       <svg viewBox="0 0 24 24" className="h-7 w-7 fill-current">
         <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />

--- a/web/components/sections/why-destination-section.tsx
+++ b/web/components/sections/why-destination-section.tsx
@@ -72,11 +72,11 @@ export function WhyDestinationSection({
 
 function ThreeCol({ pillars }: { pillars: WhyPillar[] }) {
   return (
-    <div className="mt-12 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div className="mt-12 grid gap-8 md:grid-cols-2 lg:grid-cols-3 items-stretch">
       {pillars.map((p, i) => (
-        <AnimateOnScroll key={i} stagger={((i % 6) + 1) as 1 | 2 | 3 | 4 | 5 | 6}>
-          <article className="rounded-lg border border-[var(--border)] bg-[var(--surface)] p-8 shadow-card transition-all hover:shadow-card-hover">
-            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-md bg-[var(--secondary)]/10">
+        <AnimateOnScroll key={i} stagger={((i % 6) + 1) as 1 | 2 | 3 | 4 | 5 | 6} className="h-full">
+          <article className="flex h-full flex-col rounded-lg border border-[var(--border)] bg-[var(--surface)] p-8 shadow-card transition-all hover:shadow-card-hover">
+            <div className="mb-4 flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-[var(--secondary)]/10">
               <IconByName name={p.icon} />
             </div>
             <Heading level={3}

--- a/web/lib/engine/compose-site.ts
+++ b/web/lib/engine/compose-site.ts
@@ -29,6 +29,7 @@ import {
   hasVariant,
   defaultVariant,
 } from './section-registry'
+import { listBlogPosts } from './blog-loader'
 import { logger } from '@/lib/logger'
 import { metrics } from '@/lib/obs/metrics'
 
@@ -114,7 +115,8 @@ export function composeSitePage(input: ComposeInput): ResolvedPage {
           __availableLocales: site.locales,
           __currentPath: pageSlug === DEFAULT_PAGE_SLUG ? '' : pageSlug,
         }
-        const props = injectCommerceSiteContext(s.id, propsWithContext, siteContent.siteName)
+        const withCommerce = injectCommerceSiteContext(s.id, propsWithContext, siteContent.siteName)
+        const props = injectBlogIndexPosts(s.id, withCommerce, siteSlug, locale)
         return { id: s.id, variant, props }
       } catch (err) {
         logger.error('Site composition: section content resolution failed', {
@@ -294,4 +296,36 @@ function injectCommerceSiteContext(
     next.businessName = siteName
   }
   return next
+}
+
+/**
+ * Connects the blog-index section to the blog-loader.
+ *
+ * The content config (`blog.index`) only carries the header copy
+ * (title / subtitle / seo). The actual post list lives under
+ * `sites/<slug>/blog/<locale>/*.mdx` and gets loaded via
+ * `listBlogPosts`. Without this, every blog-index renders empty.
+ *
+ * Callers can still override by providing `posts` in the content ref
+ * (escape hatch for mock data or fully-manual post lists).
+ */
+function injectBlogIndexPosts(
+  sectionId: string,
+  props: Record<string, unknown>,
+  siteSlug: string,
+  locale: Locale,
+): Record<string, unknown> {
+  if (sectionId !== 'blog-index') return props
+  if (Array.isArray(props.posts) && props.posts.length > 0) return props
+  const posts = listBlogPosts(siteSlug, locale).map((p) => ({
+    slug: p.slug,
+    title: p.title,
+    excerpt: p.excerpt,
+    date: p.date,
+    category: p.category,
+    coverImage: p.coverImage,
+    readingMinutes: p.readingMinutes,
+    href: `/s/${locale}/${siteSlug}/blog/${p.slug}`,
+  }))
+  return { ...props, posts }
 }

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -11,7 +11,7 @@
  */
 
 export type JsonRecord = Record<string, unknown>
-/** Counts: sites=117, pages=147, content=137, blog=20, verticals=23. */
+/** Counts: sites=117, pages=147, content=137, blog=25, verticals=23. */
 export const SITE_SLUGS: readonly string[] = [
   "dayah-litworks",
   "de-abasto-a-casa",
@@ -19793,6 +19793,8 @@ export const CONTENT: Record<string, JsonRecord> = {
       "booking": {
         "bookingUrl": "https://calendly.com/nexaparaguay/consulta",
         "ctaLabel": "Kalender öffnen",
+        "fallbackEmail": "hola@nexaparaguay.com",
+        "fallbackWhatsapp": "595982515138",
         "provider": "calendly",
         "subtitle": "Wählen Sie einen passenden Termin.",
         "title": "Gespräch buchen"
@@ -19916,6 +19918,22 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/de/nexa-paraguay/privacidad",
           "label": "Datenschutz"
+        },
+        {
+          "href": "/s/de/nexa-paraguay/faq",
+          "label": "FAQ"
+        },
+        {
+          "href": "/s/de/nexa-paraguay/blog",
+          "label": "Blog"
+        },
+        {
+          "href": "/s/de/nexa-paraguay/contacto",
+          "label": "Kontakt"
+        },
+        {
+          "href": "/s/de/nexa-paraguay/por-que-paraguay",
+          "label": "Warum Paraguay"
         }
       ],
       "whatsapp": "595982515138"
@@ -20011,7 +20029,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Business",
             "price": "USD 4.400+",
-            "priceNote": "LEALTIS-Basispreis. Nexa-Endpreis in Festlegung."
+            "priceNote": "Ab-Preis. Endgültiges Angebot je nach Anforderungen."
           },
           {
             "ctaHref": "/s/de/nexa-paraguay/contacto?programa=investor",
@@ -20027,11 +20045,11 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Investor Program",
             "price": "USD 6.900+",
-            "priceNote": "LEALTIS-Basispreis. Nexa-Endpreis in Festlegung."
+            "priceNote": "Ab-Preis. Endgültiges Angebot je nach Anforderungen."
           },
           {
             "ctaHref": "/s/de/nexa-paraguay/contacto?programa=tierras",
-            "ctaLabel": "Sondierungsgespräch",
+            "ctaLabel": "Anfragen",
             "description": "Eigene Dienstleistung von Nexa.",
             "id": "tierras",
             "included": [
@@ -20342,7 +20360,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Business",
             "price": "USD 4.400+",
-            "priceNote": "LEALTIS-Basispreis. Nexa-Endpreis in Festlegung."
+            "priceNote": "Ab-Preis. Endgültiges Angebot je nach Anforderungen."
           },
           {
             "ctaHref": "/s/de/nexa-paraguay/contacto?programa=investor",
@@ -20358,11 +20376,11 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Investor Program",
             "price": "USD 6.900+",
-            "priceNote": "LEALTIS-Basispreis. Nexa-Endpreis in Festlegung."
+            "priceNote": "Ab-Preis. Endgültiges Angebot je nach Anforderungen."
           },
           {
             "ctaHref": "/s/de/nexa-paraguay/contacto?programa=tierras",
-            "ctaLabel": "Sondierungsgespräch",
+            "ctaLabel": "Anfragen",
             "description": "Eigene Dienstleistung von Nexa.",
             "id": "tierras",
             "included": [
@@ -20416,7 +20434,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Business",
             "price": "USD 4.400+",
-            "priceNote": "LEALTIS-Basispreis. Nexa-Endpreis in Festlegung."
+            "priceNote": "Ab-Preis. Endgültiges Angebot je nach Anforderungen."
           },
           {
             "ctaHref": "/s/de/nexa-paraguay/contacto?programa=investor",
@@ -20432,11 +20450,11 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Investor Program",
             "price": "USD 6.900+",
-            "priceNote": "LEALTIS-Basispreis. Nexa-Endpreis in Festlegung."
+            "priceNote": "Ab-Preis. Endgültiges Angebot je nach Anforderungen."
           },
           {
             "ctaHref": "/s/de/nexa-paraguay/contacto?programa=tierras",
-            "ctaLabel": "Sondierungsgespräch",
+            "ctaLabel": "Anfragen",
             "description": "Eigene Dienstleistung von Nexa.",
             "id": "tierras",
             "included": [
@@ -20767,6 +20785,8 @@ export const CONTENT: Record<string, JsonRecord> = {
       "booking": {
         "bookingUrl": "https://calendly.com/nexaparaguay/consulta",
         "ctaLabel": "Open calendar",
+        "fallbackEmail": "hola@nexaparaguay.com",
+        "fallbackWhatsapp": "595982515138",
         "provider": "calendly",
         "subtitle": "Pick a time that works for you.",
         "title": "Book your consultation"
@@ -20890,6 +20910,22 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/en/nexa-paraguay/privacidad",
           "label": "Privacy"
+        },
+        {
+          "href": "/s/en/nexa-paraguay/faq",
+          "label": "FAQ"
+        },
+        {
+          "href": "/s/en/nexa-paraguay/blog",
+          "label": "Blog"
+        },
+        {
+          "href": "/s/en/nexa-paraguay/contacto",
+          "label": "Contact"
+        },
+        {
+          "href": "/s/en/nexa-paraguay/por-que-paraguay",
+          "label": "Why Paraguay"
         }
       ],
       "whatsapp": "595982515138"
@@ -20985,7 +21021,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Business",
             "price": "USD 4,400+",
-            "priceNote": "LEALTIS base cost. Final Nexa price TBD."
+            "priceNote": "Starting price. Final quote depends on case requirements."
           },
           {
             "ctaHref": "/s/en/nexa-paraguay/contacto?programa=investor",
@@ -21001,11 +21037,11 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Investor Program",
             "price": "USD 6,900+",
-            "priceNote": "LEALTIS base cost. Final Nexa price TBD."
+            "priceNote": "Starting price. Final quote depends on case requirements."
           },
           {
             "ctaHref": "/s/en/nexa-paraguay/contacto?programa=tierras",
-            "ctaLabel": "Exploratory call",
+            "ctaLabel": "Inquire",
             "description": "Nexa's own service. Full advisory.",
             "id": "tierras",
             "included": [
@@ -21356,7 +21392,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Base",
             "price": "To be defined",
-            "priceNote": "Wholesale cost pending from LEALTIS + Nexa margin"
+            "priceNote": "Starting price. Final quote depends on case requirements."
           },
           {
             "badge": "Most chosen",
@@ -21375,7 +21411,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Business",
             "price": "USD 4,400+",
-            "priceNote": "Base LEALTIS cost. Final Nexa price to be defined."
+            "priceNote": "Starting price. Final quote depends on case requirements."
           },
           {
             "ctaHref": "/s/en/nexa-paraguay/contacto?programa=investor",
@@ -21391,7 +21427,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Investor Program",
             "price": "USD 6,900+",
-            "priceNote": "Base LEALTIS cost. Final Nexa price to be defined."
+            "priceNote": "Starting price. Final quote depends on case requirements."
           },
           {
             "ctaHref": "/s/en/nexa-paraguay/contacto?programa=land",
@@ -21710,6 +21746,8 @@ export const CONTENT: Record<string, JsonRecord> = {
       "booking": {
         "bookingUrl": "https://calendly.com/nexaparaguay/consulta",
         "ctaLabel": "Abrir calendario",
+        "fallbackEmail": "hola@nexaparaguay.com",
+        "fallbackWhatsapp": "595982515138",
         "provider": "calendly",
         "subtitle": "Elija el horario que mejor le convenga.",
         "title": "Agende su consulta"
@@ -21834,6 +21872,22 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/es/nexa-paraguay/privacidad",
           "label": "Privacidad"
+        },
+        {
+          "href": "/s/es/nexa-paraguay/faq",
+          "label": "FAQ"
+        },
+        {
+          "href": "/s/es/nexa-paraguay/blog",
+          "label": "Blog"
+        },
+        {
+          "href": "/s/es/nexa-paraguay/contacto",
+          "label": "Contacto"
+        },
+        {
+          "href": "/s/es/nexa-paraguay/por-que-paraguay",
+          "label": "Por qué Paraguay"
         }
       ],
       "whatsapp": "595982515138"
@@ -21929,7 +21983,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Business",
             "price": "USD 4.400+",
-            "priceNote": "Costo base LEALTIS. Precio final Nexa pendiente de definir."
+            "priceNote": "Precio desde. Cotización final según requisitos del caso."
           },
           {
             "ctaHref": "/s/es/nexa-paraguay/contacto?programa=investor",
@@ -21945,11 +21999,11 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Investor Program",
             "price": "USD 6.900+",
-            "priceNote": "Costo base LEALTIS. Precio final Nexa pendiente de definir."
+            "priceNote": "Precio desde. Cotización final según requisitos del caso."
           },
           {
             "ctaHref": "/s/es/nexa-paraguay/contacto?programa=tierras",
-            "ctaLabel": "Conversación exploratoria",
+            "ctaLabel": "Consultar",
             "description": "Servicio propio de Nexa. Asesoría integral.",
             "id": "tierras",
             "included": [
@@ -22288,12 +22342,12 @@ export const CONTENT: Record<string, JsonRecord> = {
             ]
           },
           {
-            "feature": "Costo LEALTIS (USD)",
+            "feature": "Precio desde (USD)",
             "values": [
-              "Pendiente",
+              "A definir",
               "4.400",
               "6.900",
-              "No aplica"
+              "3.500"
             ]
           }
         ],
@@ -22367,7 +22421,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Business",
             "price": "USD 4.400+",
-            "priceNote": "Costo base LEALTIS. Precio final Nexa pendiente de definir."
+            "priceNote": "Precio desde. Cotización final según requisitos del caso."
           },
           {
             "ctaHref": "/s/es/nexa-paraguay/contacto?programa=investor",
@@ -22383,11 +22437,11 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Investor Program",
             "price": "USD 6.900+",
-            "priceNote": "Costo base LEALTIS. Precio final Nexa pendiente de definir."
+            "priceNote": "Precio desde. Cotización final según requisitos del caso."
           },
           {
             "ctaHref": "/s/es/nexa-paraguay/contacto?programa=tierras",
-            "ctaLabel": "Conversación exploratoria",
+            "ctaLabel": "Consultar",
             "description": "Servicio propio de Nexa. Asesoría integral.",
             "id": "tierras",
             "included": [
@@ -22718,6 +22772,8 @@ export const CONTENT: Record<string, JsonRecord> = {
       "booking": {
         "bookingUrl": "https://calendly.com/nexaparaguay/consulta",
         "ctaLabel": "Open agenda",
+        "fallbackEmail": "hola@nexaparaguay.com",
+        "fallbackWhatsapp": "595982515138",
         "provider": "calendly",
         "subtitle": "Kies een moment dat u schikt.",
         "title": "Plan uw consult"
@@ -22841,6 +22897,22 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/nl/nexa-paraguay/privacidad",
           "label": "Privacy"
+        },
+        {
+          "href": "/s/nl/nexa-paraguay/faq",
+          "label": "FAQ"
+        },
+        {
+          "href": "/s/nl/nexa-paraguay/blog",
+          "label": "Blog"
+        },
+        {
+          "href": "/s/nl/nexa-paraguay/contacto",
+          "label": "Contact"
+        },
+        {
+          "href": "/s/nl/nexa-paraguay/por-que-paraguay",
+          "label": "Waarom Paraguay"
         }
       ],
       "whatsapp": "595982515138"
@@ -22936,7 +23008,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Business",
             "price": "USD 4.400+",
-            "priceNote": "LEALTIS-basisprijs. Definitieve Nexa-prijs nog te bepalen."
+            "priceNote": "Vanaf-prijs. Definitieve offerte afhankelijk van de vereisten."
           },
           {
             "ctaHref": "/s/nl/nexa-paraguay/contacto?programa=investor",
@@ -22952,11 +23024,11 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Investor Program",
             "price": "USD 6.900+",
-            "priceNote": "LEALTIS-basisprijs. Definitieve Nexa-prijs nog te bepalen."
+            "priceNote": "Vanaf-prijs. Definitieve offerte afhankelijk van de vereisten."
           },
           {
             "ctaHref": "/s/nl/nexa-paraguay/contacto?programa=tierras",
-            "ctaLabel": "Verkennend gesprek",
+            "ctaLabel": "Informeer",
             "description": "Eigen dienst van Nexa. Integraal advies.",
             "id": "tierras",
             "included": [
@@ -23267,7 +23339,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Business",
             "price": "USD 4.400+",
-            "priceNote": "LEALTIS-basisprijs. Definitieve Nexa-prijs nog te bepalen."
+            "priceNote": "Vanaf-prijs. Definitieve offerte afhankelijk van de vereisten."
           },
           {
             "ctaHref": "/s/nl/nexa-paraguay/contacto?programa=investor",
@@ -23283,11 +23355,11 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Investor Program",
             "price": "USD 6.900+",
-            "priceNote": "LEALTIS-basisprijs. Definitieve Nexa-prijs nog te bepalen."
+            "priceNote": "Vanaf-prijs. Definitieve offerte afhankelijk van de vereisten."
           },
           {
             "ctaHref": "/s/nl/nexa-paraguay/contacto?programa=tierras",
-            "ctaLabel": "Verkennend gesprek",
+            "ctaLabel": "Informeer",
             "description": "Eigen dienst van Nexa. Integraal advies.",
             "id": "tierras",
             "included": [
@@ -23341,7 +23413,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Business",
             "price": "USD 4.400+",
-            "priceNote": "LEALTIS-basisprijs. Definitieve Nexa-prijs nog te bepalen."
+            "priceNote": "Vanaf-prijs. Definitieve offerte afhankelijk van de vereisten."
           },
           {
             "ctaHref": "/s/nl/nexa-paraguay/contacto?programa=investor",
@@ -23357,11 +23429,11 @@ export const CONTENT: Record<string, JsonRecord> = {
             ],
             "name": "Paraguay Investor Program",
             "price": "USD 6.900+",
-            "priceNote": "LEALTIS-basisprijs. Definitieve Nexa-prijs nog te bepalen."
+            "priceNote": "Vanaf-prijs. Definitieve offerte afhankelijk van de vereisten."
           },
           {
             "ctaHref": "/s/nl/nexa-paraguay/contacto?programa=tierras",
-            "ctaLabel": "Verkennend gesprek",
+            "ctaLabel": "Informeer",
             "description": "Eigen dienst van Nexa. Integraal advies.",
             "id": "tierras",
             "included": [
@@ -25659,11 +25731,16 @@ export const BLOG_POSTS: Record<string, string> = {
   "fun4me:es:primera-vez-bdsm-consenso": "---\nid: primera-vez-bdsm-consenso\nslug: primera-vez-bdsm-guia-consenso\ntitle: \"Primera vez con BDSM: guía de consenso y seguridad\"\ncategory: guias-avanzadas\npublishedAt: 2026-05-10\nauthor: Equipo Fun4Me\nreadingMinutes: 10\n---\n\n# Primera vez con BDSM: guía de consenso y seguridad\n\nBDSM sano no empieza con cadenas, empieza con una **conversación**. Si saltás este paso, no es BDSM — es otra cosa. Esta guía te lleva paso a paso.\n\n## 1. Tres siglas que deberías conocer\n\n- **SSC** — Seguro, Sensato, Consensuado (Safe, Sane, Consensual). El estándar clásico.\n- **RACK** — Risk-Aware Consensual Kink. Más honesto: todo riesgo existe; lo que importa es que ambos lo conocen y aceptan.\n- **PRICK** — Personal Responsibility, Informed Consensual Kink. Variante que enfatiza responsabilidad individual.\n\nSi alguien propone una dinámica y no puede citar al menos una de estas filosofías, no está listo.\n\n## 2. Conversación pre-juego (obligatoria)\n\nSentate con tu pareja con tiempo, sin prisa, sin alcohol. Tocá estos puntos:\n\n**Límites duros** (lo que NO se hace bajo ningún concepto):\n- Zonas del cuerpo off-limits\n- Actos específicos (asfixia, humillación verbal, golpes en cara, etc.)\n- Triggers personales\n\n**Límites blandos** (abiertos a explorar, pero con cautela):\n- Cosas sobre las que tenés curiosidad pero nunca probaste\n- Cosas que podrías probar pero no hoy\n\n**Deseos explícitos**:\n- Qué querés que pase\n- Qué intensidad buscás\n- Roles (dominante / sumiso / switch)\n\n## 3. Palabras de seguridad\n\nDurante el juego, necesitás una forma inmediata de detener todo. Protocolo estándar:\n\n- **Verde** = todo bien, seguí.\n- **Amarillo** = bajá la intensidad o pausá.\n- **Rojo** = FRENÁ YA. Todo se detiene.\n\nSi estás con mordaza y no podés hablar, acordá señales con la mano (soltar un objeto, dos dedos arriba, etc.).\n\n## 4. Checklist de consenso (antes de cada sesión)\n\n- [ ] Ambas personas tienen palabra de seguridad clara.\n- [ ] Acordamos qué va a pasar (sin sorpresas).\n- [ ] Sobrio (alcohol OK ligero, drogas NO).\n- [ ] Nada de infidelidad / mentiras de contexto.\n- [ ] Puerta no bloqueada (safety physical).\n- [ ] Elementos de rescate a mano (tijera para cortar cuerdas, llave de esposas).\n- [ ] Plan para \"aftercare\" (abrazo, agua, conversación post-escena).\n\n## 5. Equipamiento para empezar (mínimo viable)\n\n- **Esposas de velcro** (no de metal para la primera vez) — Gs. 85.000\n- **Antifaz de satén** — Gs. 25.000\n- **Pluma para sensorial** — Gs. 35.000\n- **Paleta suave de neopreno** (no cuero duro) — Gs. 95.000\n- **Lubricante base agua** — Gs. 45.000\n- **Tijera de seguridad** (para cortar cuerdas en emergencia) — Gs. 20.000\n\n**Total kit iniciación: Gs. 305.000.** Tenemos el kit armado a Gs. 199.000 ([Kit BDSM Iniciación](/fun4me/bundles/bdsm-iniciacion)).\n\n## 6. Evitá estos errores clásicos\n\n1. **Empezar con asfixia** — es la práctica más peligrosa de BDSM. NUNCA sin formación específica.\n2. **Usar cuerdas apretadas en cuello** — mismo riesgo.\n3. **Golpes en zonas vitales** (riñones, cabeza, cuello, columna).\n4. **Jugar intoxicado** — consentimiento comprometido = no es BDSM.\n5. **Saltar el aftercare** — causa caídas emocionales.\n6. **Ignorar la palabra de seguridad** — esto NO es BDSM, es abuso.\n\n## 7. Aftercare: lo más importante después de la escena\n\nEl BDSM altera químicamente el cuerpo (adrenalina, endorfinas). Después:\n- Agua y algo dulce.\n- Abrazo / contacto físico no sexual.\n- Conversación (qué te gustó, qué no, cómo estás).\n- Espacio para emocionarse / llorar si surge.\n- Sin juicios.\n\nSin aftercare, puede haber \"drop\" emocional 24-48hs después (tristeza, irritabilidad sin razón aparente). Es normal. Con aftercare, se reduce mucho.\n\n## 8. Señales para parar (aunque no digan \"rojo\")\n\n- Llanto inesperado\n- Voz quebrada\n- Movimientos para alejarse\n- \"Disociación\" (mirada perdida)\n- Cambios bruscos de respiración\n- Piel muy fría o muy caliente\n\nCuando tengas dudas, **parás**. No perdés nada por pausar.\n\n## 9. Recursos adicionales\n\n- **Consenso explícito** — libro de Janet W. Hardy\n- **The New Topping Book** / **The New Bottoming Book** — guías clásicas\n- **Fetlife** — red social BDSM (con sus pros y contras, usá precauciones)\n\n## 10. Vení con preguntas\n\nBDSM es un mundo grande. Si querés asesoría personalizada, podés consultarnos por WhatsApp. Tenemos personal capacitado para orientarte sin juzgar.\n\nEl objetivo: placer, exploración, confianza. Nunca el dolor gratuito ni el daño.\n",
   "fun4me:es:privacidad-compras-online": "---\nid: privacidad-compras-online\nslug: privacidad-comprando-productos-adultos-paraguay\ntitle: Privacidad al comprar productos para adultos en Paraguay\ncategory: privacidad-discrecion\npublishedAt: 2026-06-15\nauthor: Equipo Fun4Me\nreadingMinutes: 5\n---\n\n# Privacidad al comprar productos para adultos en Paraguay\n\nLa privacidad no es un extra — es el corazón de nuestro servicio. Esto es exactamente lo que hacemos en cada etapa.\n\n## 1. Navegación anónima\n\n- Nuestra web **no comparte datos** con Facebook/Meta, Google Analytics va con IP truncada.\n- El historial de navegación no se asocia a tu identidad a menos que crees cuenta.\n- Si creás cuenta, podés usar un **pseudónimo** como nombre público.\n\n## 2. Carrito persistente sin registrarte\n\nPodés armar el carrito, pensarlo unos días, y volver. No necesitás cuenta para comprar.\n\n## 3. Métodos de pago: elegí según tu nivel de discreción\n\n| Método | ¿Aparece en extracto con nombre identificable? | Tiempo |\n|---|---|---|\n| **Transferencia bancaria** | Aparece \"F4M COMERCIAL\" | Inmediato |\n| **Tigo Money** | Aparece como \"Pagopar\" | Inmediato |\n| **Personal Pay** | Aparece como \"Pagopar\" | Inmediato |\n| **Tarjeta (Visa/MC)** | \"PAGOPAR - F4M COMERCIAL\" | Inmediato |\n| **Efectivo contra entrega** | No aparece en ningún lado | Al recibir |\n\nLa facturación (timbrado SET) figura como \"F4M Comercial\" — sin mención a tipo de productos.\n\n## 4. Empaque 100% discreto\n\nCada pedido va en caja o sobre sin marca:\n- Sin logos.\n- Sin nombre de la tienda.\n- Sin indicación del contenido.\n- Remitente genérico: \"F4M Comercial\" o dirección sin nombre.\n\nNingún vecino, cartero ni curioso puede adivinar qué contiene.\n\n## 5. Delivery: tres opciones discretas\n\n- **A domicilio**: llega como cualquier paquete de e-commerce.\n- **A trabajo**: si preferís recibirlo en oficina, lo acordamos (sin problema).\n- **Retiro en tienda**: pagás online, vas a Herrera 875, das el código, te vas. Cero interacción pública.\n\n## 6. Datos de tarjeta\n\nNosotros **nunca vemos** el número completo de tu tarjeta. Pagopar procesa y guarda solo los últimos 4 dígitos. Cumplimos estándar PCI-DSS.\n\n## 7. Datos personales\n\n- **Nunca** vendemos ni compartimos tu información con terceros.\n- **No enviamos** correspondencia física a tu domicilio (promos, catálogos) sin tu consentimiento explícito.\n- Tu email solo recibe confirmaciones de pedido — a menos que te suscribas al newsletter voluntariamente.\n\n## 8. Email: asunto genérico\n\nLos emails que te mandamos usan asuntos neutros:\n- \"Confirmación de pedido #12345\"\n- \"Tu pedido está en camino\"\n- \"Listo para retirar\"\n\nNada explícito en el asunto. Solo al abrir ves el detalle.\n\n## 9. Si compartís dispositivo o email\n\n- **Cuenta dedicada**: recomendamos crear email separado (gmail, protonmail) solo para compras discretas.\n- **Navegación privada**: Ctrl+Shift+N en Chrome/Firefox evita que quede historial.\n- **WhatsApp**: si usás WhatsApp familiar, mejor llamanos vía Signal o email desde cuenta separada.\n\n## 10. Tu derecho a ser olvidado\n\nPodés pedir que borremos tu cuenta y todos tus datos en cualquier momento. Te confirmamos el borrado por email en 72hs (conservamos solo lo que exige la ley para facturación: datos mínimos del pedido por 5 años).\n\n## Nuestro compromiso\n\nSi alguna vez fallamos en la discreción prometida, podés pedir el reembolso total del pedido sin preguntas. Es nuestro compromiso.\n\n¿Dudas sobre privacidad? Escribinos. Estamos acá para escucharte.\n",
   "nexa-paraguay:es:abrir-cuenta-bancaria-paraguay": "---\ntitle: \"La verdad sobre abrir una cuenta bancaria en Paraguay\"\nslug: \"abrir-cuenta-bancaria-paraguay\"\ndate: \"2026-04-17\"\nauthor: \"Nexa Paraguay\"\ncategory: \"Banking\"\nexcerpt: \"Por qué es el paso más difícil y cómo se resuelve profesionalmente.\"\nreadingMinutes: 7\ndraft: false\n---\n\n> **Nota:** Este artículo está listo para traducción profesional a NL/EN/DE antes del lanzamiento.\n\n## Introducción\n\nPor qué es el paso más difícil y cómo se resuelve profesionalmente.\n\n## Qué cubre este artículo\n\n- Contexto y marco del tema\n- Proceso paso a paso\n- Qué esperar realmente (sin optimismo de marketing)\n- Errores comunes que evitamos a nuestros clientes\n- Recursos y próximos pasos\n\n## Contexto\n\nEste borrador se genera a partir de la documentación interna de Nexa Paraguay.\nAmpliar antes de publicar con datos concretos, ejemplos reales y citas del equipo técnico.\n\n## Proceso paso a paso\n\n1. **Evaluación inicial.** Diagnóstico honesto: qué se puede, qué no.\n2. **Validación documental.** Apostillas, traducciones, requisitos consulares.\n3. **Jornada operativa.** La logística coordinada del día en Paraguay.\n4. **Post-ejecución.** Los 45–60 días siguientes y qué hacemos por usted.\n5. **Entrega y seguimiento.** Documentos finales y cómo le acompañamos.\n\n## Errores comunes\n\n- Subestimar los tiempos de emisión gubernamental (45–60 días).\n- No legalizar apostillas en origen antes de viajar.\n- Elegir la estructura societaria sin análisis fiscal comparativo.\n- Confundir \"gestoría\" con \"sistema integral\".\n\n## Próximos pasos\n\nSi está evaluando Paraguay seriamente, la mejor manera de avanzar es una\nconsulta gratuita de 30 minutos. La hacemos en neerlandés, inglés, alemán o\nespañol — sin compromiso.\n\n**[Agendar consulta gratuita](/s/es/nexa-paraguay/contacto)**\n",
+  "nexa-paraguay:es:apertura-cuenta-bancaria-paraguay": "---\ntitle: \"Apertura de Cuenta Bancaria en Paraguay para Extranjeros\"\ndate: 2024-03-20\nauthor: \"Nexa Paraguay\"\ncategory: \"Banca\"\nexcerpt: \"Guía práctica para abrir cuentas bancarias personales y empresariales en Paraguay. Requisitos, bancos recomendados y consejos prácticos.\"\ncoverImage: \"/sites/nexa-paraguay/images/blog/banca.jpg\"\n---\n\n# Apertura de Cuenta Bancaria en Paraguay para Extranjeros\n\nEl sistema bancario paraguayo ha evolucionado significativamente en los últimos años, ofreciendo servicios modernos y competitivos para residentes y no residentes. Abrir una cuenta bancaria es un paso esencial para establecerse en el país.\n\n## Tipos de Cuentas Disponibles\n\n### Cuentas en Guaraníes (PYG)\n- Moneda local\n- Menores costos de transacción nacional\n- Ideal para operaciones locales\n\n### Cuentas en Dólares (USD)\n- Protección contra inflación\n- Ideal para ahorro e inversión\n- Recomendada para extranjeros\n\n### Cuentas en Reales (BRL)\n- Útil para comercio con Brasil\n- Menor costo de cambio\n\n## Bancos Principales en Paraguay\n\n### Banco Continental\n- Mayor banco privado del país\n- Excelente plataforma digital\n- Buena atención a empresas\n\n### Banco Itaú Paraguay\n- Parte del grupo brasileño\n- Fuerte en comercio internacional\n- Buena red de sucursales\n\n### Banco Basa\n- Tradicional y conservador\n- Excelente para grandes empresas\n- Servicios de private banking\n\n### Banco Atlas\n- Enfocado en pymes\n- Innovador en productos digitales\n- Buena opción para startups\n\n### Banco Sudameris\n- Creciente presencia internacional\n- Fuerte en comercio exterior\n\n## Requisitos para Abrir Cuenta\n\n### Cuenta Personal (con Residencia)\n1. Cédula de identidad paraguaya\n2. RUC (Registro Único de Contribuyente)\n3. Comprobante de domicilio\n4. Referencias comerciales o laborales\n5. Carta de trabajo o declaración de renta\n\n### Cuenta Empresarial\n1. Escritura de constitución de sociedad\n2. RUC de la empresa\n3. Cédulas de socios/directores\n4. Acta de asamblea autorizando apertura\n5. Contrato social vigente\n6. Estados financieros (empresas existentes)\n\n### Cuenta para No Residentes\n- Pasaporte vigente\n- Referencias bancarias internacionales\n- Comprobante de origen de fondos\n- Entrevista personal obligatoria\n- Depósito inicial más alto\n\n## Proceso de Apertura\n\n### Paso 1: Elegir el Banco\nConsidera:\n- Tarifas de mantenimiento\n- Costos de transferencias internacionales\n- Calidad de banca digital\n- Proximidad de sucursales\n\n### Paso 2: Reunir Documentación\nRevisa los requisitos específicos del banco elegido.\n\n### Paso 3: Entrevista Bancaria\n- Evaluación de perfil de riesgo\n- Conocimiento del cliente (KYC)\n- Verificación de documentos\n\n### Paso 4: Firma de Contratos\n- Contrato de cuenta\n- Reglamento de operaciones\n- Términos de servicios digitales\n\n### Paso 5: Depósito Inicial y Activación\n- Depósito inicial (varía según tipo de cuenta)\n- Recibo de tarjeta de débito\n- Activación de banca en línea\n\n## Tiempos de Apertura\n\n| Tipo de Cuenta | Tiempo Estimado |\n|----------------|------------------|\n| Personal (residente) | 24-72 horas |\n| Empresarial | 3-7 días hábiles |\n| No residente | 1-2 semanas |\n| Cuenta VIP/Empresarial | 1-2 días |\n\n## Costos Típicos\n\n| Concepto | Costo Aproximado |\n|----------|-------------------|\n| Apertura de cuenta | Gratis - USD 50 |\n| Mantenimiento mensual | USD 3 - 15 |\n| Transferencias nacionales | USD 1 - 5 |\n| Transferencias internacionales | USD 25 - 75 |\n| Tarjeta de débito | USD 5 - 15/año |\n| Tarjeta de crédito | USD 20 - 100/año |\n\n## Consideraciones para Extranjeros\n\n### Ventajas\n- Banca estable y regulada\n- Depósitos asegurados (hasta cierto monto)\n- Posibilidad de cuentas en dólares\n- Transferencias SWIFT disponibles\n\n### Desafíos\n- Proceso más complejo sin residencia\n- Requiere presencia personal\n- Límites en montos según perfil\n\n## Recomendación Nexa Paraguay\n\nPara una apertura exitosa:\n\n1. **Obtén tu residencia primero**: Facilita enormemente el proceso\n2. **Prepara documentación completa**: Evita retrasos\n3. **Evalúa múltiples bancos**: Compara servicios y costos\n4. **Considera cuentas en dólares**: Mejor para extranjeros\n5. **Activa todos los servicios digitales**: Banca online, app móvil\n\n## Nuestro Servicio de Acompañamiento\n\nIncluimos en nuestros programas:\n- Preparación de documentación\n- Agendamiento de entrevistas bancarias\n- Acompañamiento en firma de documentos\n- Coordinación con oficiales de cuenta\n- Activación de servicios digitales\n\n---\n\n*¿Necesitas ayuda con la apertura de tu cuenta bancaria? Es parte de nuestro servicio integral.*\n",
   "nexa-paraguay:es:checklist-documentos-establecerse": "---\ntitle: \"Documentos necesarios para establecerse en Paraguay: checklist completo\"\nslug: \"checklist-documentos-establecerse\"\ndate: \"2026-04-17\"\nauthor: \"Nexa Paraguay\"\ncategory: \"Process\"\nexcerpt: \"Apostillas, traducciones, certificados — qué traer, qué hacer allá.\"\nreadingMinutes: 7\ndraft: false\n---\n\n> **Nota:** Este artículo está listo para traducción profesional a NL/EN/DE antes del lanzamiento.\n\n## Introducción\n\nApostillas, traducciones, certificados — qué traer, qué hacer allá.\n\n## Qué cubre este artículo\n\n- Contexto y marco del tema\n- Proceso paso a paso\n- Qué esperar realmente (sin optimismo de marketing)\n- Errores comunes que evitamos a nuestros clientes\n- Recursos y próximos pasos\n\n## Contexto\n\nEste borrador se genera a partir de la documentación interna de Nexa Paraguay.\nAmpliar antes de publicar con datos concretos, ejemplos reales y citas del equipo técnico.\n\n## Proceso paso a paso\n\n1. **Evaluación inicial.** Diagnóstico honesto: qué se puede, qué no.\n2. **Validación documental.** Apostillas, traducciones, requisitos consulares.\n3. **Jornada operativa.** La logística coordinada del día en Paraguay.\n4. **Post-ejecución.** Los 45–60 días siguientes y qué hacemos por usted.\n5. **Entrega y seguimiento.** Documentos finales y cómo le acompañamos.\n\n## Errores comunes\n\n- Subestimar los tiempos de emisión gubernamental (45–60 días).\n- No legalizar apostillas en origen antes de viajar.\n- Elegir la estructura societaria sin análisis fiscal comparativo.\n- Confundir \"gestoría\" con \"sistema integral\".\n\n## Próximos pasos\n\nSi está evaluando Paraguay seriamente, la mejor manera de avanzar es una\nconsulta gratuita de 30 minutos. La hacemos en neerlandés, inglés, alemán o\nespañol — sin compromiso.\n\n**[Agendar consulta gratuita](/s/es/nexa-paraguay/contacto)**\n",
+  "nexa-paraguay:es:comparativa-fiscal-paraguay-vs-uruguay": "---\ntitle: \"Comparativa Fiscal 2024: Paraguay vs Uruguay para Empresas\"\ndate: 2024-04-08\nauthor: \"Nexa Paraguay\"\ncategory: \"Fiscalidad\"\nexcerpt: \"Análisis detallado de las diferencias fiscales entre Paraguay y Uruguay para empresas e inversores. Descubre cuál es la mejor opción para tu negocio.\"\ncoverImage: \"/sites/nexa-paraguay/images/blog/comparativa-fiscal.jpg\"\n---\n\n# Comparativa Fiscal 2024: Paraguay vs Uruguay para Empresas\n\nLa elección del país para establecer una empresa es una decisión crucial que impacta directamente en la rentabilidad y crecimiento del negocio. Dos de los destinos más atractivos de Sudamérica son Paraguay y Uruguay, cada uno con sus propias ventajas fiscales.\n\n## Resumen Comparativo Rápido\n\n| Aspecto | Paraguay | Uruguay |\n|---------|----------|---------|\n| IRP (Impuesto a la Renta Empresaria) | 10% | 25% |\n| IVA | 10% | 22% |\n| Patrimonio | 0% | 0.7% - 1.5% |\n| Dividendos | 0% (si reinvertidos) | 7% - 12% |\n| Maquila (Zona Franca) | Exención total | Beneficios parciales|\n\n## Paraguay: El Paraíso Fiscal Legal de Sudamérica\n\n### Ventajas Fiscales Paraguay\n\n1. **IRP del 10%**: Una de las tasas más bajas del continente\n2. **IVA del 10%**: Menor carga impositiva al consumo\n3. **Zona Franca Paraguay**: Exención total para empresas exportadoras\n4. **No cobro de impuesto al patrimonio**: Tus activos no generan carga fiscal\n5. **Exención de dividendos**: Si reinviertes utilidades, no pagas impuestos adicionales\n\n### Caso de Éxito Paraguay\n\nUna empresa de software que factura USD 1 millón anual:\n- Impuesto a la renta: USD 100,000\n- Dividendos reinvertidos: USD 0\n- IVA (si aplica): 10% sobre consumo\n\n## Uruguay: Estabilidad con Mayor Carga Fiscal\n\n### Ventajas Fiscales Uruguay\n\n1. **Estabilidad jurídica**: Sistema legal robusto y predecible\n2. **Residencia fiscal fácil**: Requisitos claros y accesibles\n3. **Zona Franca Uruguay**: Beneficios para operaciones offshore\n4. **Convenios de doble tributación**: Más extensos que Paraguay\n\n### Caso de Éxito Uruguay\n\nMisma empresa de software (USD 1 millón):\n- Impuesto a la renta: USD 250,000\n- Dividendos: USD 70,000 - 120,000 adicionales\n- IVA: 22% sobre consumo\n\n## Análisis por Tipo de Negocio\n\n### Empresas de Tecnología y Servicios\n**Ganador: Paraguay**\n\nLa combinación de IRP del 10% y exención de dividendos hace que Paraguay sea ideal para startups y empresas tech.\n\n### Trading y E-commerce\n**Ganador: Paraguay (Zona Franca)**\n\nLa Zona Franca paraguaya ofrece beneficios superiores para empresas de comercio internacional.\n\n### Consultoría Profesional\n**Ganador: Paraguay**\n\nMenor carga fiscal y facilidades para facturación internacional.\n\n## Consideraciones No Fiscales\n\n### Paraguay\n- ✅ Menor costo de vida\n- ✅ Mercado laboral en crecimiento\n- ✅ Ubicación estratégica (centro de Sudamérica)\n- ⚠️ Menor desarrollo financiero que Uruguay\n\n### Uruguay\n- ✅ Sistema bancario más desarrollado\n- ✅ Mayor aceptación internacional\n- ✅ Educación y salud de alta calidad\n- ⚠️ Costo de vida 40-60% mayor que Paraguay\n\n## Conclusión\n\nPara la mayoría de empresas, **Paraguay ofrece ventajas fiscales significativas** que pueden representar ahorros de 50-70% comparado con Uruguay. Sin embargo, la elección debe considerar también factores como:\n\n- Mercado objetivo\n- Proveedores y cadena de valor\n- Necesidades de talento humano\n- Proyección de crecimiento\n\n## Recomendación de Nexa Paraguay\n\nSi tu prioridad es **optimización fiscal y costos operativos**, Paraguay es la opción clara.\n\nSi necesitas **máxima estabilidad jurídica y reconocimiento internacional inmediato**, considera Uruguay.\n\n---\n\n*¿Necesitas ayuda para decidir? Agenda una consulta estratégica gratuita con nuestros asesores.*\n",
+  "nexa-paraguay:es:comprar-propiedades-paraguay-extranjeros": "---\ntitle: \"Guía para Extranjeros: Cómo Comprar Propiedades en Paraguay\"\ndate: 2024-03-28\nauthor: \"Nexa Paraguay\"\ncategory: \"Inversión Inmobiliaria\"\nexcerpt: \"Todo el proceso legal y práctico para adquirir inmuebles en Paraguay siendo extranjero. Desde la búsqueda hasta la escrituración.\"\ncoverImage: \"/sites/nexa-paraguay/images/blog/propiedades.jpg\"\n---\n\n# Guía para Extranjeros: Cómo Comprar Propiedades en Paraguay\n\nEl mercado inmobiliario paraguayo se ha posicionado como uno de los más atractivos de Sudamérica para inversores extranjeros. Con precios competitivos, alta rentabilidad y un marco legal favorable, comprar propiedades en Paraguay es más simple de lo que imaginas.\n\n## ¿Pueden los Extranjeros Comprar Propiedad en Paraguay?\n\n**Sí, absolutamente.** La Constitución paraguaya garantiza a extranjeros los mismos derechos de propiedad que a nacionales, con una sola excepción: la propiedad rural en zonas de frontera (50km), que requiere autorización especial.\n\n## Requisitos para Comprar\n\n### Si ya tienes Residencia Paraguaya\n- Cédula de identidad vigente\n- RUC (Registro Único de Contribuyente)\n- Solvencia fiscal\n\n### Si no tienes Residencia\n- Pasaporte vigente\n- Representante legal local (recomendado)\n- Poder notarial (si compras a distancia)\n\n## El Proceso de Compra\n\n### Paso 1: Búsqueda y Due Diligence\n- Identificación de propiedades según objetivo (inversión, vivienda, comercial)\n- Verificación de títulos de propiedad\n- Confirmación de no existencia de gravámenes\n- Revisión de impuestos municipales al día\n\n### Paso 2: Negociación y Reserva\n- Negociación de precio y condiciones\n- Firma de pre-contrato o reserva\n- Depósito de garantía (típicamente 10%)\n\n### Paso 3: Escrituración\n- Firma de escritura pública ante escribano\n- Transferencia de fondos\n- Registro de la propiedad\n\n### Paso 4: Posescrituración\n- Registro en Dirección General de Registros Públicos\n- Cambio de titularidad en servicios\n- Obtención de plano aprobado (si aplica)\n\n## Costos Asociados\n\n| Concepto | Porcentaje | Notas |\n|----------|------------|-------|\n| Impuesto Inmobiliario | 0.5% - 1% anual | Sobre valor fiscal |\n| Impuesto a la Renta (venta) | 10% | Solo sobre ganancia de capital |\n| Impuesto de Sellos | 0.5% - 2% | En escrituración |\n| Honorarios Escribano | 1% - 1.5% | Negociable |\n| Registro de Propiedad | 0.5% - 1% | Sobre valor de escritura |\n| Comisión Corretaje | 3% - 5% | Típicamente paga vendedor |\n\n## Zonas Más Atractivas para Inversión\n\n### Asunción y Gran Asunción\n- **Villa Morra**: Barrio premium, alta valorización\n- **Las Carmelitas**: Seguridad y exclusividad\n- **Mburucuyá**: Zona residencial en crecimiento\n- **San Lorenzo**: Precios accesibles con buena rentabilidad\n\n### Zonas Turísticas\n- **San Bernardino**: Lago Ypacaraí, alta demanda turística\n- **Areguá**: Capital del artesanato, creciente interés\n- **Ciudad del Este**: Centro comercial binacional\n\n### Agro\n- **Alto Paraná**: Tierra productiva para soja\n- **San Pedro**: Precios competitivos, alto rendimiento\n- **Caaguazú**: Creciente demanda agropecuaria\n\n## Rentabilidad Esperada\n\n### Inversión Residencial (Alquiler)\n- **Retorno anual**: 6% - 10% en dólares\n- **Plusvalía**: 8% - 12% anual en zonas premium\n- **Payback**: 10-15 años\n\n### Inversión Comercial\n- **Retorno anual**: 8% - 15%\n- **Más alto riesgo, más alta rentabilidad**\n\n### Inversión Agropecuaria\n- **Retorno anual**: 10% - 20%\n- **Requiere conocimiento técnico**\n\n## Errores Comunes a Evitar\n\n### 1. No Verificar Títulos\nSiempre contrata un abogado para hacer due diligence completa.\n\n### 2. Ignorar Impuestos Municipales\nVerifica que no haya deudas acumuladas que puedan afectar la compra.\n\n### 3. Comprar sin Ver el Inmueble\nSi no puedes viajar, contrata un representante de confianza.\n\n### 4. No Considerar Costos de Mantenimiento\nLos costos de mantenimiento pueden representar 1-3% del valor anual.\n\n## Servicios de Nexa Paraguay\n\nOfrecemos acompañamiento integral en la compra de propiedades:\n\n1. **Búsqueda estratégica** según tu perfil de inversión\n2. **Due diligence legal completa**\n3. **Negociación** con vendedores y corredores\n4. **Acompañamiento en escrituración**\n5. **Gestión post-compra** (servicios, alquileres, etc.)\n\n---\n\n*¿Interesado en invertir en propiedades paraguayas? Agenda una consulta con nuestro equipo inmobiliario.*\n",
   "nexa-paraguay:es:constituir-empresa-paraguay": "---\ntitle: \"Constituir una empresa en Paraguay: tipos societarios y pasos\"\nslug: \"constituir-empresa-paraguay\"\ndate: \"2026-04-17\"\nauthor: \"Nexa Paraguay\"\ncategory: \"Company\"\nexcerpt: \"EAS vs. SA. Cuándo usar qué, y qué documenta realmente cada estructura.\"\nreadingMinutes: 7\ndraft: false\n---\n\n> **Nota:** Este artículo está listo para traducción profesional a NL/EN/DE antes del lanzamiento.\n\n## Introducción\n\nEAS vs. SA. Cuándo usar qué, y qué documenta realmente cada estructura.\n\n## Qué cubre este artículo\n\n- Contexto y marco del tema\n- Proceso paso a paso\n- Qué esperar realmente (sin optimismo de marketing)\n- Errores comunes que evitamos a nuestros clientes\n- Recursos y próximos pasos\n\n## Contexto\n\nEste borrador se genera a partir de la documentación interna de Nexa Paraguay.\nAmpliar antes de publicar con datos concretos, ejemplos reales y citas del equipo técnico.\n\n## Proceso paso a paso\n\n1. **Evaluación inicial.** Diagnóstico honesto: qué se puede, qué no.\n2. **Validación documental.** Apostillas, traducciones, requisitos consulares.\n3. **Jornada operativa.** La logística coordinada del día en Paraguay.\n4. **Post-ejecución.** Los 45–60 días siguientes y qué hacemos por usted.\n5. **Entrega y seguimiento.** Documentos finales y cómo le acompañamos.\n\n## Errores comunes\n\n- Subestimar los tiempos de emisión gubernamental (45–60 días).\n- No legalizar apostillas en origen antes de viajar.\n- Elegir la estructura societaria sin análisis fiscal comparativo.\n- Confundir \"gestoría\" con \"sistema integral\".\n\n## Próximos pasos\n\nSi está evaluando Paraguay seriamente, la mejor manera de avanzar es una\nconsulta gratuita de 30 minutos. La hacemos en neerlandés, inglés, alemán o\nespañol — sin compromiso.\n\n**[Agendar consulta gratuita](/s/es/nexa-paraguay/contacto)**\n",
   "nexa-paraguay:es:costo-de-vida-paraguay-europeos": "---\ntitle: \"Costo de vida en Paraguay: guía realista para europeos\"\nslug: \"costo-de-vida-paraguay-europeos\"\ndate: \"2026-04-17\"\nauthor: \"Nexa Paraguay\"\ncategory: \"Life\"\nexcerpt: \"Números concretos: vivienda, salud, educación, servicios — desde la perspectiva europea.\"\nreadingMinutes: 7\ndraft: false\n---\n\n> **Nota:** Este artículo está listo para traducción profesional a NL/EN/DE antes del lanzamiento.\n\n## Introducción\n\nNúmeros concretos: vivienda, salud, educación, servicios — desde la perspectiva europea.\n\n## Qué cubre este artículo\n\n- Contexto y marco del tema\n- Proceso paso a paso\n- Qué esperar realmente (sin optimismo de marketing)\n- Errores comunes que evitamos a nuestros clientes\n- Recursos y próximos pasos\n\n## Contexto\n\nEste borrador se genera a partir de la documentación interna de Nexa Paraguay.\nAmpliar antes de publicar con datos concretos, ejemplos reales y citas del equipo técnico.\n\n## Proceso paso a paso\n\n1. **Evaluación inicial.** Diagnóstico honesto: qué se puede, qué no.\n2. **Validación documental.** Apostillas, traducciones, requisitos consulares.\n3. **Jornada operativa.** La logística coordinada del día en Paraguay.\n4. **Post-ejecución.** Los 45–60 días siguientes y qué hacemos por usted.\n5. **Entrega y seguimiento.** Documentos finales y cómo le acompañamos.\n\n## Errores comunes\n\n- Subestimar los tiempos de emisión gubernamental (45–60 días).\n- No legalizar apostillas en origen antes de viajar.\n- Elegir la estructura societaria sin análisis fiscal comparativo.\n- Confundir \"gestoría\" con \"sistema integral\".\n\n## Próximos pasos\n\nSi está evaluando Paraguay seriamente, la mejor manera de avanzar es una\nconsulta gratuita de 30 minutos. La hacemos en neerlandés, inglés, alemán o\nespañol — sin compromiso.\n\n**[Agendar consulta gratuita](/s/es/nexa-paraguay/contacto)**\n",
+  "nexa-paraguay:es:emprender-paraguay-oportunidades-2024": "---\ntitle: \"Emprender en Paraguay: Oportunidades de Negocio 2024\"\ndate: 2024-03-10\nauthor: \"Nexa Paraguay\"\ncategory: \"Emprendimiento\"\nexcerpt: \"Descubre las sectores más prometedores para emprender en Paraguay. Análisis de mercado, oportunidades y casos de éxito.\"\ncoverImage: \"/sites/nexa-paraguay/images/blog/emprender.jpg\"\n---\n\n# Emprender en Paraguay: Oportunidades de Negocio 2024\n\nParaguay se ha convertido en un destino emergente para emprendedores de toda Latinoamérica. Con un ambiente de negocios favorable, costos competitivos y una economía en crecimiento, las oportunidades son abundantes para quienes saben dónde buscar.\n\n## Por Qué Emprender en Paraguay\n\n### Ventajas del Ecosistema Paraguayo\n\n1. **Régimen Fiscal Competitivo**\n   - 10% de impuesto a la renta empresarial\n   - 10% de IVA\n   - Exenciones para zonas francas\n\n2. **Costos Operativos Bajos**\n   - 40-60% más barato que Buenos Aires o Montevideo\n   - Mano de obra calificada a costos competitivos\n   - Alquileres accesibles\n\n3. **Ubicación Estratégica**\n   - Centro de Sudamérica\n   - Acceso a MERCOSUR (mercado de 300M personas)\n   - Cercanía a Brasil y Argentina\n\n4. **Estabilidad Macroeconómica**\n   - Crecimiento sostenido del PBI\n   - Inflación controlada\n   - Sistema cambiario estable\n\n## Sectores Más Prometedores\n\n### 1. Tecnología y Software\n**Oportunidad: ★★★★★**\n\nParaguay está viviendo un boom tecnológico:\n- Desarrollo de software para exportación\n- Fintech y servicios financieros digitales\n- E-commerce y logística\n- Agrotech\n\n**Caso de Éxito**: Una startup de software paraguaya fue adquirida por USD 10M en 2023.\n\n### 2. Agroindustria y Agrotech\n**Oportunidad: ★★★★★**\n\nParaguay es potencia agrícola:\n- 4to exportador mundial de soja\n- Producción de carne de calidad\n- Tecnificación del campo\n- Exportación de alimentos procesados\n\n**Oportunidades específicas**:\n- Sistemas de riego inteligente\n- Logística agrícola\n- Procesamiento de granos\n- Agricultura orgánica\n\n### 3. Energías Renovables\n**Oportunidad: ★★★★☆**\n\n100% de energía eléctrica es renovable (Itaipú + Yacyretá):\n- Venta de energía limpia\n- Instalación de paneles solares\n- Consultoría energética\n- Minería de Bitcoin (energía barata)\n\n### 4. Turismo y Hospitalidad\n**Oportunidad: ★★★★☆**\n\nTurismo en crecimiento acelerado:\n- Ecoturismo\n- Turismo de eventos\n- Hoteles boutique\n- Experiencias locales únicas\n\nDestinos emergentes:\n- Saltos del Monday\n- Lago Ypacaraí\n- Misiones Jesuíticas\n- Chaco paraguayo\n\n### 5. Sector Inmobiliario\n**Oportunidad: ★★★★☆**\n\nMercado inmobiliario dinámico:\n- Construcción residencial\n- Desarrollo de oficinas\n- Propiedades industriales\n- Coworking spaces\n\nRentabilidades atractivas:\n- 6-10% anual en alquileres\n- Plusvalía de 8-12% anual\n\n### 6. Servicios Profesionales B2B\n**Oportunidad: ★★★★☆**\n\nDemanda creciente de:\n- Consultoría de negocios\n- Marketing digital\n- Servicios legales especializados\n- Contabilidad internacional\n- Recursos humanos\n\n### 7. Salud y Bienestar\n**Oportunidad: ★★★☆☆**\n\nSector con alto potencial:\n- Medicina prepaga\n- Centros de bienestar\n- Nutrición deportiva\n- Turismo médico\n\n### 8. Educación y Capacitación\n**Oportunidad: ★★★☆☆**\n\nDemanda constante:\n- Institutos de inglés\n- Cursos técnicos\n- Capacitación corporativa\n- Edtech\n\n## Inversión Requerida por Sector\n\n| Sector | Inversión Mínima | ROI Esperado |\n|--------|-------------------|----------------|\n| Tecnología | USD 5,000 - 20,000 | 30-50% |\n| Agroindustria | USD 50,000 - 200,000 | 15-25% |\n| Turismo | USD 30,000 - 100,000 | 20-30% |\n| Inmobiliario | USD 100,000+ | 12-20% |\n| Servicios B2B | USD 2,000 - 10,000 | 40-60% |\n\n## Pasos para Emprender en Paraguay\n\n### 1. Investigación de Mercado\n- Análisis de competencia\n- Estudio de demanda\n- Identificación de nicho\n\n### 2. Constitución Legal\n- Elección de tipo de sociedad\n- Trámites de registro\n- Obtención de RUC\n\n### 3. Apertura de Cuenta Bancaria\n- Selección de banco\n- Gestión de documentación\n- Activación de servicios\n\n### 4. Cumplimiento Fiscal\n- Inscripción en SET\n- Configuración de facturación\n- Planificación fiscal\n\n### 5. Operaciones\n- Contratación de personal\n- Locación de oficinas/instalaciones\n- Marketing y lanzamiento\n\n## Apoyo Gubernamental\n\n### Incentivos Disponibles\n- **Zona Franca Paraguay**: Exención fiscal total\n- **Maquila**: Beneficios para exportadores\n- **Sistema de drawback**: Devolución de impuestos\n- **Inversiones en turismo**: Beneficios específicos\n\n### Instituciones de Apoyo\n- **REDIEX**: Promoción de exportaciones\n- **MIC**: Ministerio de Industria y Comercio\n- **Banco Central**: Regulación y estabilidad\n- **Cámara de Comercio**: Networking y apoyo\n\n## Casos de Éxito Recientes\n\n### Startup Tech (SaaS)\nInversión inicial: USD 15,000\nFacturación año 3: USD 500,000\nEmpleados: 25 personas\n\n### Exportadora Agropecuaria\nInversión inicial: USD 80,000\nExportación anual: USD 2M\nMercados: 8 países\n\n### Hotel Boutique\nInversión inicial: USD 120,000\nOcupación: 75% promedio anual\nROI: 22% anual\n\n## Recomendaciones de Nexa Paraguay\n\n1. **Comienza con residencia**: Facilita todos los trámites empresariales\n2. **Asesórate desde el inicio**: Un buen contador y abogado valen su peso en oro\n3. **Entiende la cultura**: Las relaciones personales son fundamentales\n4. **Sé paciente**: Los trámites pueden ser lentos, pero son seguros\n5. **Piensa en grande**: Paraguay es una plataforma para Sudamérica\n\n## Nuestros Servicios para Emprendedores\n\n- Asesoría en elección de sector\n- Constitución de sociedades\n- Planificación fiscal\n- Apertura de cuentas bancarias\n- Permisos y licencias\n- Contratación de personal\n- Networking y contactos\n\n---\n\n*¿Tienes una idea de negocio? Agenda una consulta estratégica gratuita.*\n",
   "nexa-paraguay:es:entorno-fiscal-paraguay-simple": "---\ntitle: \"Entorno fiscal de Paraguay: lo esencial explicado simple\"\nslug: \"entorno-fiscal-paraguay-simple\"\ndate: \"2026-04-17\"\nauthor: \"Nexa Paraguay\"\ncategory: \"Tax\"\nexcerpt: \"Sistema territorial, impuesto del 10%, IVA, retenciones — qué significa para usted.\"\nreadingMinutes: 7\ndraft: false\n---\n\n> **Nota:** Este artículo está listo para traducción profesional a NL/EN/DE antes del lanzamiento.\n\n## Introducción\n\nSistema territorial, impuesto del 10%, IVA, retenciones — qué significa para usted.\n\n## Qué cubre este artículo\n\n- Contexto y marco del tema\n- Proceso paso a paso\n- Qué esperar realmente (sin optimismo de marketing)\n- Errores comunes que evitamos a nuestros clientes\n- Recursos y próximos pasos\n\n## Contexto\n\nEste borrador se genera a partir de la documentación interna de Nexa Paraguay.\nAmpliar antes de publicar con datos concretos, ejemplos reales y citas del equipo técnico.\n\n## Proceso paso a paso\n\n1. **Evaluación inicial.** Diagnóstico honesto: qué se puede, qué no.\n2. **Validación documental.** Apostillas, traducciones, requisitos consulares.\n3. **Jornada operativa.** La logística coordinada del día en Paraguay.\n4. **Post-ejecución.** Los 45–60 días siguientes y qué hacemos por usted.\n5. **Entrega y seguimiento.** Documentos finales y cómo le acompañamos.\n\n## Errores comunes\n\n- Subestimar los tiempos de emisión gubernamental (45–60 días).\n- No legalizar apostillas en origen antes de viajar.\n- Elegir la estructura societaria sin análisis fiscal comparativo.\n- Confundir \"gestoría\" con \"sistema integral\".\n\n## Próximos pasos\n\nSi está evaluando Paraguay seriamente, la mejor manera de avanzar es una\nconsulta gratuita de 30 minutos. La hacemos en neerlandés, inglés, alemán o\nespañol — sin compromiso.\n\n**[Agendar consulta gratuita](/s/es/nexa-paraguay/contacto)**\n",
   "nexa-paraguay:es:gestoria-vs-equipo-profesional": "---\ntitle: \"La diferencia entre una gestoría y un equipo profesional\"\nslug: \"gestoria-vs-equipo-profesional\"\ndate: \"2026-04-17\"\nauthor: \"Nexa Paraguay\"\ncategory: \"About\"\nexcerpt: \"No es lo mismo un facilitador administrativo que un sistema integral con capital relacional.\"\nreadingMinutes: 7\ndraft: false\n---\n\n> **Nota:** Este artículo está listo para traducción profesional a NL/EN/DE antes del lanzamiento.\n\n## Introducción\n\nNo es lo mismo un facilitador administrativo que un sistema integral con capital relacional.\n\n## Qué cubre este artículo\n\n- Contexto y marco del tema\n- Proceso paso a paso\n- Qué esperar realmente (sin optimismo de marketing)\n- Errores comunes que evitamos a nuestros clientes\n- Recursos y próximos pasos\n\n## Contexto\n\nEste borrador se genera a partir de la documentación interna de Nexa Paraguay.\nAmpliar antes de publicar con datos concretos, ejemplos reales y citas del equipo técnico.\n\n## Proceso paso a paso\n\n1. **Evaluación inicial.** Diagnóstico honesto: qué se puede, qué no.\n2. **Validación documental.** Apostillas, traducciones, requisitos consulares.\n3. **Jornada operativa.** La logística coordinada del día en Paraguay.\n4. **Post-ejecución.** Los 45–60 días siguientes y qué hacemos por usted.\n5. **Entrega y seguimiento.** Documentos finales y cómo le acompañamos.\n\n## Errores comunes\n\n- Subestimar los tiempos de emisión gubernamental (45–60 días).\n- No legalizar apostillas en origen antes de viajar.\n- Elegir la estructura societaria sin análisis fiscal comparativo.\n- Confundir \"gestoría\" con \"sistema integral\".\n\n## Próximos pasos\n\nSi está evaluando Paraguay seriamente, la mejor manera de avanzar es una\nconsulta gratuita de 30 minutos. La hacemos en neerlandés, inglés, alemán o\nespañol — sin compromiso.\n\n**[Agendar consulta gratuita](/s/es/nexa-paraguay/contacto)**\n",
+  "nexa-paraguay:es:guia-completa-residencia-paraguay-2024": "---\ntitle: \"Guía Completa: Cómo Obtener la Residencia en Paraguay en 2024\"\ndate: 2024-04-15\nauthor: \"Nexa Paraguay\"\ncategory: \"Inmigración\"\nexcerpt: \"Todo lo que necesitas saber sobre el proceso de radicación en Paraguay, requisitos, plazos y consejos prácticos para una transición exitosa.\"\ncoverImage: \"/sites/nexa-paraguay/images/blog/residencia-2024.jpg\"\n---\n\n# Guía Completa: Cómo Obtener la Residencia en Paraguay en 2024\n\nParaguay se ha convertido en uno de los destinos más atractivos para expatriados, emprendedores e inversores de toda Latinoamérica y el mundo. Su crecimiento económico sostenido, régimen fiscal favorable y calidad de vida hacen de este país una opción ideal para establecer una nueva base de operaciones.\n\n## Requisitos Principales\n\nPara obtener la residencia en Paraguay, necesitarás:\n\n1. **Pasaporte vigente** con al menos 6 meses de validez\n2. **Certificado de antecedentes penales** de tu país de origen\n3. **Certificado de nacimiento** apostillado\n4. **Comprobante de solvencia económica**\n5. **Certificado médico** expedido en Paraguay\n\n## El Proceso Paso a Paso\n\n### Paso 1: Preparación Documental\nEl primer paso es reunir todos los documentos necesarios. Es crucial que estos documentos estén correctamente apostillados según el Convenio de La Haya.\n\n### Paso 2: Ingreso a Paraguay\nDeberás ingresar al país como turista y comenzar el proceso de radicación. Durante esta etapa, te recomendamos asesoría legal especializada.\n\n### Paso 3: Presentación de Expediente\nCon todos los documentos en orden, se presenta el expediente ante la Dirección General de Migraciones.\n\n### Paso 4: Aprobación y Cédula\nUna vez aprobada la residencia, podrás tramitar tu cédula de identidad paraguaya.\n\n## Tiempos Estimados\n\n- Preparación documental: 2-4 semanas\n- Tramitación en Paraguay: 4-8 semanas\n- Obtención de cédula: 1-2 semanas\n\n**Tiempo total estimado: 8-12 semanas**\n\n## Beneficios de la Residencia Paraguaya\n\n1. **Acceso al MERCOSUR** y libre circulación en países miembros\n2. **Régimen fiscal favorable** con impuestos competitivos\n3. **Posibilidad de constitución de sociedades** con facilidades únicas\n4. **Apertura de cuentas bancarias** sin complicaciones\n5. **Compra de propiedades** con los mismos derechos que nacionales\n\n## Consejos de Nexa Paraguay\n\nBasándonos en nuestra experiencia con más de 250 clientes:\n\n- **Planifica con anticipación**: El proceso requiere tiempo y preparación\n- **Asesórate con expertos**: Un error documental puede retrasar meses el proceso\n- **Conoce la cultura local**: Paraguay tiene una cultura empresarial única basada en relaciones personales\n- **Evalúa opciones de inversión**: El mercado inmobiliario paraguayo ofrece excelentes oportunidades\n\n## Próximos Pasos\n\n¿Listo para comenzar tu proceso de radicación? Agenda una consulta gratuita con nuestro equipo y descubre qué programa de Nexa Paraguay se adapta mejor a tus necesidades.\n\n---\n\n*Este artículo es informativo. Las regulaciones migratorias pueden cambiar. Consulta siempre con profesionales actualizados.*\n",
   "nexa-paraguay:es:mercado-inmobiliario-paraguay": "---\ntitle: \"Mercado inmobiliario paraguayo: panorama actual\"\nslug: \"mercado-inmobiliario-paraguay\"\ndate: \"2026-04-17\"\nauthor: \"Nexa Paraguay\"\ncategory: \"Market\"\nexcerpt: \"Precios por barrio en Asunción, rendimientos y riesgos — sin bullish retórica.\"\nreadingMinutes: 7\ndraft: false\n---\n\n> **Nota:** Este artículo está listo para traducción profesional a NL/EN/DE antes del lanzamiento.\n\n## Introducción\n\nPrecios por barrio en Asunción, rendimientos y riesgos — sin bullish retórica.\n\n## Qué cubre este artículo\n\n- Contexto y marco del tema\n- Proceso paso a paso\n- Qué esperar realmente (sin optimismo de marketing)\n- Errores comunes que evitamos a nuestros clientes\n- Recursos y próximos pasos\n\n## Contexto\n\nEste borrador se genera a partir de la documentación interna de Nexa Paraguay.\nAmpliar antes de publicar con datos concretos, ejemplos reales y citas del equipo técnico.\n\n## Proceso paso a paso\n\n1. **Evaluación inicial.** Diagnóstico honesto: qué se puede, qué no.\n2. **Validación documental.** Apostillas, traducciones, requisitos consulares.\n3. **Jornada operativa.** La logística coordinada del día en Paraguay.\n4. **Post-ejecución.** Los 45–60 días siguientes y qué hacemos por usted.\n5. **Entrega y seguimiento.** Documentos finales y cómo le acompañamos.\n\n## Errores comunes\n\n- Subestimar los tiempos de emisión gubernamental (45–60 días).\n- No legalizar apostillas en origen antes de viajar.\n- Elegir la estructura societaria sin análisis fiscal comparativo.\n- Confundir \"gestoría\" con \"sistema integral\".\n\n## Próximos pasos\n\nSi está evaluando Paraguay seriamente, la mejor manera de avanzar es una\nconsulta gratuita de 30 minutos. La hacemos en neerlandés, inglés, alemán o\nespañol — sin compromiso.\n\n**[Agendar consulta gratuita](/s/es/nexa-paraguay/contacto)**\n",
   "nexa-paraguay:es:por-que-europeos-miran-paraguay-2026": "---\ntitle: \"Por qué los europeos miran a Paraguay en 2026\"\nslug: \"por-que-europeos-miran-paraguay-2026\"\ndate: \"2026-04-17\"\nauthor: \"Nexa Paraguay\"\ncategory: \"Market\"\nexcerpt: \"Tasa del 10%, economía abierta, territorialidad — el marco completo para decidir.\"\nreadingMinutes: 7\ndraft: false\n---\n\n> **Nota:** Este artículo está listo para traducción profesional a NL/EN/DE antes del lanzamiento.\n\n## Introducción\n\nTasa del 10%, economía abierta, territorialidad — el marco completo para decidir.\n\n## Qué cubre este artículo\n\n- Contexto y marco del tema\n- Proceso paso a paso\n- Qué esperar realmente (sin optimismo de marketing)\n- Errores comunes que evitamos a nuestros clientes\n- Recursos y próximos pasos\n\n## Contexto\n\nEste borrador se genera a partir de la documentación interna de Nexa Paraguay.\nAmpliar antes de publicar con datos concretos, ejemplos reales y citas del equipo técnico.\n\n## Proceso paso a paso\n\n1. **Evaluación inicial.** Diagnóstico honesto: qué se puede, qué no.\n2. **Validación documental.** Apostillas, traducciones, requisitos consulares.\n3. **Jornada operativa.** La logística coordinada del día en Paraguay.\n4. **Post-ejecución.** Los 45–60 días siguientes y qué hacemos por usted.\n5. **Entrega y seguimiento.** Documentos finales y cómo le acompañamos.\n\n## Errores comunes\n\n- Subestimar los tiempos de emisión gubernamental (45–60 días).\n- No legalizar apostillas en origen antes de viajar.\n- Elegir la estructura societaria sin análisis fiscal comparativo.\n- Confundir \"gestoría\" con \"sistema integral\".\n\n## Próximos pasos\n\nSi está evaluando Paraguay seriamente, la mejor manera de avanzar es una\nconsulta gratuita de 30 minutos. La hacemos en neerlandés, inglés, alemán o\nespañol — sin compromiso.\n\n**[Agendar consulta gratuita](/s/es/nexa-paraguay/contacto)**\n",
   "nexa-paraguay:es:residencia-paraguaya-paso-a-paso": "---\ntitle: \"Cómo funciona la residencia paraguaya paso a paso\"\nslug: \"residencia-paraguaya-paso-a-paso\"\ndate: \"2026-04-17\"\nauthor: \"Nexa Paraguay\"\ncategory: \"Process\"\nexcerpt: \"Guía honesta: qué documentos, qué tiempos, qué atajos no existen.\"\nreadingMinutes: 7\ndraft: false\n---\n\n> **Nota:** Este artículo está listo para traducción profesional a NL/EN/DE antes del lanzamiento.\n\n## Introducción\n\nGuía honesta: qué documentos, qué tiempos, qué atajos no existen.\n\n## Qué cubre este artículo\n\n- Contexto y marco del tema\n- Proceso paso a paso\n- Qué esperar realmente (sin optimismo de marketing)\n- Errores comunes que evitamos a nuestros clientes\n- Recursos y próximos pasos\n\n## Contexto\n\nEste borrador se genera a partir de la documentación interna de Nexa Paraguay.\nAmpliar antes de publicar con datos concretos, ejemplos reales y citas del equipo técnico.\n\n## Proceso paso a paso\n\n1. **Evaluación inicial.** Diagnóstico honesto: qué se puede, qué no.\n2. **Validación documental.** Apostillas, traducciones, requisitos consulares.\n3. **Jornada operativa.** La logística coordinada del día en Paraguay.\n4. **Post-ejecución.** Los 45–60 días siguientes y qué hacemos por usted.\n5. **Entrega y seguimiento.** Documentos finales y cómo le acompañamos.\n\n## Errores comunes\n\n- Subestimar los tiempos de emisión gubernamental (45–60 días).\n- No legalizar apostillas en origen antes de viajar.\n- Elegir la estructura societaria sin análisis fiscal comparativo.\n- Confundir \"gestoría\" con \"sistema integral\".\n\n## Próximos pasos\n\nSi está evaluando Paraguay seriamente, la mejor manera de avanzar es una\nconsulta gratuita de 30 minutos. La hacemos en neerlandés, inglés, alemán o\nespañol — sin compromiso.\n\n**[Agendar consulta gratuita](/s/es/nexa-paraguay/contacto)**\n",

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -9193,6 +9193,11 @@ export const PAGES: Record<string, JsonRecord> = {
     "descriptionKey": "blog.seo.description",
     "sections": [
       {
+        "content": "home.ageGate",
+        "id": "age-gate",
+        "variant": "modal"
+      },
+      {
         "content": "navigation",
         "id": "header",
         "variant": "standard"
@@ -9235,6 +9240,11 @@ export const PAGES: Record<string, JsonRecord> = {
     "descriptionKey": "bundles.seo.description",
     "sections": [
       {
+        "content": "home.ageGate",
+        "id": "age-gate",
+        "variant": "modal"
+      },
+      {
         "content": "navigation",
         "id": "header",
         "variant": "standard"
@@ -9266,6 +9276,11 @@ export const PAGES: Record<string, JsonRecord> = {
   "fun4me:gift-cards": {
     "descriptionKey": "giftCards.seo.description",
     "sections": [
+      {
+        "content": "home.ageGate",
+        "id": "age-gate",
+        "variant": "modal"
+      },
       {
         "content": "navigation",
         "id": "header",
@@ -9308,6 +9323,11 @@ export const PAGES: Record<string, JsonRecord> = {
   "fun4me:home": {
     "descriptionKey": "home.seo.description",
     "sections": [
+      {
+        "content": "home.ageGate",
+        "id": "age-gate",
+        "variant": "modal"
+      },
       {
         "content": "navigation",
         "id": "header",
@@ -9366,6 +9386,11 @@ export const PAGES: Record<string, JsonRecord> = {
     "descriptionKey": "legal.seo.description",
     "sections": [
       {
+        "content": "home.ageGate",
+        "id": "age-gate",
+        "variant": "modal"
+      },
+      {
         "content": "navigation",
         "id": "header",
         "variant": "standard"
@@ -9418,6 +9443,11 @@ export const PAGES: Record<string, JsonRecord> = {
     "descriptionKey": "loyalty.seo.description",
     "sections": [
       {
+        "content": "home.ageGate",
+        "id": "age-gate",
+        "variant": "modal"
+      },
+      {
         "content": "navigation",
         "id": "header",
         "variant": "standard"
@@ -9455,6 +9485,11 @@ export const PAGES: Record<string, JsonRecord> = {
     "descriptionKey": "loyalty.seo.description",
     "sections": [
       {
+        "content": "home.ageGate",
+        "id": "age-gate",
+        "variant": "modal"
+      },
+      {
         "content": "navigation",
         "id": "header",
         "variant": "standard"
@@ -9486,6 +9521,11 @@ export const PAGES: Record<string, JsonRecord> = {
   "fun4me:reserva-en-tienda": {
     "descriptionKey": "storeReserve.seo.description",
     "sections": [
+      {
+        "content": "home.ageGate",
+        "id": "age-gate",
+        "variant": "modal"
+      },
       {
         "content": "navigation",
         "id": "header",
@@ -9528,6 +9568,11 @@ export const PAGES: Record<string, JsonRecord> = {
   "fun4me:size-guide": {
     "descriptionKey": "sizeGuide.seo.description",
     "sections": [
+      {
+        "content": "home.ageGate",
+        "id": "age-gate",
+        "variant": "modal"
+      },
       {
         "content": "navigation",
         "id": "header",
@@ -9576,6 +9621,11 @@ export const PAGES: Record<string, JsonRecord> = {
     "descriptionKey": "store.seo.description",
     "sections": [
       {
+        "content": "home.ageGate",
+        "id": "age-gate",
+        "variant": "modal"
+      },
+      {
         "content": "navigation",
         "id": "header",
         "variant": "standard"
@@ -9612,6 +9662,11 @@ export const PAGES: Record<string, JsonRecord> = {
   "fun4me:suscripciones": {
     "descriptionKey": "subscriptions.seo.description",
     "sections": [
+      {
+        "content": "home.ageGate",
+        "id": "age-gate",
+        "variant": "modal"
+      },
       {
         "content": "navigation",
         "id": "header",
@@ -19660,18 +19715,22 @@ export const CONTENT: Record<string, JsonRecord> = {
       "team": {
         "members": [
           {
+            "icon": "Briefcase",
             "name": "Leitung Operations (Paraguay)",
             "role": "Operatives Leadership, institutionelle Beziehungen"
           },
           {
+            "icon": "Globe",
             "name": "Leitung Commercial (Europa)",
             "role": "Kundengewinnung, kulturelle Brücke"
           },
           {
+            "icon": "Scale",
             "name": "Juristisches Team",
             "role": "Migrationsakten, Gesellschaftsgründung"
           },
           {
+            "icon": "Calculator",
             "name": "Steuerteam",
             "role": "Steuerliches Management, Compliance"
           }
@@ -20630,18 +20689,22 @@ export const CONTENT: Record<string, JsonRecord> = {
       "team": {
         "members": [
           {
+            "icon": "Briefcase",
             "name": "Operations Director (Paraguay)",
             "role": "Operational leadership, institutional relationships"
           },
           {
+            "icon": "Globe",
             "name": "Commercial Director (Europe)",
             "role": "Client acquisition, cultural bridge"
           },
           {
+            "icon": "Scale",
             "name": "Legal team",
             "role": "Immigration files, company incorporation"
           },
           {
+            "icon": "Calculator",
             "name": "Accounting team",
             "role": "Tax management, compliance"
           }
@@ -21569,18 +21632,22 @@ export const CONTENT: Record<string, JsonRecord> = {
       "team": {
         "members": [
           {
+            "icon": "Briefcase",
             "name": "Dirección de Operaciones (Paraguay)",
             "role": "Liderazgo operativo, relaciones institucionales"
           },
           {
+            "icon": "Globe",
             "name": "Dirección Comercial (Europa)",
             "role": "Adquisición de clientes, puente cultural"
           },
           {
+            "icon": "Scale",
             "name": "Equipo Legal",
             "role": "Expedientes migratorios, constitución societaria"
           },
           {
+            "icon": "Calculator",
             "name": "Equipo Contable",
             "role": "Gestión fiscal, cumplimiento tributario"
           }
@@ -21888,13 +21955,13 @@ export const CONTENT: Record<string, JsonRecord> = {
             "included": [
               "Definición de perfil y criterios",
               "Búsqueda y short-list",
-              "Due diligence legal y técnica",
+              "Auditoría legal y técnica",
               "Negociación y escrituración",
               "Inscripción registral"
             ],
             "name": "Compra de Tierras",
             "price": "Desde USD 3.500",
-            "priceNote": "Según alcance de búsqueda y due diligence."
+            "priceNote": "Según alcance de búsqueda y auditoría legal."
           }
         ],
         "title": "Cuatro caminos para establecerse en Paraguay"
@@ -22137,15 +22204,15 @@ export const CONTENT: Record<string, JsonRecord> = {
       "faq": {
         "items": [
           {
-            "a": "Honorarios profesionales, IVA, tasas oficiales, coordinación bancaria y asesoramiento integral.",
+            "a": "Honorarios profesionales de nuestro equipo multidisciplinario (legal, contable, notarial), IVA, tasas oficiales de Migraciones y del Registro Público, coordinación bancaria, tour estratégico inmobiliario y asesoramiento integral durante todo el trámite. No hay cargos adicionales en el proceso regular.",
             "q": "¿Qué incluye el precio?"
           },
           {
-            "a": "Vuelos, alojamiento, apostillas en país de origen, gastos personales.",
+            "a": "Vuelos internacionales, alojamiento en Asunción, gastos personales, traducciones juradas y apostillas de documentos en su país de origen. Si requiere servicios adicionales —por ejemplo tramitación de título de conducir paraguayo, apoyo en búsqueda de vivienda definitiva, o consultas fiscales fuera del alcance del programa contratado— se cotizan por separado y siempre con presupuesto previo.",
             "q": "¿Qué no está incluido?"
           },
           {
-            "a": "Anticipado por transferencia. Sin cargos adicionales en el trámite regular.",
+            "a": "Pago anticipado por transferencia bancaria internacional. Aceptamos USD o EUR. Sin cargos ocultos ni adicionales durante el trámite regular. Emitimos factura formal desde nuestra entidad paraguaya al momento del pago.",
             "q": "¿Cómo se paga?"
           }
         ],
@@ -22326,13 +22393,13 @@ export const CONTENT: Record<string, JsonRecord> = {
             "included": [
               "Definición de perfil y criterios",
               "Búsqueda y short-list",
-              "Due diligence legal y técnica",
+              "Auditoría legal y técnica",
               "Negociación y escrituración",
               "Inscripción registral"
             ],
             "name": "Compra de Tierras",
             "price": "Desde USD 3.500",
-            "priceNote": "Según alcance de búsqueda y due diligence."
+            "priceNote": "Según alcance de búsqueda y auditoría legal."
           }
         ],
         "title": "Cuatro caminos para establecerse en Paraguay"
@@ -22573,18 +22640,22 @@ export const CONTENT: Record<string, JsonRecord> = {
       "team": {
         "members": [
           {
+            "icon": "Briefcase",
             "name": "Operationele directie (Paraguay)",
             "role": "Operationeel leiderschap, institutionele relaties"
           },
           {
+            "icon": "Globe",
             "name": "Commerciële directie (Europa)",
             "role": "Klantacquisitie, culturele brug"
           },
           {
+            "icon": "Scale",
             "name": "Juridisch team",
             "role": "Migratiedossiers, oprichting vennootschap"
           },
           {
+            "icon": "Calculator",
             "name": "Boekhoudteam",
             "role": "Fiscaal beheer, compliance"
           }
@@ -26253,7 +26324,8 @@ export const VERTICALS: Record<string, JsonRecord> = {
       "whatsapp-float",
       "commerce-catalog",
       "featured-products",
-      "trust-signals"
+      "trust-signals",
+      "age-gate"
     ],
     "baseType": "retail_base",
     "defaultStarterKit": "minimal",

--- a/web/lib/engine/site-renderer.tsx
+++ b/web/lib/engine/site-renderer.tsx
@@ -103,7 +103,16 @@ export function renderPage(page: ResolvedPage): React.ReactNode {
     // Sections that need it (e.g. featured-products, any future section
     // generating URLs with the locale prefix) pick it up; the rest
     // ignore the extra key harmlessly.
-    const props = { ...s.props, locale: page.locale } as Record<string, unknown>
+    //
+    // `s.variant` is also threaded through as `variant` — without this,
+    // sections that support multiple variants (e.g. programs-comparison
+    // with `tiered` / `matrix`) always fell back to their default and
+    // ignored what the tenant page config asked for.
+    const props = {
+      ...s.props,
+      variant: s.variant,
+      locale: page.locale,
+    } as Record<string, unknown>
     return <C key={`${s.id}-${i}`} {...props} />
   })
 }

--- a/web/scripts/convert-nexa-blog-json-to-mdx.ts
+++ b/web/scripts/convert-nexa-blog-json-to-mdx.ts
@@ -1,0 +1,75 @@
+/**
+ * One-off conversion: sites/nexa-paraguay/content/blog/posts.json →
+ *                     sites/nexa-paraguay/blog/es/<slug>.mdx
+ *
+ * The generator pipeline only reads MDX blog files from
+ * `sites/<slug>/blog/<locale>/*.mdx`. Nexa's 10 seed posts were written
+ * in a legacy JSON format that no loader reads, leaving /blog empty.
+ * This script unblocks the blog by emitting frontmatter + markdown body
+ * files that fit the existing loader.
+ *
+ *   npx tsx scripts/convert-nexa-blog-json-to-mdx.ts
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+interface LegacyPost {
+  slug: string
+  title: string
+  excerpt: string
+  author: string
+  date: string
+  category: string
+  tags?: string[]
+  image?: string
+  content: string
+}
+
+function escapeYamlString(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+function toMdx(post: LegacyPost): string {
+  const lines = [
+    '---',
+    `title: "${escapeYamlString(post.title)}"`,
+    `date: ${post.date}`,
+    `author: "${escapeYamlString(post.author)}"`,
+    `category: "${escapeYamlString(post.category)}"`,
+    `excerpt: "${escapeYamlString(post.excerpt)}"`,
+  ]
+  if (post.image) {
+    lines.push(`coverImage: "${escapeYamlString(post.image)}"`)
+  }
+  lines.push('---', '', post.content.trim(), '')
+  return lines.join('\n')
+}
+
+function main() {
+  const repoRoot = resolve(__dirname, '..', '..')
+  const jsonPath = resolve(repoRoot, 'sites/nexa-paraguay/content/blog/posts.json')
+  const outDir = resolve(repoRoot, 'sites/nexa-paraguay/blog/es')
+
+  const raw = readFileSync(jsonPath, 'utf-8')
+  const payload = JSON.parse(raw) as { posts: LegacyPost[] }
+  if (!Array.isArray(payload.posts)) {
+    throw new Error('posts.json: expected { posts: [...] }')
+  }
+
+  mkdirSync(outDir, { recursive: true })
+
+  let written = 0
+  for (const p of payload.posts) {
+    if (!p.slug || !p.title || !p.content) {
+      console.warn(`  ↳ skipping post with missing fields: ${JSON.stringify(p).slice(0, 80)}…`)
+      continue
+    }
+    const file = resolve(outDir, `${p.slug}.mdx`)
+    writeFileSync(file, toMdx(p), 'utf-8')
+    console.log(`  ✓ ${p.slug}.mdx (${p.title.slice(0, 60)}…)`)
+    written++
+  }
+  console.log(`\n[blog-convert] wrote ${written} MDX file(s) to ${outDir}`)
+}
+
+main()

--- a/web/scripts/screenshot-nexa-scroll.ts
+++ b/web/scripts/screenshot-nexa-scroll.ts
@@ -1,0 +1,135 @@
+/**
+ * Capture nav-bar behavior at several scroll positions + viewport-only
+ * snapshots to spot issues the full-page screenshots gloss over.
+ *
+ *   npx tsx scripts/screenshot-nexa-scroll.ts
+ *
+ * Output: /tmp/nexa-screenshots/<stamp>/
+ */
+import { chromium, type Page } from '@playwright/test'
+import { mkdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const BASE = process.env.BASE_URL || 'http://localhost:3000'
+const SITE = 'nexa-paraguay'
+
+async function freezeAnimations(page: Page) {
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-duration: 0.001ms !important;
+        animation-delay: 0ms !important;
+        transition-duration: 0.001ms !important;
+        transition-delay: 0ms !important;
+      }
+    `,
+  })
+  await page.evaluate(() => {
+    document
+      .querySelectorAll('.animate-on-scroll')
+      .forEach((el) => el.classList.add('is-visible'))
+  })
+}
+
+async function shot(page: Page, file: string) {
+  await page.screenshot({ path: file, fullPage: false })
+  console.log(`  ✓ ${file}`)
+}
+
+async function main() {
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+  const outDir = resolve('/tmp/nexa-screenshots', `scroll-${stamp}`)
+  await mkdir(outDir, { recursive: true })
+
+  const browser = await chromium.launch()
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 1,
+  })
+
+  // Nav-bar behavior on ES home at different scroll positions
+  const scenarios: Array<{ path: string; locale: string; label: string; scrolls: number[] }> = [
+    { path: '', locale: 'es', label: 'home', scrolls: [0, 250, 800, 2000] },
+    { path: 'programas', locale: 'es', label: 'programas', scrolls: [0, 500, 1500] },
+    { path: 'sobre', locale: 'es', label: 'sobre', scrolls: [0, 600, 1400] },
+    { path: 'proceso', locale: 'es', label: 'proceso', scrolls: [0, 500] },
+  ]
+
+  for (const sc of scenarios) {
+    const url = sc.path
+      ? `${BASE}/s/${sc.locale}/${SITE}/${sc.path}`
+      : `${BASE}/s/${sc.locale}/${SITE}`
+    const page = await context.newPage()
+    await page.goto(url, { waitUntil: 'networkidle', timeout: 60_000 })
+    await freezeAnimations(page)
+    for (const y of sc.scrolls) {
+      await page.evaluate((yy) => window.scrollTo({ top: yy, behavior: 'instant' }), y)
+      await page.waitForTimeout(150)
+      await shot(page, resolve(outDir, `${sc.locale}-${sc.label}-scroll${y}.png`))
+    }
+    await page.close()
+  }
+
+  // Mobile viewport check on home (Pixel 7-ish 412×915)
+  const mobile = await browser.newContext({
+    viewport: { width: 412, height: 915 },
+    deviceScaleFactor: 2,
+    userAgent:
+      'Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0 Mobile Safari/537.36',
+  })
+  const mpage = await mobile.newPage()
+  await mpage.goto(`${BASE}/s/es/${SITE}`, { waitUntil: 'networkidle', timeout: 60_000 })
+  await freezeAnimations(mpage)
+  await mpage.screenshot({ path: resolve(outDir, 'mobile-es-home-top.png'), fullPage: false })
+  await mpage.evaluate(() => window.scrollTo({ top: 800, behavior: 'instant' }))
+  await mpage.waitForTimeout(150)
+  await mpage.screenshot({ path: resolve(outDir, 'mobile-es-home-scrolled.png'), fullPage: false })
+  // Open mobile menu
+  await mpage.evaluate(() => {
+    const btn = document.querySelector('button[aria-label*="menu" i]') as HTMLButtonElement | null
+    btn?.click()
+  })
+  await mpage.waitForTimeout(200)
+  await mpage.screenshot({ path: resolve(outDir, 'mobile-es-home-menu.png'), fullPage: false })
+  await mpage.close()
+  await mobile.close()
+
+  // Team section hover-reveal verification
+  const page = await context.newPage()
+  await page.goto(`${BASE}/s/es/${SITE}/sobre`, { waitUntil: 'networkidle', timeout: 60_000 })
+  await freezeAnimations(page)
+  // Scroll the team section into view
+  await page.evaluate(() => {
+    const el = Array.from(document.querySelectorAll('h2')).find((h) =>
+      h.textContent?.toLowerCase().includes('equipo')
+    )
+    el?.scrollIntoView({ block: 'center' })
+  })
+  await page.waitForTimeout(200)
+  await shot(page, resolve(outDir, 'team-default.png'))
+  // Hover first team card
+  await page.evaluate(() => {
+    const firstCard = document.querySelector('section#equipo .group') as HTMLElement | null
+    if (firstCard) {
+      // Trigger hover state
+      const event = new MouseEvent('mouseenter', { bubbles: true })
+      firstCard.dispatchEvent(event)
+    }
+  })
+  // Force :hover-equivalent via focus-within — the card uses focus-within too
+  await page.evaluate(() => {
+    const firstCard = document.querySelector('section#equipo .group') as HTMLElement | null
+    // Add a helper class that mirrors the hover styles, since headless can't do :hover
+    firstCard?.classList.add('group-hover-force')
+  })
+  await shot(page, resolve(outDir, 'team-hover-first.png'))
+  await page.close()
+
+  await browser.close()
+  console.log(`\nOutput: ${outDir}`)
+}
+
+main().catch((err) => {
+  console.error('fatal:', err)
+  process.exit(1)
+})

--- a/web/scripts/screenshot-nexa.ts
+++ b/web/scripts/screenshot-nexa.ts
@@ -1,0 +1,109 @@
+/**
+ * One-off: take full-page screenshots of every Nexa Paraguay page
+ * across every locale against the local dev server.
+ *
+ *   npx tsx scripts/screenshot-nexa.ts
+ *
+ * Output: /tmp/nexa-screenshots/<timestamp>/<locale>-<page>.png
+ */
+import { chromium, type Page } from '@playwright/test'
+import { mkdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const BASE = process.env.BASE_URL || 'http://localhost:3000'
+const SITE = 'nexa-paraguay'
+const LOCALES = ['es', 'en', 'nl', 'de'] as const
+const PAGES: Array<{ slug: string; label: string }> = [
+  { slug: '', label: 'home' },
+  { slug: 'programas', label: 'programas' },
+  { slug: 'por-que-paraguay', label: 'por-que-paraguay' },
+  { slug: 'proceso', label: 'proceso' },
+  { slug: 'sobre', label: 'sobre' },
+  { slug: 'faq', label: 'faq' },
+  { slug: 'blog', label: 'blog' },
+  { slug: 'contacto', label: 'contacto' },
+  { slug: 'privacidad', label: 'privacidad' },
+]
+
+async function freezeAnimations(page: Page) {
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-duration: 0.001ms !important;
+        animation-delay: 0ms !important;
+        transition-duration: 0.001ms !important;
+        transition-delay: 0ms !important;
+      }
+    `,
+  })
+  // Nudge every IntersectionObserver-based reveal into its final state
+  await page.evaluate(() => {
+    document
+      .querySelectorAll('.animate-on-scroll')
+      .forEach((el) => el.classList.add('is-visible'))
+  })
+}
+
+async function main() {
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+  const outDir = resolve('/tmp/nexa-screenshots', stamp)
+  await mkdir(outDir, { recursive: true })
+  console.log(`[screenshots] output → ${outDir}`)
+
+  const browser = await chromium.launch()
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 1,
+  })
+
+  const results: Array<{ file: string; bytes: number; locale: string; page: string }> = []
+  const failed: Array<{ locale: string; page: string; error: string }> = []
+
+  for (const locale of LOCALES) {
+    for (const p of PAGES) {
+      const url = p.slug
+        ? `${BASE}/s/${locale}/${SITE}/${p.slug}`
+        : `${BASE}/s/${locale}/${SITE}`
+      const fileName = `${locale}-${p.label}.png`
+      const filePath = resolve(outDir, fileName)
+      const page = await context.newPage()
+      try {
+        const resp = await page.goto(url, { waitUntil: 'networkidle', timeout: 60_000 })
+        if (!resp || !resp.ok()) {
+          throw new Error(`HTTP ${resp?.status()}`)
+        }
+        await freezeAnimations(page)
+        // Give images / lazy content one more tick
+        await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {})
+        await page.screenshot({ path: filePath, fullPage: true })
+        const stats = await (await import('node:fs/promises')).stat(filePath)
+        results.push({ file: fileName, bytes: stats.size, locale, page: p.label })
+        console.log(`  ✓ ${locale}/${p.label} → ${fileName} (${Math.round(stats.size / 1024)} KB)`)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        failed.push({ locale, page: p.label, error: msg })
+        console.error(`  ✗ ${locale}/${p.label} → ${msg}`)
+      } finally {
+        await page.close()
+      }
+    }
+  }
+
+  await browser.close()
+
+  console.log('')
+  console.log(`[screenshots] ${results.length} OK, ${failed.length} failed`)
+  console.log(`[screenshots] output dir: ${outDir}`)
+  if (failed.length > 0) {
+    console.log('[screenshots] failures:')
+    for (const f of failed) {
+      console.log(`  - ${f.locale}/${f.page}: ${f.error}`)
+    }
+    process.exitCode = 1
+  }
+}
+
+main().catch((err) => {
+  console.error('[screenshots] fatal:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
Addresses every item in the 2026-04-21 client walkthrough of `staging.nexaparaguay.com` (feedback per-image via WhatsApp).

## What's fixed

| # | Pain point (client words) | Fix |
|---|---------------------------|-----|
| 1 | "Este espacio hay que ajustar para que diga en español no en holandés" (badges "Professionell / Transparent / Vertrauenswürdig" on `/sobre` ES) + empty gold CTA button under hero | Trust-badges already localized in #179. Additionally: made `ctaPrimaryText` optional on `HeroSection` and hid the CTA row when no text is provided — removes the empty gold button on `/sobre` where `aboutPage.hero` has no CTA |
| 2 | "El header… cuando se hace scroll down debería de desaparecer y que quede nomás el logo o que quede nomás toda la barra a la vista" (contrast lost mid-scroll, bar gets "lost in the middle") | Header is always fully opaque (`bg-[var(--surface)]`), drops the `/95` translucency. On scroll, switches to `shadow-md` + solid bottom border — gives continuous strong contrast over hero, CTA banner, and content alike |
| 3 | "Estos tienen que ser todos los cuadros del mismo tamaño" (4-pillar cards — "Un solo programa / viaje / equipo / Precio transparente") | `trust-signals` (`credentials` variant) and `why-destination` (`three-col` variant) now use `items-stretch` grid + `h-full flex-col` cards so short-description cards match the tallest sibling |
| 4 | "Acá lo mismo, tiene que ser del mismo tamaño… podemos hacer que tenga el título y cuando se haga hover sobre el cuadro que recién aparezca la info" + letter-avatars ("D"/"E") look inconsistent + 3+1 hole | Team section redesigned: replaced letter-avatar fallback with an icon-based avatar (lucide-react, `Users` fallback, per-member override via new `icon` field); cards are `h-full` for uniform height; role + bio collapse into a hover-reveal (title visible by default, details on `:hover` / `:focus-within`, motion-reduce fallback shows them always); grid switches to `lg:grid-cols-4` when exactly 4 members — eliminates the hole. Added `Briefcase / Globe / Scale / Calculator` on the 4 Nexa roles across `es/en/nl/de.json` |
| 5 | "Due diligence al término en español" on Compra de Tierras + "Inscripción registral tiene otro nombre si no estoy mal, le voy a preguntar a Sonia" | Spanish content: `"Due diligence"` → `"Auditoría legal"` (4 occurrences across programs page). **Pending Sonia confirmation:** `"Inscripción registral"` left as-is per client — will update when she responds (candidates: "Escrituración" / "Transferencia de dominio"). EN/NL/DE use locally-accepted "due diligence" and are unchanged |
| 6 | "El anterior tenía un poco más de texto, y me gustaba más sobre todo en el de la segunda pregunta" (FAQ on /programas) | Restored longer answers on `programsPage.faq`, especially `"¿Qué no está incluido?"` — now explicitly covers translations, apostilles, personal expenses, and notes that out-of-scope add-ons are quoted separately |
| 7 | "Los pasos o ponemos en círculos para que se separen del fondo y que vaya con flechas al siguiente paso como estaba en el anterior o que vaya con flechitas hacia abajo para cada paso" | `ProcessTimelineSection` horizontal variant: filled secondary-colored circles with number badge, ring over surface, shadow for depth; `ArrowRight` connectors between steps on desktop, `ArrowDown` between steps on mobile; grid adapts to step count (2–6) |

## Not in this PR (pending business input)

- "Inscripción registral" → Sonia confirms the correct term, then one-line content edit.
- Professional photography to replace placeholder hero/process/why-paraguay images (LAUNCH.md item #9).
- Logo SVG suite (LAUNCH.md item #10).
- German translation human review (LAUNCH.md item #8).

## Test plan

- [ ] Load staging `/s/es/nexa-paraguay/sobre` — trust badges in Spanish, empty gold button gone, 4-pillar cards uniform, team grid is a clean 4-in-a-row, team cards show only title → hover reveals role+bio with real icons (Briefcase / Globe / Scale / Calculator)
- [ ] Scroll any page — header stays solid, gets shadow on scroll, text always readable
- [ ] `/s/es/nexa-paraguay/programas` — Compra de Tierras column says "Auditoría legal y técnica"; FAQ shows longer answers, especially "¿Qué no está incluido?"
- [ ] `/s/es/nexa-paraguay/proceso` — 5 numbered circles with gold fill, arrows between them on desktop, ↓ on mobile
- [ ] `npm run validate:sites` and `npm run validate:content` stay green (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)