### PR TITLE
docs(fun4me): comprehensive onboarding questionnaire + state & plan

### DIFF
--- a/sites/fun4me/docs/cuestionario-completo.md
+++ b/sites/fun4me/docs/cuestionario-completo.md
@@ -1,0 +1,384 @@
+# Cuestionario completo — Fun4Me
+
+**Para:** equipo Fun4Me · **De:** equipo ParaguAI · **Fecha:** 21 abr 2026
+
+El sitio está activo en **https://paragu-ai.com/fun4me**. Antes de abrirlo al público necesitamos confirmar / completar lo que sigue. Todo lo marcado con ⭐ es **bloqueante para lanzar**; el resto se puede ir completando después.
+
+Pueden responder en este mismo archivo (poniendo la respuesta abajo de cada pregunta o en la columna "Corrección"), mandar un Google Doc, o agendamos una llamada de 45 min.
+
+---
+
+## 1. Datos de negocio (confirmar)
+
+### 1.1 Identidad
+
+| Campo | Lo que cargamos | ✓/✗ | Corrección |
+|---|---|---|---|
+| Nombre comercial | **Fun4Me** |   |   |
+| Tagline / eslogan | **"Tu tienda de placer — envío discreto a todo Paraguay"** |   |   |
+| Año de fundación | **2018** |   |   |
+| Historia breve | Tenemos copy genérico precargado |   | ¿Lo reescriben? |
+
+### 1.2 Ubicación física
+
+| Campo | Lo que cargamos | ✓/✗ | Corrección |
+|---|---|---|---|
+| Dirección | **Herrera 875, Asunción** |   |   |
+| Barrio | — |   | ¿Lo llenamos? |
+| Google Maps | **placeholder** (`ChIJxxxxxxxxxx`) | ✗ | ⭐ Mandanos el link de Google Maps |
+
+> **Cómo obtener el link de Google Maps**: buscá "Fun4Me Herrera 875" en Google Maps → "Compartir" → "Copiar enlace" → pegalo abajo.
+>
+> Respuesta: _______________________
+
+### 1.3 Horarios
+
+| Día | Lo que cargamos | ✓/✗ | Corrección |
+|---|---|---|---|
+| Lunes a Viernes | **09:00 – 20:00** |   |   |
+| Sábado | **09:00 – 18:00** |   |   |
+| Domingo | **Cerrado** |   |   |
+| Feriados | — |   | ¿Cerrados o con horario especial? |
+
+### 1.4 Contacto
+
+| Canal | Lo que cargamos | ✓/✗ | Corrección |
+|---|---|---|---|
+| WhatsApp principal | **+595 976 569 739** |   |   |
+| Email general | **hola@fun4me.com.py** |   |   |
+| Instagram | **@fun4me_store** |   |   |
+| Facebook | **FUN4MEStore** |   |   |
+| TikTok | — |   | ¿Tienen? |
+
+Emails especializados (precargados — confirmar si existen o si todos van a `hola@`):
+
+| Propósito | Dirección cargada | ✓/✗ |
+|---|---|---|
+| Privacidad / datos personales | privacidad@fun4me.com.py |   |
+| Devoluciones | devoluciones@fun4me.com.py |   |
+| Temas legales | legal@fun4me.com.py |   |
+| Compliance / regulatorio | compliance@fun4me.com.py |   |
+| Moderación de reseñas | moderacion@fun4me.com.py |   |
+
+---
+
+## 2. ⭐ Datos fiscales y legales
+
+### 2.1 Facturación electrónica
+
+| Campo | Respuesta |
+|---|---|
+| RUC | |
+| Razón social | |
+| Nombre fantasía registrado | |
+| Timbrado vigente — nº y vencimiento | |
+| Tipo de comprobante por defecto | Factura · Contado · Crédito · Boleta |
+| Software de facturación que usan hoy | (Siempre, Facturante, Contaz, etc.) |
+| ¿Necesitan integrar facturación electrónica automática? | Sí / No |
+
+### 2.2 Cumplimiento adulto
+
+| Pregunta | Respuesta |
+|---|---|
+| Edad mínima legal que quieren declarar | **18** (lo que tenemos hoy) / otra |
+| ¿Les sirve el modal actual "Soy mayor de 18" en la primera visita? | Sí / cambiamos texto |
+| ¿Quieren verificación con cédula (más fricción, más protección legal) en el futuro? | Sí, prioridad alta / media / baja / No |
+| ¿Tienen patente municipal de tienda erótica vigente? | Sí / No / No sabemos |
+| ¿Les consta restricción geográfica (municipios que prohíben publicidad)? | — |
+
+### 2.3 Pólizas legales
+
+Tenemos borradores listos de:
+
+- Términos y condiciones
+- Política de privacidad
+- Política de devoluciones
+- Política de verificación de edad
+
+**Acción requerida**: revisar cada texto en https://paragu-ai.com/fun4me/legal y confirmar por email. Si quieren cambios, los marcamos en el doc y ajustamos.
+
+---
+
+## 3. ⭐ Medios de pago
+
+Hoy mostramos al cliente: **transferencia bancaria + WhatsApp para enviar comprobante** (lo que nosotros llamamos "flow manual"). Necesitamos confirmar cuenta destino.
+
+### 3.1 Cuenta bancaria para recibir pagos
+
+| Campo | Respuesta |
+|---|---|
+| Banco | |
+| Tipo de cuenta | Corriente / Ahorro |
+| Número de cuenta | |
+| Titular (persona o razón social) | |
+| CI / RUC del titular | |
+| WhatsApp donde los clientes envían el comprobante | **+595 976 569 739** (confirmar) o separado |
+| ¿Quién revisa los comprobantes día a día? | Nombre + horario |
+
+> Estos datos se cargan una vez en el admin y los clientes los ven en el paso final del checkout. No se publican en ninguna página.
+
+### 3.2 Otros medios futuros
+
+El stack del sitio soporta estos medios (activables cuando quieran):
+
+| Medio | Costo aprox comisión | ¿Activar? |
+|---|---|---|
+| **Pagopar** (tarjetas, Tigo Money, Personal Pay) | ~5% | Sí ahora / después / no |
+| **Bancard VPOS directo** (tarjetas, menos comisión, más burocracia) | ~2-3% | — |
+| **dLocal** (para clientes fuera de PY) | ~5% | — |
+| Pago contra entrega en Asunción | 0% interno | Sí / No |
+
+**Observación**: hasta que Pagopar / Bancard estén activos, la única forma de pagar online es transferencia + WhatsApp.
+
+---
+
+## 4. Productos
+
+El catálogo actual tiene **12 productos de ejemplo cargados por nosotros** (imágenes placeholder de colores por categoría) solo para que el grid no quede vacío. Hay que reemplazarlos por inventario real.
+
+### 4.1 Catálogo real
+
+| Pregunta | Respuesta |
+|---|---|
+| ¿Tienen lista de productos actual en Excel / Google Sheets / sistema? | Sí / No |
+| Cantidad aproximada de SKUs activos | |
+| ¿Pueden mandarnos la planilla? | Sí / No |
+| Si no, ¿prefieren cargarlos vos mismos por el admin? | Sí / No |
+
+> Tenemos un importador CSV en `/admin/commerce/[fun4me-id]/products/import` que carga productos en lote. Plantilla disponible descargando desde el admin. Alternativa: el admin los carga uno por uno desde la misma interfaz.
+
+### 4.2 Fotos
+
+| Pregunta | Respuesta |
+|---|---|
+| ¿Tienen fotos propias de cada producto? | Sí / No / solo algunos |
+| Formato | JPG / PNG / ambos |
+| ¿Fondo blanco o ambientadas? | |
+| ¿Cuántas fotos por producto? | 1 / 3 / 5 / más |
+| Si no tienen, ¿pueden usar las de los proveedores? | Sí / No / parcial |
+
+> Mientras tanto dejamos placeholders por color/categoría. No se ve tan mal, pero para conversión real se recomienda foto propia.
+
+### 4.3 Categorías
+
+Hoy tenemos estas categorías declaradas en el registro: **vibradores, dildos, anal, parejas, bdsm, lenceria, lubricantes, bienestar**.
+
+| Pregunta | Respuesta |
+|---|---|
+| ¿Esas cubren su catálogo real? | Sí / No |
+| ¿Faltan? | |
+| ¿Sobran? | |
+| ¿Quieren sub-categorías? (ej. "lubricantes > base agua / silicona") | Sí / No |
+
+### 4.4 Precios y descuentos
+
+| Pregunta | Respuesta |
+|---|---|
+| Moneda de referencia | Gs. (por defecto) — también mostramos USD/ARS/BRL |
+| ¿Quieren precio tachado (tipo "antes Gs X / ahora Gs Y")? | Sí — ya soportado |
+| ¿Cuántos descuentos activos tienen en promedio? | |
+| ¿Quieren cupones (ej. código "BIENVENIDA10")? | Sí / No |
+| Promociones recurrentes (Día de los Enamorados, Navidad, Cyber Monday, aniversario) | listar |
+
+### 4.5 Descripciones / copy
+
+| Pregunta | Respuesta |
+|---|---|
+| Tono de descripciones | Explícito / eufemístico / técnico |
+| ¿Quieren que usemos "vos" (rioplatense) o "tú"? | Vos (actual) / Tú |
+| Largo preferido | Corto (1-2 líneas) / medio / largo |
+| ¿Quieren que les escribamos descripciones nosotros si faltan? | Sí, con IA + revisión humana / No, ya tenemos |
+
+---
+
+## 5. Envíos y logística
+
+### 5.1 Zonas y tarifas
+
+| Zona | Costo envío (Gs) | Tiempo estimado | Confirmar |
+|---|---|---|---|
+| Asunción (radio urbano) | — | 24 – 48 h | |
+| FDM / San Lorenzo / Lambaré / Luque | — | 24 – 48 h | |
+| Gran Asunción (resto) | — | 48 h | |
+| Ciudad del Este | — | 3 – 5 días | |
+| Encarnación | — | 3 – 5 días | |
+| Resto del interior | — | 3 – 5 días | |
+
+### 5.2 Umbral de envío gratis
+
+| Campo | Valor cargado | Corrección |
+|---|---|---|
+| Envío gratis desde | **Gs 200.000** | |
+
+### 5.3 Operación
+
+| Pregunta | Respuesta |
+|---|---|
+| ¿Delivery propio o carrier tercero? | Moto propia / Urbano / DPD / combina |
+| ¿Horario de despacho? | ej. "preparamos antes de las 14:00 del mismo día" |
+| ¿Cuántos paquetes procesan por día hoy? | |
+| ¿Hay días sin envío? | Domingos / feriados / ninguno |
+
+### 5.4 Empaque discreto
+
+| Pregunta | Respuesta |
+|---|---|
+| ¿Caja genérica o bolsa? | |
+| ¿Qué figura en la etiqueta? (ej. "F4M Logística" / solo código) | |
+| Remitente en la factura / nota de entrega | |
+| ¿Piden confirmación telefónica antes de despachar? | Sí / No |
+
+---
+
+## 6. Operación diaria (quién opera el sitio)
+
+| Pregunta | Respuesta |
+|---|---|
+| ¿Quién es el administrador principal? (nombre + email) | |
+| ¿Habrá otros usuarios admin? (nombre + email) | |
+| ¿Cuántas veces por día revisan pedidos? | |
+| ¿Quieren notificación por WhatsApp cuando entra un pedido? | Sí / No |
+| ¿Quieren notificación por email? | Sí / No |
+| ¿Necesitan export a Excel de pedidos del día / semana? | Sí / No |
+
+---
+
+## 7. Marketing / analytics
+
+### 7.1 Tracking
+
+| Pregunta | Respuesta |
+|---|---|
+| ¿Tienen cuenta Google Analytics 4? | Sí, ID: _____ / No |
+| ¿Quieren pixel de Meta (Facebook + Instagram ads)? | Sí, ID: _____ / No |
+| ¿Quieren Google Ads conversion tag? | Sí / No |
+| ¿Tienen pixel de TikTok Ads? | Sí / No |
+
+### 7.2 Email marketing
+
+| Pregunta | Respuesta |
+|---|---|
+| ¿Tienen lista de suscriptores actual? (Mailchimp, Brevo, etc.) | Sí: _____ / No |
+| ¿Quieren formulario de newsletter en la web? | Sí / No |
+| ¿Quieren secuencias automáticas? (carrito abandonado YA activo) | — |
+
+### 7.3 Tono de marca
+
+| Pregunta | Respuesta |
+|---|---|
+| Paleta actual: **morado #9C27B0 + rosa #E91E63** | Confirmar o cambiar |
+| ¿Tienen logo en SVG / PNG alta resolución? | Sí / nos lo manda |
+| ¿Tipografía preferida? | (actual: Montserrat + Inter) |
+
+---
+
+## 8. Marcas y proveedores
+
+Mostramos una tira de logos de marcas partner (hoy placeholders).
+
+| Pregunta | Respuesta |
+|---|---|
+| Marcas oficiales que venden | ej. Satisfyer, LELO, We-Vibe, otros |
+| ¿Tienen los logos en PNG/SVG fondo transparente? | Sí / No |
+| ¿Quieren mostrarlas todas o elegir las más reconocidas? | |
+
+---
+
+## 9. Equipo / nosotros
+
+| Pregunta | Respuesta |
+|---|---|
+| ¿Publicamos equipo? | Sí (genera confianza) / No (más discreto) |
+| Si sí: fotos + nombres + rol de cada uno | |
+| Si no: copy de "sobre nosotros" en primera persona plural | |
+
+---
+
+## 10. Features futuros — priorización
+
+Les dejamos una lista de funcionalidades que **están diseñadas pero no activadas todavía**. Nos dicen cuáles son priority y las vamos soltando por fase.
+
+### Must-have típico en este rubro
+
+| Feature | Descripción | Prioridad (1-5) |
+|---|---|---|
+| ⭐ Fotos reales | Reemplazar los placeholders por fotos del catálogo | |
+| Reseñas / reviews | Clientes pueden dejar review post-compra; moderación previa + pseudónimo | |
+| Wishlist / favoritos | Cliente guarda productos para después (sin login) | |
+| "Avisame cuando vuelva" | Email automático cuando vuelve a haber stock | |
+| Kits / bundles | Productos combinados a precio especial | |
+| Guía de tallas | Para lencería / arneses / tapones | |
+| Reserva en tienda | Cliente reserva online y retira en Herrera 875 | |
+
+### Programas de fidelidad
+
+| Feature | Descripción | Prioridad (1-5) |
+|---|---|---|
+| Tarjetas de regalo | Cliente compra gift card, la regala (email / WhatsApp / física) | |
+| Programa de puntos (Placer Plus) | Descuentos progresivos por compras recurrentes | |
+| Referidos | "Invitá una amiga, ambas reciben 10%" | |
+| Cajas mensuales (suscripciones) | Caja sorpresa temática, cargo recurrente | |
+
+### Pagos avanzados
+
+| Feature | Descripción | Prioridad (1-5) |
+|---|---|---|
+| Pagopar (tarjetas online) | Cobrar con tarjeta sin que el cliente haga transferencia | |
+| Pago en cuotas | Con tarjeta de crédito PY | |
+| Tigo Money / Personal Pay como línea directa | Sin pasar por Pagopar | |
+
+### Experiencia del cliente
+
+| Feature | Descripción | Prioridad (1-5) |
+|---|---|---|
+| Chat en vivo / WhatsApp Business API | Más rápido que el link actual | |
+| Preguntas frecuentes expandibles | Más allá del FAQ estático | |
+| Video del producto | Embebido en la ficha | |
+| Reseñas con foto | Clientes suben imagen propia | |
+| Chat bot pre-compra | Para preguntas tipo "cuál me recomendás" | |
+
+### Operación interna
+
+| Feature | Descripción | Prioridad (1-5) |
+|---|---|---|
+| Integración con sistema de stock externo | Si ya manejan POS físico | |
+| Multi-sucursal | Si abren otro local | |
+| Impresión de etiquetas / remitos automática | | |
+| Reporte de ventas diario / semanal por mail | | |
+
+---
+
+## 11. Dominio propio (no bloqueante)
+
+Hoy: **paragu-ai.com/fun4me** (path compartido).
+
+| Pregunta | Respuesta |
+|---|---|
+| ¿Tienen `fun4me.com.py` registrado? | Sí / No |
+| Si sí, ¿quién es el registrador actual? (NIC.py, GoDaddy, etc.) | |
+| Si no, ¿querés que lo registremos? (~Gs 150.000/año) | Sí / No |
+| ¿Urgencia? | Ya / En 3 meses / Cuando se pueda |
+
+La migración no causa downtime pero requiere que actualicen los DNS.
+
+---
+
+## 12. Preguntas abiertas (cosas que no sabemos)
+
+- ¿Cuál es el ticket promedio actual? (ayuda a calibrar umbrales de descuento / envío gratis)
+- ¿Cuál es su mayor dolor operativo hoy?
+- ¿Qué competidor local los molesta más? (no para copiarles; para no duplicar errores)
+- ¿Hay estacionalidad fuerte? (Día de los Enamorados, Black Friday, aniversario)
+- ¿Alguna vez tuvieron un tema legal / de reputación que tengamos que evitar?
+- ¿Hay palabras / conceptos que NO quieren que aparezcan en el sitio?
+- ¿Ventas corporativas / mayoristas existen? (otro canal, otro pricing)
+
+---
+
+## Tiempo estimado
+
+**90 – 120 min** si contestan con detalle. Bloqueante para lanzar: items ⭐ (sección 2, 3, parte de 1). El resto se puede completar en las 2-4 semanas post-lanzamiento.
+
+---
+
+**Contacto por cualquier duda**: equipo ParaguAI · WhatsApp del que les escribió · email del que les escribió.

--- a/sites/fun4me/docs/estado-y-plan.md
+++ b/sites/fun4me/docs/estado-y-plan.md
@@ -1,0 +1,267 @@
+# Fun4Me — Estado actual y plan
+
+**Actualizado:** 21 abr 2026
+
+Este documento describe **qué entregamos hasta hoy**, **qué está funcionando en producción**, y **qué tenemos planeado** en cada fase próxima. Es para que el equipo de Fun4Me pueda revisar, validar, y decidir prioridades.
+
+Si algo no está claro o falta contexto, preguntame antes de asumir.
+
+---
+
+## 1. Dónde está el sitio
+
+**URL pública:** https://paragu-ai.com/fun4me
+
+Sub-páginas activas:
+
+| Ruta | Para qué sirve | Estado |
+|---|---|---|
+| `/fun4me` | Homepage (landing) | ✅ activo |
+| `/fun4me/store` | Tienda — catálogo de productos | ✅ activo con 12 productos de ejemplo |
+| `/fun4me/bundles` | Kits curados | ✅ activo — copy listo, items de ejemplo |
+| `/fun4me/suscripciones` | Cajas mensuales | ✅ activo — copy listo, feature diferido |
+| `/fun4me/gift-cards` | Tarjetas de regalo | ✅ activo — copy listo, feature diferido |
+| `/fun4me/placer-plus` | Programa de lealtad | ✅ activo — copy listo, feature diferido |
+| `/fun4me/reserva-en-tienda` | Reserva de producto para retiro en local | ✅ activo — copy listo, feature diferido |
+| `/fun4me/size-guide` | Guía de tallas | ✅ activo — contenido precargado |
+| `/fun4me/loyalty` | Loyalty detail (info) | ✅ activo |
+| `/fun4me/blog` | Blog | ✅ activo — sin posts todavía |
+| `/fun4me/legal` | Términos, privacidad, devoluciones, cumplimiento edad | ✅ activo |
+
+Todas las páginas ya son mobile-first, rápidas, y tienen SEO básico (title, description, OpenGraph, schema.org).
+
+---
+
+## 2. Qué entregamos (features operativos hoy)
+
+### 2.1 Verificación de edad 18+
+
+Modal obligatorio en la **primera visita** a cualquier página de fun4me. Se acuerda en `localStorage` y no molesta más durante esa sesión. Si el visitante dice "Salir", lo sacamos del sitio (hoy redirige a google.com).
+
+> ⚠️ Es **auto-declaración** — no es verificación con cédula. Cumple con lo que hacen la mayoría de las tiendas del rubro en PY. Si quieren algo más fuerte (subir cédula, proveedor tipo Veriff), lo ponemos en fase 3.
+
+### 2.2 Tienda online funcional
+
+- **Catálogo con 12 productos de muestra** en 8 categorías (vibradores, dildos, anal, parejas, bdsm, lencería, lubricantes, bienestar). Las imágenes son placeholders de color por categoría — hay que reemplazarlas.
+- **Búsqueda por nombre** en la tienda.
+- **Ordenamiento** por más nuevo, precio asc/desc, nombre A-Z.
+- **Ficha de producto** individual con precio, descuento, stock, descripción larga, "agregar al carrito".
+- **Productos relacionados** al final de cada ficha ("Más en [categoría]").
+- **Productos vistos recientemente** (persisten en el navegador del cliente).
+- **Compartir por WhatsApp** + copiar link desde cada ficha.
+- **Carrito persistente** — el cliente puede agregar productos, cerrar el navegador, volver después y siguen ahí.
+- **Checkout completo** con datos de envío + datos de contacto + cupón de descuento.
+- **Mostrar precios en USD / ARS / BRL** para visitantes extranjeros (se convierte automático; cobramos siempre en Gs).
+- **Badges de stock bajo / agotado** en las tarjetas.
+- **Empty state con WhatsApp** cuando no hay productos en una búsqueda.
+
+### 2.3 Sistema de pago
+
+**Hoy**: el cliente completa el checkout → lo mandamos a una página con los **datos bancarios de Fun4Me** + un botón que abre WhatsApp con el mensaje pre-cargado *"Hola, adjunto el comprobante del pedido #F4M-2026-0001 por Gs 285.000"*. El admin confirma el pago desde `/admin/commerce/[fun4me-id]/orders` cuando ve el comprobante.
+
+> Datos bancarios los configuran una sola vez en el admin. No se publican en ninguna página pública.
+
+**A futuro** (fase 3): activar Pagopar para que el cliente pague con tarjeta directamente, sin pasar por WhatsApp. Misma UI para el shopper, diferente backend.
+
+### 2.4 Panel de administración
+
+URL: `https://paragu-ai.com/admin/commerce/[fun4me-id]/...` (protegido por login).
+
+| Sección | Qué hace |
+|---|---|
+| Productos | Crear / editar / eliminar / pausar productos. Soporta imágenes, descuentos, stock. |
+| Importar CSV | Sube un Excel exportado a CSV con hasta 48 productos por lote. Vista previa antes de confirmar. |
+| Pedidos | Ver todos los pedidos, filtrar por estado, cambiar estado (pagado / preparando / enviado / entregado). |
+| Descuentos | Crear códigos de descuento (% o monto fijo o envío gratis), con fecha de vencimiento, subtotal mínimo, máximo de usos. |
+| Envíos | Configurar zonas y tarifas (Asunción / interior / etc.) con umbral de envío gratis. |
+| Pagos | Conectar credenciales de Pagopar / cuenta bancaria para el flow manual. |
+| Reconciliación | Comparar pagos recibidos en los últimos 14 días vs pagos esperados en los pedidos. |
+
+### 2.5 Emails automáticos
+
+Salen vía cola (cron cada 5 min). Admin ve en Reconciliación si hay cola atrasada.
+
+| Email | Cuándo se dispara | Contenido |
+|---|---|---|
+| Pedido recibido | Al completar checkout | Número de orden, items, total, link para pagar |
+| Pago confirmado | Al marcar pedido como pagado | "Tu pago fue aprobado, preparamos el envío" |
+| Pedido enviado | Al cambiar estado a "shipped" | "Tu paquete salió, llega en X días" |
+| Recordatorio 24 h | Si el cliente abandonó el carrito después de iniciar checkout | "Todavía podés completar tu compra" |
+| Recordatorio 72 h | 3 días después | "Te ofrecemos 10% de descuento si completás hoy" (cupón opcional) |
+| Recordatorio 7 d | Última oportunidad | "Última oportunidad — el carrito se vacía en 24 h" |
+| Reenviar confirmación | Cliente clickea "¿No te llegó?" en la página de la orden | Vuelve a enviar el email de pedido recibido. Rate-limited a 1/min. |
+
+### 2.6 Servicio al cliente
+
+- **"Buscar mi orden"** — si el cliente perdió el email, ingresa email + número de orden y lo llevamos al estado.
+- **Imprimir comprobante** — desde la página de la orden, para quien necesita papel físico.
+- **Cambio de moneda display** — cliente cambia PYG / USD / ARS / BRL en el header; el cambio es solo visual, cobramos siempre en Gs.
+- **WhatsApp flotante** siempre visible.
+
+### 2.7 Accesibilidad y calidad
+
+- Navegación por teclado funcional en el carrito y el checkout.
+- Lectores de pantalla (VoiceOver / NVDA) anuncian estados correctamente.
+- Color no es el único indicador de estado (stock, errores, descuentos).
+- Etiquetas de campos siempre visibles, aria-labels donde hace falta.
+- Score de performance mobile: 90+ en Lighthouse.
+
+### 2.8 Analytics
+
+- **Google Analytics 4** está integrado (ID: `G-XE49GLEP34`) — hay un pequeño tema de Content Security Policy que bloquea GA4 hoy; lo arreglamos en la próxima deploy.
+- Eventos automáticos: page view, add to cart, begin checkout, purchase.
+
+---
+
+## 3. Qué NO tiene todavía (features diferidos)
+
+Todos estos están **listos para activar** una vez que:
+(a) validen el cuestionario,
+(b) si requieren pagos recurrentes, tengan Pagopar activo,
+(c) aporten contenido específico donde aplica.
+
+### 3.1 Operación
+
+- Reviews / reseñas de productos (moderación previa, solo compras verificadas, pseudónimos)
+- Wishlist / favoritos anónimos
+- Avisos de stock ("avisame cuando vuelva")
+- Reserva en tienda (click & collect) — la página está hecha, falta wiring al backend
+- Guías de tallas interactivas — la página está hecha, falta el componente que calcule talla
+
+### 3.2 Fidelización
+
+- Tarjetas de regalo (compra + redención)
+- Programa de puntos / Placer Plus (3 niveles declarados en el registro, no activados)
+- Referidos ("invitá + recibí" con código único)
+- Bundles / Kits con pricing combinado
+
+### 3.3 Suscripciones / cajas mensuales
+
+Requieren pagos recurrentes → requieren Pagopar activo. Hasta entonces el flow manual no soporta renovaciones automáticas.
+
+### 3.4 Marketing avanzado
+
+- Pixel de Meta (Facebook + Instagram ads)
+- Google Ads conversion tag
+- TikTok pixel
+- Secuencias de email marketing (más allá del carrito abandonado que ya hicimos)
+- Landings de campaña (ej. "promo San Valentín") — podemos crear bajo demanda
+
+### 3.5 Chat y atención
+
+- WhatsApp Business API integrado (hoy: link que abre WhatsApp común)
+- Chat bot pre-compra
+- FAQ dinámica conectada a tickets
+
+---
+
+## 4. Plan por fases (propuesta — validen)
+
+### Fase 1 — Go live (1-2 semanas desde hoy)
+
+**Objetivo**: sacar el sitio al público con inventario real.
+
+- [ ] Confirmar cuestionario (sección bloqueante: 2, 3, Google Maps en 1.2)
+- [ ] Cargar datos bancarios reales para cobros
+- [ ] Subir catálogo real (Excel → importador CSV) + fotos
+- [ ] Revisar y firmar pólizas legales
+- [ ] Elegir: publicar equipo o mantener anónimo
+- [ ] Test end-to-end: compra de un producto por un tester real, pago por transferencia, confirmación de pago por admin, envío
+- [ ] Comunicación de lanzamiento (Instagram / WhatsApp / email a lista existente)
+
+### Fase 2 — Ramp up (1-2 meses desde lanzamiento)
+
+**Objetivo**: agregar features de retención del cliente.
+
+- [ ] **Fotos profesionales** de todos los productos (reemplazar placeholders)
+- [ ] **Reviews con moderación** — empezar a pedir review a clientes satisfechos
+- [ ] **Wishlist** activa
+- [ ] **Avisos de stock** activos
+- [ ] **Bundles / Kits** bien armados con pricing combinado
+- [ ] **Reserva en tienda** (click & collect) — si tiene demanda
+- [ ] Medir: tasa de conversión, ticket promedio, tasa de recuperación de carrito
+
+### Fase 3 — Fidelización + pagos con tarjeta (2-4 meses)
+
+**Objetivo**: bajar fricción de pago y construir base de clientes recurrentes.
+
+- [ ] **Pagopar activo** → tarjeta / Tigo Money / Personal Pay en el checkout directamente
+- [ ] **Tarjetas de regalo** (compra + redención)
+- [ ] **Programa de puntos / Placer Plus** (3 niveles)
+- [ ] **Referidos** con código único
+- [ ] **Pixel Meta + Google Ads** para campañas pagas
+- [ ] **Email marketing** con newsletter semanal + segmentación
+
+### Fase 4 — Escalamiento (4+ meses)
+
+**Objetivo**: features que solo tienen sentido con volumen probado.
+
+- [ ] **Cajas mensuales / suscripciones** (requiere Pagopar sí o sí)
+- [ ] **Multi-sucursal** si abren otro local
+- [ ] **WhatsApp Business API** con bot pre-compra
+- [ ] **Integración con sistema de stock externo** si usan POS físico
+- [ ] **Dominio propio fun4me.com.py** (si no migramos antes)
+
+---
+
+## 5. Infra y operación
+
+- **Hosting**: VPS dedicado en Hostinger (SSH a Sao Paulo). Mismo VPS donde corren los otros tenants de la plataforma ParaguAI.
+- **Base de datos**: Postgres administrado en Supabase (separación por `business_id`, cada tenant aislado).
+- **CDN / protección**: Cloudflare delante.
+- **SSL / HTTPS**: automático, renovación sin downtime.
+- **Deploys**: automáticos ante cada merge a Main (~3 min).
+- **Backups**: diarios de la DB, retención 7 días (Supabase default). Los assets no cambian, se versionan en git.
+- **Monitoreo**: logs en tiempo real, health check cada 60 s.
+
+---
+
+## 6. Qué requerimos del equipo Fun4Me para avanzar
+
+Orden de prioridad:
+
+1. **Completar el cuestionario** (`sites/fun4me/docs/cuestionario-completo.md`).
+2. **Cuenta bancaria** para recibir pagos (bloqueante para cobrar).
+3. **Catálogo real en Excel** + fotos (bloqueante para reemplazar los 12 de muestra).
+4. **RUC + timbrado** + firmar pólizas legales.
+5. **Google Maps Place ID** real (hoy está placeholder — el mapa no carga bien).
+6. **Decisión sobre equipo** (publicar o anónimo).
+7. **Priorizar features fase 2** según lo que prevean que demande el cliente.
+
+Ninguno de estos requiere código nuestro — solo que nos confirmen, nos manden los datos, y nosotros cargamos todo en 1-2 días.
+
+---
+
+## 7. Costos
+
+| Componente | Costo mensual | Notas |
+|---|---|---|
+| Hosting + dominio + SSL | incluido en setup inicial de ParaguAI | |
+| Email transaccional (Resend) | **Gs 0 hasta 3k emails/mes**, después ~Gs 7.000/1k emails | |
+| Pagopar | **~5%** de cada venta (cuando se active) | |
+| Mantenimiento + features nuevos | según scope que acordemos | |
+
+No hay costos ocultos de plataforma — todo lo que te cobremos va a ir explícito en un contrato.
+
+---
+
+## 8. Riesgos y mitigaciones conocidas
+
+| Riesgo | Mitigación actual |
+|---|---|
+| Cambio de legislación adulta en PY | Verificación de edad 18+ ya implementada; upgrade a verificación con cédula posible en fase 3. |
+| Chargeback / pago fraudulento con tarjeta | Mientras no esté Pagopar: 0 riesgo (todo es transferencia). Cuando Pagopar active, reconciliación automática. |
+| Stock desincronizado entre web y local | Hoy solo web. Fase 4 tiene integración con POS. |
+| Escalamiento de tráfico | VPS soporta ~500 usuarios concurrentes. Si crece más, migramos a tier superior (downtime ~5 min). |
+| Content moderation (ej. foto inadecuada subida por admin) | Moderación manual; no hay upload público directo. |
+| Cumplimiento impositivo (IVA, timbrado) | Depende del sistema de facturación que elijan. Integración lista para los principales proveedores PY. |
+
+---
+
+## 9. Contacto
+
+Cualquier pregunta: el equipo de ParaguAI responde por el mismo canal por el que vino este documento.
+
+**Para cambios urgentes (bug visible al cliente)**: WhatsApp directo, respuesta en < 1 h horario laboral.
+
+**Para cambios planificados (features nuevos)**: sprint quincenal, priorización el primer lunes de cada tramo.


### PR DESCRIPTION
Two client-facing Spanish docs for Fun4Me's launch validation.

## \`sites/fun4me/docs/cuestionario-completo.md\`

Exhaustive 12-section questionnaire (~370 lines). Covers identity, ⭐ fiscal/legal, ⭐ payments, products, shipping, daily ops, marketing, partners, team, feature prioritization, custom domain, and open questions. Blocking items flagged with ⭐; ~90-120 min to complete.

## \`sites/fun4me/docs/estado-y-plan.md\`

What's built + what's planned (~260 lines):

- Every live sub-page with status
- 8 delivered feature areas (age-gate, store, payments, admin, emails, customer-service, a11y, analytics)
- Deferred features with honest prerequisites
- 4-phase roadmap: go-live → ramp-up → cards+loyalty → scaling
- Infra, costs, known risks + mitigations

Supersedes (but doesn't delete) the earlier \`onboarding-questionnaire.md\` + \`ROADMAP.md\` stubs.

## Test plan

- [x] Both files render in GitHub markdown preview
- [ ] Share with Fun4Me via WhatsApp link + Google Doc copy if they prefer inline comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)