### PR TITLE
fix(tenant-nav): rewrite bare-'/' href to tenant home (fixes Inicio bouncing out of fun4me)

### DIFF
--- a/web/lib/engine/compose-site.ts
+++ b/web/lib/engine/compose-site.ts
@@ -106,6 +106,23 @@ export function composeSitePage(input: ComposeInput): ResolvedPage {
         // Normalize legacy prop names for known section components
         const normalized = normalizeSectionProps(s.id, filled)
 
+        // Rewrite bare-'/' navItem hrefs to the tenant's home URL.
+        // Content authors reasonably write href:"/" for "Home", but on
+        // a tenant page that would bounce the shopper to the platform
+        // root (paragu-ai.com) instead of keeping them inside the
+        // tenant. Does nothing when navItems isn't an array or no item
+        // needs rewriting — safe on every section.
+        if (s.id === 'header' && Array.isArray(normalized.navItems)) {
+          const tenantHome = site.path ?? `/s/${locale}/${siteSlug}`
+          normalized.navItems = (normalized.navItems as Array<Record<string, unknown>>).map(
+            (item) => {
+              const href = typeof item.href === 'string' ? item.href : ''
+              if (href === '' || href === '/') return { ...item, href: tenantHome }
+              return item
+            },
+          )
+        }
+
         const propsWithContext: Record<string, unknown> = {
           ...normalized,
           __siteSlug: site.slug,

--- a/web/lib/engine/site-types.ts
+++ b/web/lib/engine/site-types.ts
@@ -15,6 +15,14 @@ export interface SiteDefinition {
   domain: string
   defaultLocale: Locale
   locales: Locale[]
+  /**
+   * Path-based public URL for tenants that live at a subpath instead of
+   * a subdomain (e.g. fun4me's site.json has `"path": "/fun4me"`).
+   * When set, it's used as the "home" link target in the header nav so
+   * clicking Inicio stays inside the tenant instead of bouncing to the
+   * platform root. Falls back to `/s/{defaultLocale}/{slug}` when absent.
+   */
+  path?: string
   navigation: Array<{ labelKey: string; path: string }>
   integrations: SiteIntegrations
   features?: Record<string, boolean>


### PR DESCRIPTION
The \"Inicio\" nav link on fun4me (and any tenant whose content author wrote \`href: \"/\"\`) went to the **platform root paragu-ai.com** — clicking it dropped the shopper out of the tenant and into ParaguAI's marketing site. Reported by the user.

## Fix

\`compose-site.ts\` now walks any header section's \`navItems\` after normalization and rewrites \`href\` values of \`\"\"\` or \`\"/\"\` to the tenant's home URL:

- Prefers \`site.path\` (path-based tenants like fun4me → \`/fun4me\`) when set.
- Falls back to canonical \`/s/{locale}/{slug}\`.
- Other navItems (absolute paths the author typed, e.g. \`/fun4me/store\`) pass through unchanged.

Also adds the missing \`path?: string\` to \`SiteDefinition\` — fun4me's \`site.json\` carries it but the TS interface was silently dropping it.

## Test plan
- [x] typecheck / tests / build — clean
- [ ] Post-deploy: click \"Inicio\" from https://paragu-ai.com/fun4me/store → lands on /fun4me, not paragu-ai.com/
- [ ] Other tenant nav items unaffected
- [ ] Platform marketing site (paragu-ai.com) unaffected (doesn't go through compose-site.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)