### PR TITLE
feat(commerce): conversion bundle — back-in-stock + search analytics + accent-insensitive + trust badges

### DIFF
--- a/sites/fun4me/content/es.json
+++ b/sites/fun4me/content/es.json
@@ -78,20 +78,23 @@
       "ctaSecondaryText": "Contactanos",
       "ctaSecondaryHref": "https://wa.me/595976569739"
     },
-    "trustBadges": [
-      {
-        "icon": "truck",
-        "text": "Envio a Todo el Pais"
-      },
-      {
-        "icon": "shield",
-        "text": "Pago Seguro"
-      },
-      {
-        "icon": "package",
-        "text": "Empaque Discreto"
-      }
-    ],
+    "trustBadges": {
+      "items": [
+        {
+          "icon": "truck",
+          "text": "Envio a Todo el Pais"
+        },
+        {
+          "icon": "shield",
+          "text": "Pago Seguro"
+        },
+        {
+          "icon": "package",
+          "text": "Empaque Discreto"
+        }
+      ],
+      "title": "Por qué comprar acá"
+    },
     "features": {
       "badge": "Nuestras Ventajas",
       "title": "Por que elegirnos?",

--- a/sites/fun4me/pages/home.json
+++ b/sites/fun4me/pages/home.json
@@ -19,6 +19,11 @@
       "content": "home.hero"
     },
     {
+      "id": "trust-badges",
+      "variant": "strip",
+      "content": "home.trustBadges"
+    },
+    {
       "id": "services",
       "variant": "cards",
       "content": "home.features"

--- a/sites/fun4me/pages/store.json
+++ b/sites/fun4me/pages/store.json
@@ -19,6 +19,11 @@
       "content": "store.hero"
     },
     {
+      "id": "trust-badges",
+      "variant": "strip",
+      "content": "home.trustBadges"
+    },
+    {
       "id": "cta-banner",
       "variant": "solid",
       "content": "home.promo"

--- a/src/verticals/retail-local/vertical.json
+++ b/src/verticals/retail-local/vertical.json
@@ -16,7 +16,7 @@
     "header", "hero", "product-catalog", "product-grid", "services",
     "gallery", "testimonials", "faq", "business-hours", "google-maps",
     "contact", "cta-banner", "footer", "whatsapp-float",
-    "commerce-catalog", "featured-products", "trust-signals", "age-gate"
+    "commerce-catalog", "featured-products", "trust-signals", "age-gate", "trust-badges"
   ],
   "defaultStarterKit": "minimal",
   "locales": ["es"]

--- a/web/app/admin/commerce/[businessId]/products/page.tsx
+++ b/web/app/admin/commerce/[businessId]/products/page.tsx
@@ -50,6 +50,9 @@ export default async function AdminProductsPage({ params }: { params: Promise<{ 
         <Link href={`/admin/commerce/${businessId}/reconciliation`} className="hover:underline">
           Conciliación
         </Link>
+        <Link href={`/admin/commerce/${businessId}/search-analytics`} className="hover:underline">
+          Búsquedas
+        </Link>
       </nav>
       <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-2xl font-bold">Productos</h1>

--- a/web/app/admin/commerce/[businessId]/search-analytics/page.tsx
+++ b/web/app/admin/commerce/[businessId]/search-analytics/page.tsx
@@ -1,0 +1,148 @@
+import Link from 'next/link'
+import { listTopSearches } from '@/lib/commerce/search-events'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export default async function SearchAnalyticsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ businessId: string }>
+  searchParams: Promise<{ days?: string; zero?: string }>
+}) {
+  const { businessId } = await params
+  const sp = await searchParams
+  const windowDays = Math.min(365, Math.max(1, parseInt(sp.days ?? '30', 10) || 30))
+  const zeroResultOnly = sp.zero === '1'
+
+  const rows = await listTopSearches(businessId, { windowDays, zeroResultOnly, limit: 50 })
+  const totalHits = rows.reduce((acc, r) => acc + r.hits, 0)
+  const zeroHits = rows.reduce((acc, r) => acc + r.zeroResultHits, 0)
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <nav className="mb-4 flex flex-wrap items-center gap-3 text-sm text-[color:var(--text-muted,#6b7280)]">
+        <Link href={`/admin/commerce/${businessId}/products`} className="hover:underline">
+          Productos
+        </Link>
+        <Link href={`/admin/commerce/${businessId}/orders`} className="hover:underline">
+          Pedidos
+        </Link>
+        <Link href={`/admin/commerce/${businessId}/discounts`} className="hover:underline">
+          Descuentos
+        </Link>
+        <Link href={`/admin/commerce/${businessId}/shipping`} className="hover:underline">
+          Envíos
+        </Link>
+        <Link href={`/admin/commerce/${businessId}/reconciliation`} className="hover:underline">
+          Conciliación
+        </Link>
+        <Link href={`/admin/commerce/${businessId}/search-analytics`} className="font-semibold text-[color:var(--text,#111)] underline">
+          Búsquedas
+        </Link>
+      </nav>
+
+      <h1 className="mb-2 text-2xl font-bold">Analíticas de búsqueda</h1>
+      <p className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">
+        Lo que tus visitantes están buscando en la tienda. Las búsquedas sin resultados son oportunidades de inventario.
+      </p>
+
+      <div className="mb-6 flex flex-wrap items-center gap-3 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-3 text-sm">
+        <span>Últimos</span>
+        {[7, 14, 30, 60, 90].map((d) => (
+          <Link
+            key={d}
+            href={`?days=${d}${zeroResultOnly ? '&zero=1' : ''}`}
+            className={`rounded border px-2 py-0.5 text-xs ${
+              d === windowDays
+                ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
+                : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
+            }`}
+          >
+            {d} días
+          </Link>
+        ))}
+        <span className="ml-auto text-xs text-[color:var(--text-muted,#6b7280)]">
+          {totalHits} búsquedas · {zeroHits} sin resultado
+        </span>
+      </div>
+
+      <div className="mb-6 flex items-center gap-3 text-sm">
+        <Link
+          href={`?days=${windowDays}`}
+          className={`rounded-full border px-3 py-1 text-xs ${
+            !zeroResultOnly
+              ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
+              : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
+          }`}
+        >
+          Todas
+        </Link>
+        <Link
+          href={`?days=${windowDays}&zero=1`}
+          className={`rounded-full border px-3 py-1 text-xs ${
+            zeroResultOnly
+              ? 'border-red-600 bg-red-600 text-white'
+              : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
+          }`}
+        >
+          Solo sin resultados
+        </Link>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-[color:var(--border,#e5e7eb)] p-12 text-center text-sm text-[color:var(--text-muted,#6b7280)]">
+          {zeroResultOnly
+            ? 'No hay búsquedas sin resultado en este período. Bien.'
+            : 'Todavía no tenemos datos de búsqueda. Volvé después de que los visitantes empiecen a buscar.'}
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)]">
+          <table className="w-full text-sm">
+            <thead className="bg-[color:var(--surface-muted,#f9fafb)] text-left">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Búsqueda</th>
+                <th className="px-4 py-3 text-right font-semibold">Veces</th>
+                <th className="px-4 py-3 text-right font-semibold">Resultados (prom.)</th>
+                <th className="px-4 py-3 text-right font-semibold">Sin resultados</th>
+                <th className="px-4 py-3 text-right font-semibold">Última</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => {
+                const zeroDominates = r.zeroResultHits / Math.max(1, r.hits) >= 0.8
+                return (
+                  <tr key={r.queryNormalized} className="border-t border-[color:var(--border,#e5e7eb)]">
+                    <td className="px-4 py-3">
+                      <span className="font-medium">{r.sampleQuery}</span>
+                      {zeroDominates ? (
+                        <span className="ml-2 rounded bg-red-50 px-1.5 py-0.5 text-[10px] text-red-700">
+                          gap
+                        </span>
+                      ) : null}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono">{r.hits}</td>
+                    <td className="px-4 py-3 text-right font-mono text-[color:var(--text-muted,#6b7280)]">
+                      {r.avgResults}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono">
+                      {r.zeroResultHits > 0 ? (
+                        <span className="text-red-700">{r.zeroResultHits}</span>
+                      ) : (
+                        <span className="text-[color:var(--text-muted,#9ca3af)]">0</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-right text-xs text-[color:var(--text-muted,#6b7280)]">
+                      {new Date(r.lastSeen).toLocaleDateString('es-PY')}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/app/api/cron/commerce-back-in-stock/route.ts
+++ b/web/app/api/cron/commerce-back-in-stock/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { findPendingBackInStockNotifications, markNotified } from '@/lib/commerce/back-in-stock'
+import { backInStockEmail } from '@/lib/commerce/email-templates'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { logger } from '@/lib/logger'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+/**
+ * Cron — dispatch back-in-stock notifications.
+ *
+ * Scans subscriptions whose target product is active AND back in stock
+ * (policy=continue OR qty>0). Enqueues an email per subscription into
+ * commerce_email_outbox and marks notified. The email-flush cron picks
+ * the row up on its next tick.
+ *
+ * Idempotent: markNotified sets notified_at so the row won't match on
+ * the next run. Email deduping is handled by the outbox itself if the
+ * sender decides to skip duplicates; we already set notified_at before
+ * returning so a re-run while this runs is safe.
+ */
+export const GET = withRequestLog<Record<string, never>>(async (_req, { log }) => {
+  const pending = await findPendingBackInStockNotifications(50)
+  if (pending.length === 0) {
+    return NextResponse.json({ processed: 0 })
+  }
+
+  const supabase = await createAdminClient()
+
+  // Look up business names in one query so we don't N+1 it in the loop.
+  const businessIds = Array.from(new Set(pending.map((p) => p.businessId)))
+  const { data: businesses } = await supabase
+    .from('businesses')
+    .select('id, name')
+    .in('id', businessIds)
+  const nameById = new Map<string, string>()
+  for (const b of (Array.isArray(businesses) ? businesses : []) as Array<{ id: string; name: string }>) {
+    nameById.set(b.id, b.name)
+  }
+
+  let enqueued = 0
+  for (const p of pending) {
+    const businessName = nameById.get(p.businessId) ?? 'Tu tienda'
+    const rendered = backInStockEmail({
+      productName: p.productName,
+      productUrl: p.productUrl,
+      businessName,
+    })
+    const { error } = await supabase.from('commerce_email_outbox').insert({
+      business_id: p.businessId,
+      template: 'back_in_stock',
+      recipient_email: p.email,
+      subject: rendered.subject,
+      html_body: rendered.html,
+    })
+    if (error) {
+      logger.warn('[cron/back-in-stock] outbox insert failed', {
+        action: 'commerce.back_in_stock.outbox_insert_failed',
+        subscriptionId: p.subscriptionId,
+        error: error.message,
+      })
+      continue
+    }
+    await markNotified(p.subscriptionId)
+    enqueued += 1
+  }
+
+  log.info('commerce.back_in_stock.cron_run', { scanned: pending.length, enqueued })
+  return NextResponse.json({ processed: pending.length, enqueued })
+})

--- a/web/app/api/storefront/[site]/back-in-stock/route.ts
+++ b/web/app/api/storefront/[site]/back-in-stock/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
+import { subscribeBackInStock } from '@/lib/commerce/back-in-stock'
+
+export const runtime = 'nodejs'
+
+const BodySchema = z.object({
+  productId: z.string().uuid(),
+  email: z.string().email().max(200),
+  locale: z.string().min(2).max(8).optional(),
+})
+
+/**
+ * POST /api/storefront/[site]/back-in-stock
+ *
+ * Shopper subscribes to a back-in-stock notification. No auth — gated
+ * by the opaque product_id UUID plus the DB unique constraint
+ * (business_id, product_id, email) so the worst abuse is a duplicate
+ * that no-ops. The notification email always goes to the submitted
+ * address, never to a caller-inferred one.
+ */
+export const POST = withRequestLog<{ site: string }>(async (req, { log }, { site }) => {
+  const business = await resolveBusinessBySlug(site)
+  if (!business) return NextResponse.json({ error: 'not_found' }, { status: 404 })
+
+  let json: unknown
+  try {
+    json = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+  const parsed = BodySchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const result = await subscribeBackInStock({
+    businessId: business.id,
+    productId: parsed.data.productId,
+    email: parsed.data.email,
+    locale: parsed.data.locale,
+  })
+  if (!result.ok) {
+    return NextResponse.json({ error: result.code }, { status: result.code === 'invalid_email' ? 400 : 500 })
+  }
+
+  log.info('commerce.back_in_stock.subscribed', {
+    businessId: business.id,
+    productId: parsed.data.productId,
+  })
+  return NextResponse.json({ ok: true })
+})

--- a/web/app/api/storefront/[site]/search-suggest/route.ts
+++ b/web/app/api/storefront/[site]/search-suggest/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { withRequestLog } from '@/lib/api/with-request-log'
 import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { listActiveProducts } from '@/lib/commerce/products'
+import { recordSearchEvent } from '@/lib/commerce/search-events'
 
 export const runtime = 'nodejs'
 
@@ -31,6 +32,13 @@ export const GET = withRequestLog<{ site: string }>(async (req, _ctx, { site }) 
       imageUrl: cover?.url ?? null,
       category: p.category,
     }
+  })
+  // Fire-and-forget — don't await, never let analytics block the response.
+  void recordSearchEvent({
+    businessId: business.id,
+    query: q,
+    resultCount: suggestions.length,
+    source: 'suggest',
   })
   return NextResponse.json({ suggestions })
 })

--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { ProductDetailActions } from '@/components/commerce/product-detail-actio
 import { ProductCard } from '@/components/commerce/product-card'
 import { ProductShare } from '@/components/commerce/product-share'
 import { WishlistButton } from '@/components/commerce/wishlist-button'
+import { BackInStockSignup } from '@/components/commerce/back-in-stock-signup'
 import { RecordRecentVisit } from '@/components/commerce/record-recent-visit'
 import { RecentlyViewedRail } from '@/components/commerce/recently-viewed-rail'
 import { PriceDisplay } from '@/components/commerce/price-display'
@@ -132,6 +133,12 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
           <div className="mt-6">
             <ProductDetailActions siteSlug={site} productId={product.id} inventoryQty={product.inventoryQty} inventoryPolicy={product.inventoryPolicy} />
           </div>
+
+          {product.inventoryPolicy === 'deny' && product.inventoryQty === 0 ? (
+            <div className="mt-4">
+              <BackInStockSignup siteSlug={site} productId={product.id} locale={locale} />
+            </div>
+          ) : null}
 
           <div className="mt-4 flex flex-wrap gap-2">
             <WishlistButton

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -7,6 +7,7 @@ import {
   listDistinctCategories,
   type ProductSort,
 } from '@/lib/commerce/products'
+import { recordSearchEvent } from '@/lib/commerce/search-events'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { ProductCard } from '@/components/commerce/product-card'
@@ -77,6 +78,17 @@ export default async function StorePage({
     loadPygRates(),
     listDistinctCategories(business.id),
   ])
+
+  // Record shopper searches only when there's an actual query term — avoids
+  // a log entry on every tienda page view. Fire-and-forget, non-blocking.
+  if (search) {
+    void recordSearchEvent({
+      businessId: business.id,
+      query: search,
+      resultCount: totalCount,
+      source: 'tienda',
+    })
+  }
 
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
   const hasActiveFilters = Boolean(

--- a/web/components/commerce/back-in-stock-signup.tsx
+++ b/web/components/commerce/back-in-stock-signup.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Props {
+  siteSlug: string
+  productId: string
+  locale?: string
+}
+
+/**
+ * Email capture shown on agotado PDPs. On submit, POSTs to
+ * /api/storefront/[site]/back-in-stock. One-shot — switches to a
+ * confirmation message on success; no second submit allowed in this
+ * session.
+ */
+export function BackInStockSignup({ siteSlug, productId, locale = 'es' }: Props) {
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle')
+  const [errorMsg, setErrorMsg] = useState('')
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const clean = email.trim()
+    if (!clean.includes('@')) {
+      setStatus('error')
+      setErrorMsg('Ingresá un email válido.')
+      return
+    }
+    setStatus('sending')
+    try {
+      const res = await fetch(`/api/storefront/${encodeURIComponent(siteSlug)}/back-in-stock`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ productId, email: clean, locale }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        setStatus('error')
+        setErrorMsg(data.error === 'invalid_email' ? 'Email inválido.' : 'No pudimos guardar tu email. Probá de nuevo.')
+        return
+      }
+      setStatus('sent')
+    } catch {
+      setStatus('error')
+      setErrorMsg('Error de red. Probá de nuevo.')
+    }
+  }
+
+  if (status === 'sent') {
+    return (
+      <div className="rounded-lg bg-green-50 p-4 text-sm text-green-900">
+        <p className="font-semibold">✓ Te avisamos cuando vuelva.</p>
+        <p className="mt-1 text-xs">
+          Te mandamos un email a <strong>{email}</strong> en cuanto tengamos stock. Sin spam, solo este aviso.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4">
+      <p className="mb-1 text-sm font-semibold text-[color:var(--text,#111)]">Avisame cuando vuelva</p>
+      <p className="mb-3 text-xs text-[color:var(--text-muted,#6b7280)]">
+        Te mandamos un solo email cuando esté disponible. Nada más.
+      </p>
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <label className="flex-1">
+          <span className="sr-only">Email</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="tu@email.com"
+            required
+            className="block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm focus:border-[color:var(--primary,#111)] focus:outline-none"
+            disabled={status === 'sending'}
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={status === 'sending'}
+          className="rounded-lg bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-semibold text-[color:var(--primary-foreground,#fff)] disabled:opacity-50"
+        >
+          {status === 'sending' ? 'Enviando…' : 'Avisame'}
+        </button>
+      </div>
+      {status === 'error' ? (
+        <p role="alert" className="mt-2 text-xs text-red-700">
+          {errorMsg}
+        </p>
+      ) : null}
+    </form>
+  )
+}

--- a/web/components/sections/trust-badges-section.tsx
+++ b/web/components/sections/trust-badges-section.tsx
@@ -1,0 +1,95 @@
+import { Container } from '@/components/ui/container'
+
+export interface TrustBadgeItem {
+  /** lucide-react icon name. Unknown names fall back to a generic dot. */
+  icon?: string
+  /** Short label for the badge. */
+  text?: string
+  /** Some content files use `title` instead of `text` — both accepted. */
+  title?: string
+  /** Optional secondary description. */
+  description?: string
+}
+
+export interface TrustBadgesSectionProps {
+  /** Array form: content.home.trustBadges. */
+  items?: TrustBadgeItem[]
+  /** Object form: content.home.trustBadges.items for consistency with other sections. */
+  badges?: TrustBadgeItem[]
+  title?: string
+  eyebrow?: string
+}
+
+/**
+ * Horizontal strip of tenant trust signals (envío discreto / pago seguro
+ * / atención, etc.). Renders above or below the hero as configured.
+ * Accepts either `items`/`badges`/bare-array content shapes so tenants
+ * whose content was authored in different eras still work.
+ *
+ * Icon rendering intentionally minimal — uses a small circle + emoji-ish
+ * fallback so we don't need to import all of lucide. The text is the
+ * payload; the glyph is decoration.
+ */
+const ICON_MAP: Record<string, string> = {
+  truck: '🚚',
+  shield: '🛡️',
+  package: '📦',
+  heart: '❤',
+  lock: '🔒',
+  bolt: '⚡',
+  check: '✓',
+  star: '★',
+  leaf: '🌿',
+  clock: '⏱',
+  phone: '📞',
+  chat: '💬',
+  smile: '😊',
+  refresh: '↻',
+}
+
+function glyph(icon?: string): string {
+  if (!icon) return '✓'
+  return ICON_MAP[icon.toLowerCase()] ?? '✓'
+}
+
+export function TrustBadgesSection({ items, badges, title, eyebrow }: TrustBadgesSectionProps) {
+  const list = (items ?? badges ?? []).filter((b) => b && (b.text || b.title))
+  if (list.length === 0) return null
+
+  return (
+    <section className="py-8">
+      <Container>
+        {eyebrow || title ? (
+          <div className="mb-4 text-center">
+            {eyebrow ? (
+              <p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--text-muted,#6b7280)]">
+                {eyebrow}
+              </p>
+            ) : null}
+            {title ? (
+              <p className="mt-1 text-lg font-semibold text-[color:var(--text,#111)]">{title}</p>
+            ) : null}
+          </div>
+        ) : null}
+        <ul className="grid grid-cols-2 gap-4 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4 sm:grid-cols-3 md:grid-cols-4">
+          {list.map((b, i) => {
+            const label = b.text ?? b.title ?? ''
+            return (
+              <li key={`${label}-${i}`} className="flex items-center gap-2 text-sm">
+                <span aria-hidden="true" className="text-lg">
+                  {glyph(b.icon)}
+                </span>
+                <div>
+                  <p className="font-medium text-[color:var(--text,#111)]">{label}</p>
+                  {b.description ? (
+                    <p className="text-xs text-[color:var(--text-muted,#6b7280)]">{b.description}</p>
+                  ) : null}
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      </Container>
+    </section>
+  )
+}

--- a/web/lib/commerce/back-in-stock.ts
+++ b/web/lib/commerce/back-in-stock.ts
@@ -1,0 +1,140 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import { logger } from '@/lib/logger'
+
+/**
+ * Shopper-facing subscribe: records an email against a product so we
+ * can notify when inventory returns. Idempotent on (business_id, product_id, email)
+ * thanks to the UNIQUE constraint — a duplicate is a no-op.
+ */
+export async function subscribeBackInStock(opts: {
+  businessId: string
+  productId: string
+  email: string
+  locale?: string
+}): Promise<{ ok: true } | { ok: false; code: 'invalid_email' | 'insert_failed' }> {
+  const email = opts.email.trim().toLowerCase()
+  if (!email.includes('@') || email.length > 200) {
+    return { ok: false, code: 'invalid_email' }
+  }
+  const supabase = await createAdminClient()
+  const { error } = await supabase
+    .from('back_in_stock_subscriptions')
+    .upsert(
+      {
+        business_id: opts.businessId,
+        product_id: opts.productId,
+        email,
+        locale: opts.locale ?? 'es',
+        notified_at: null,
+      },
+      { onConflict: 'business_id,product_id,email', ignoreDuplicates: true },
+    )
+  if (error) {
+    logger.warn('[back-in-stock] subscribe failed', {
+      action: 'commerce.back_in_stock.subscribe_failed',
+      businessId: opts.businessId,
+      productId: opts.productId,
+      error: error.message,
+    })
+    return { ok: false, code: 'insert_failed' }
+  }
+  return { ok: true }
+}
+
+export interface PendingSubscription {
+  subscriptionId: string
+  businessId: string
+  productId: string
+  productName: string
+  productSlug: string
+  productUrl: string
+  email: string
+  locale: string
+}
+
+/**
+ * Scan for subscriptions on products that are currently back in stock
+ * (inventory_qty > 0 OR policy = 'continue'). Paginated externally via
+ * the cron that calls this. Returns the payload the email renderer
+ * needs, not the raw row.
+ */
+export async function findPendingBackInStockNotifications(limit = 50): Promise<PendingSubscription[]> {
+  const supabase = await createAdminClient()
+  const { data, error } = await supabase
+    .from('back_in_stock_subscriptions')
+    .select(
+      `
+      id, business_id, product_id, email, locale,
+      products!inner (
+        slug, name, inventory_qty, inventory_policy, status
+      ),
+      businesses!inner (
+        slug
+      )
+    `,
+    )
+    .is('notified_at', null)
+    .order('created_at', { ascending: true })
+    .limit(limit)
+  if (error) {
+    logger.error('[back-in-stock] pending scan failed', {
+      action: 'commerce.back_in_stock.scan_failed',
+      error: error.message,
+    })
+    return []
+  }
+  // PostgREST embedded joins come back as arrays even for single-row
+  // relations when declared without `!inner`-style hints. Accept both
+  // shapes (object | array) defensively.
+  type EmbeddedProduct = { slug: string; name: string; inventory_qty: number; inventory_policy: string; status: string }
+  type EmbeddedBusiness = { slug: string }
+  const rows = (Array.isArray(data) ? data : []) as Array<{
+    id: string
+    business_id: string
+    product_id: string
+    email: string
+    locale: string
+    products: EmbeddedProduct | EmbeddedProduct[] | null
+    businesses: EmbeddedBusiness | EmbeddedBusiness[] | null
+  }>
+
+  const pickOne = <T,>(v: T | T[] | null): T | null => {
+    if (!v) return null
+    return Array.isArray(v) ? v[0] ?? null : v
+  }
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://paragu-ai.com'
+
+  return rows
+    .map((r) => ({ raw: r, product: pickOne(r.products), business: pickOne(r.businesses) }))
+    .filter(({ product, business }) => {
+      if (!product || !business || product.status !== 'active') return false
+      return product.inventory_policy === 'continue' || product.inventory_qty > 0
+    })
+    .map(({ raw, product, business }) => ({
+      subscriptionId: raw.id,
+      businessId: raw.business_id,
+      productId: raw.product_id,
+      productName: product!.name,
+      productSlug: product!.slug,
+      productUrl: `${appUrl}/s/${raw.locale}/${business!.slug}/producto/${product!.slug}`,
+      email: raw.email,
+      locale: raw.locale,
+    }))
+}
+
+/** Mark a subscription as notified. Idempotent. */
+export async function markNotified(subscriptionId: string): Promise<void> {
+  const supabase = await createAdminClient()
+  const { error } = await supabase
+    .from('back_in_stock_subscriptions')
+    .update({ notified_at: new Date().toISOString() })
+    .eq('id', subscriptionId)
+  if (error) {
+    logger.warn('[back-in-stock] markNotified failed', {
+      action: 'commerce.back_in_stock.mark_notified_failed',
+      subscriptionId,
+      error: error.message,
+    })
+  }
+}

--- a/web/lib/commerce/email-templates.ts
+++ b/web/lib/commerce/email-templates.ts
@@ -92,6 +92,26 @@ export function cartRecoveryEmail(ctx: CartRecoveryContext) {
   }
 }
 
+export interface BackInStockContext {
+  productName: string
+  productUrl: string
+  businessName: string
+}
+
+export function backInStockEmail(ctx: BackInStockContext) {
+  return {
+    subject: `¡${ctx.productName} volvió al stock!`,
+    html: `
+<!doctype html><html><body style="font-family:system-ui,-apple-system,sans-serif;color:#111;max-width:600px;margin:0 auto;padding:24px;">
+  <h1 style="font-size:20px;">Tu producto volvió</h1>
+  <p><strong>${escape(ctx.productName)}</strong> está otra vez disponible en ${escape(ctx.businessName)}.</p>
+  <p style="margin:24px 0;"><a href="${ctx.productUrl}" style="display:inline-block;background:#111;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Comprar ahora</a></p>
+  <p style="color:#666;font-size:12px;margin-top:24px;">Este es el único aviso que vas a recibir por este producto. Si ya no te interesa, ignorá este mensaje.</p>
+  <p style="color:#666;font-size:12px;">${escape(ctx.businessName)} · enviado desde Paragu-AI</p>
+</body></html>`.trim(),
+  }
+}
+
 function escape(s: string): string {
   return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!))
 }

--- a/web/lib/commerce/products.ts
+++ b/web/lib/commerce/products.ts
@@ -1,6 +1,7 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { scopedQueries } from '@/lib/supabase/scoped'
 import type { Product, ProductCreate, ProductUpdate } from '@/lib/schemas/commerce/product'
+import { normalizeSearchTerm } from './search-normalize'
 
 interface ProductRow {
   id: string
@@ -99,11 +100,14 @@ export async function listActiveProducts(
       let query = q.eq('status', 'active').order(sort.column, { ascending: sort.ascending })
       if (opts.category) query = query.eq('category', opts.category)
       if (opts.search && opts.search.trim()) {
-        // Match name OR description OR SKU. ilike = case-insensitive substring.
-        // Not accent-insensitive at the DB level — fine for catalogs <5k; swap
-        // for tsvector+unaccent+GIN when a tenant outgrows this.
-        const pat = `%${escapeIlike(opts.search.trim())}%`
-        query = query.or(`name.ilike.${pat},description.ilike.${pat},sku.ilike.${pat}`)
+        // Accent-insensitive search. The DB carries a generated
+        // `search_haystack` column = lower(unaccent(name+desc+sku)). We
+        // normalize the user's input to the same shape (NFD strip +
+        // lowercase) and ilike against the haystack, so "uñas" matches
+        // stored "unas" and vice versa. Backed by a GIN trgm index.
+        const normalized = normalizeSearchTerm(opts.search)
+        const pat = `%${escapeIlike(normalized)}%`
+        query = query.ilike('search_haystack', pat)
       }
       if (typeof opts.minPriceCents === 'number') query = query.gte('price_cents', opts.minPriceCents)
       if (typeof opts.maxPriceCents === 'number') query = query.lte('price_cents', opts.maxPriceCents)
@@ -151,8 +155,11 @@ export async function countActiveProducts(
     .eq('status', 'active')
   if (opts.category) query = query.eq('category', opts.category)
   if (opts.search && opts.search.trim()) {
-    const pat = `%${escapeIlike(opts.search.trim())}%`
-    query = query.or(`name.ilike.${pat},description.ilike.${pat},sku.ilike.${pat}`)
+    // See listActiveProducts for rationale — match the same shape as the
+    // DB-side search_haystack column.
+    const normalized = normalizeSearchTerm(opts.search)
+    const pat = `%${escapeIlike(normalized)}%`
+    query = query.ilike('search_haystack', pat)
   }
   if (typeof opts.minPriceCents === 'number') query = query.gte('price_cents', opts.minPriceCents)
   if (typeof opts.maxPriceCents === 'number') query = query.lte('price_cents', opts.maxPriceCents)

--- a/web/lib/commerce/search-events.ts
+++ b/web/lib/commerce/search-events.ts
@@ -1,0 +1,124 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import { logger } from '@/lib/logger'
+import { normalizeSearchTerm } from './search-normalize'
+
+export type SearchEventSource = 'tienda' | 'suggest' | 'header'
+
+/**
+ * Fire-and-forget record of a shopper search. Non-blocking —
+ * failures are logged and swallowed so the UI is never affected.
+ * Powers the admin analytics view (top queries, zero-result queries).
+ */
+export async function recordSearchEvent(opts: {
+  businessId: string
+  query: string
+  resultCount: number
+  source: SearchEventSource
+  sessionToken?: string | null
+}): Promise<void> {
+  const clean = opts.query.trim()
+  if (!clean) return
+  try {
+    const supabase = await createAdminClient()
+    const { error } = await supabase.from('search_events').insert({
+      business_id: opts.businessId,
+      query: clean,
+      query_normalized: normalizeSearchTerm(clean),
+      result_count: opts.resultCount,
+      source: opts.source,
+      session_token: opts.sessionToken ?? null,
+    })
+    if (error) {
+      logger.warn('[search-events] insert failed', {
+        action: 'commerce.search_event.insert_failed',
+        error: error.message,
+      })
+    }
+  } catch (err) {
+    logger.warn('[search-events] insert threw', {
+      action: 'commerce.search_event.threw',
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+export interface SearchEventSummary {
+  queryNormalized: string
+  sampleQuery: string
+  hits: number
+  avgResults: number
+  zeroResultHits: number
+  lastSeen: string
+}
+
+/**
+ * Admin summary: top search queries in a window, aggregated by their
+ * normalized form so "uñas"/"Uñas"/"unas" collapse into one row. Sort
+ * by total hits desc.
+ */
+export async function listTopSearches(
+  businessId: string,
+  opts: { windowDays?: number; limit?: number; zeroResultOnly?: boolean } = {},
+): Promise<SearchEventSummary[]> {
+  const windowDays = opts.windowDays ?? 30
+  const limit = opts.limit ?? 20
+  const supabase = await createAdminClient()
+  const since = new Date(Date.now() - windowDays * 86_400_000).toISOString()
+  let query = supabase
+    .from('search_events')
+    .select('query, query_normalized, result_count, created_at')
+    .eq('business_id', businessId)
+    .gte('created_at', since)
+    .order('created_at', { ascending: false })
+    .limit(5000)
+  if (opts.zeroResultOnly) query = query.eq('result_count', 0)
+  const { data } = await query
+
+  const rows = (Array.isArray(data) ? data : []) as Array<{
+    query: string
+    query_normalized: string
+    result_count: number
+    created_at: string
+  }>
+
+  // Aggregate in-process. At 5k rows / 30 days this costs nothing.
+  const agg = new Map<string, {
+    queryNormalized: string
+    sampleQuery: string
+    hits: number
+    resultsSum: number
+    zeroResultHits: number
+    lastSeen: string
+  }>()
+  for (const r of rows) {
+    const key = r.query_normalized
+    const current = agg.get(key)
+    if (current) {
+      current.hits += 1
+      current.resultsSum += r.result_count
+      if (r.result_count === 0) current.zeroResultHits += 1
+      if (r.created_at > current.lastSeen) current.lastSeen = r.created_at
+    } else {
+      agg.set(key, {
+        queryNormalized: key,
+        sampleQuery: r.query,
+        hits: 1,
+        resultsSum: r.result_count,
+        zeroResultHits: r.result_count === 0 ? 1 : 0,
+        lastSeen: r.created_at,
+      })
+    }
+  }
+  const list: SearchEventSummary[] = [...agg.values()]
+    .map((v) => ({
+      queryNormalized: v.queryNormalized,
+      sampleQuery: v.sampleQuery,
+      hits: v.hits,
+      avgResults: v.hits > 0 ? Math.round(v.resultsSum / v.hits) : 0,
+      zeroResultHits: v.zeroResultHits,
+      lastSeen: v.lastSeen,
+    }))
+    .sort((a, b) => b.hits - a.hits)
+    .slice(0, limit)
+  return list
+}

--- a/web/lib/commerce/search-normalize.ts
+++ b/web/lib/commerce/search-normalize.ts
@@ -1,0 +1,17 @@
+/**
+ * Normalize a search term to the same shape as `products.search_haystack`:
+ * lowercased, Unicode-decomposed, stripped of combining marks. Matches the
+ * DB-side `lower(unaccent(...))` closely enough for Spanish (á/é/í/ó/ú/ñ
+ * all fold to their base letter) without pulling in a full i18n library.
+ *
+ * Used in both listActiveProducts (filter side) and search-suggest (API)
+ * so the user can type "uñas" and match products stored as "unas",
+ * or vice versa. Shared to keep the normalization rule in one place.
+ */
+export function normalizeSearchTerm(raw: string): string {
+  return raw
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // strip combining diacritics
+    .toLowerCase()
+    .trim()
+}

--- a/web/lib/engine/section-registry.ts
+++ b/web/lib/engine/section-registry.ts
@@ -133,6 +133,15 @@ export const SECTION_CATALOG: Record<string, SectionManifest> = {
     defaultVariant: 'modal',
     variants: ['modal'],
   },
+  'trust-badges': {
+    // Horizontal strip of short trust signals (envío discreto / pago
+    // seguro / etc.) driven by content.home.trustBadges or similar
+    // content ref. Simpler than `trust-signals` which is a
+    // credentials/logos-row section; this one is a pure badge strip.
+    id: 'trust-badges',
+    defaultVariant: 'strip',
+    variants: ['strip'],
+  },
   footer: {
     id: 'footer',
     defaultVariant: 'standard',

--- a/web/lib/engine/site-renderer.tsx
+++ b/web/lib/engine/site-renderer.tsx
@@ -15,6 +15,7 @@ import { ProductCatalogSection } from '@/components/sections/product-catalog-sec
 import { FeaturedProductsSection } from '@/components/sections/featured-products-section'
 import { CommerceCatalogSection } from '@/components/sections/commerce-catalog-section'
 import { AgeGateSection } from '@/components/sections/age-gate-section'
+import { TrustBadgesSection } from '@/components/sections/trust-badges-section'
 import { GallerySection } from '@/components/sections/gallery-section'
 import { TeamSection } from '@/components/sections/team-section'
 import { TestimonialsSection } from '@/components/sections/testimonials-section'
@@ -55,6 +56,7 @@ const COMPONENTS: Record<string, React.ComponentType<any>> = {
   'featured-products': FeaturedProductsSection,
   'commerce-catalog': CommerceCatalogSection,
   'age-gate': AgeGateSection,
+  'trust-badges': TrustBadgesSection,
   gallery: GallerySection,
   team: TeamSection,
   testimonials: TestimonialsSection,


### PR DESCRIPTION
Four compounding additions. All platform-wide, no client input required.

## Prereq — DB migrations (applied via Supabase MCP already)
- \`unaccent\` + \`pg_trgm\` extensions
- Generated \`products.search_haystack\` column (+ GIN trgm index)
- \`back_in_stock_subscriptions\` table
- \`search_events\` table
- Extended \`commerce_email_outbox.template\` CHECK to allow \`back_in_stock\`

## 1. Accent-insensitive search
- Haystack = \`lower(unaccent(name || description || sku))\` generated column
- JS-side normalizer strips combining marks + lowercases
- listActiveProducts + countActiveProducts now ilike against the haystack
- "uñas" / "Uñas" / "unas" all match stored values regardless of accent

## 2. Search analytics
- Record on /tienda GET (when ?q=) and on /search-suggest hits
- New admin page \`/admin/commerce/[id]/search-analytics\` with 7/14/30/60/90-day windows, "solo sin resultados" filter, \"gap\" badge when zero-results dominate
- Aggregates by query_normalized so "uñas/Uñas/unas" collapse

## 3. Back-in-stock notifications
- Shopper email capture on agotado PDPs → \`POST /api/storefront/[site]/back-in-stock\`
- New cron \`/api/cron/commerce-back-in-stock\` scans + enqueues into existing outbox
- \`backInStockEmail\` template + allowed template value
- One-shot form with confirmation UI

## 4. Trust-badges strip section
- \`<TrustBadgesSection>\` glyph+label grid, accepts items/badges/array shapes
- Registered in engine + retail-local whitelist
- fun4me opt-in: reshaped content + added to home + store pages

## Test plan
- [x] typecheck / tests / build clean
- [ ] Post-deploy: search "vibrador" and "vibrador" (with accent) return same results
- [ ] Admin /admin/commerce/[id]/search-analytics renders
- [ ] PDP for an agotado product shows BackInStockSignup
- [ ] fun4me /store has trust-badges row after hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)