### PR TITLE
feat(fun4me): compliance-disclaimer-footer across all pages

### DIFF
--- a/sites/fun4me/content/es.json
+++ b/sites/fun4me/content/es.json
@@ -1554,5 +1554,15 @@
       "sunday": "Domingo: Cerrado",
       "holidays": "Feriados: Cerrado (consultar por WhatsApp para urgencias)"
     }
+  },
+  "compliance": {
+    "paragraphs": [
+      "fun4me es un comercio de venta de productos para adultos. El acceso al sitio está restringido a personas mayores de 18 años. Al ingresar, confirmás que sos mayor de edad bajo las leyes de la República del Paraguay.",
+      "Las imágenes y descripciones de productos son de carácter comercial. Los productos se comercializan conforme a la Ley de Defensa del Consumidor Nº 1334/98 y demás normativa aplicable.",
+      "Los envíos se realizan en empaque neutro sin referencias al contenido. fun4me no comparte datos personales con terceros salvo lo estrictamente necesario para procesar el pedido (empresa de envíos, procesador de pagos)."
+    ],
+    "licenseNumbers": [],
+    "linkText": "Leer política de privacidad completa",
+    "linkHref": "/s/es/fun4me/legal"
   }
 }

--- a/sites/fun4me/pages/blog.json
+++ b/sites/fun4me/pages/blog.json
@@ -39,6 +39,11 @@
       "content": "footer"
     },
     {
+      "id": "compliance-disclaimer-footer",
+      "variant": "standard",
+      "content": "compliance"
+    },
+    {
       "id": "whatsapp-float",
       "variant": "standard",
       "content": "whatsapp"

--- a/sites/fun4me/pages/bundles.json
+++ b/sites/fun4me/pages/bundles.json
@@ -29,6 +29,11 @@
       "content": "footer"
     },
     {
+      "id": "compliance-disclaimer-footer",
+      "variant": "standard",
+      "content": "compliance"
+    },
+    {
       "id": "whatsapp-float",
       "variant": "standard",
       "content": "whatsapp"

--- a/sites/fun4me/pages/gift-cards.json
+++ b/sites/fun4me/pages/gift-cards.json
@@ -39,6 +39,11 @@
       "content": "footer"
     },
     {
+      "id": "compliance-disclaimer-footer",
+      "variant": "standard",
+      "content": "compliance"
+    },
+    {
       "id": "whatsapp-float",
       "variant": "standard",
       "content": "whatsapp"

--- a/sites/fun4me/pages/home.json
+++ b/sites/fun4me/pages/home.json
@@ -69,6 +69,11 @@
       "content": "footer"
     },
     {
+      "id": "compliance-disclaimer-footer",
+      "variant": "standard",
+      "content": "compliance"
+    },
+    {
       "id": "whatsapp-float",
       "variant": "standard",
       "content": "whatsapp"

--- a/sites/fun4me/pages/loyalty.json
+++ b/sites/fun4me/pages/loyalty.json
@@ -34,6 +34,11 @@
       "content": "footer"
     },
     {
+      "id": "compliance-disclaimer-footer",
+      "variant": "standard",
+      "content": "compliance"
+    },
+    {
       "id": "whatsapp-float",
       "variant": "standard",
       "content": "whatsapp"

--- a/sites/fun4me/pages/placer-plus.json
+++ b/sites/fun4me/pages/placer-plus.json
@@ -29,6 +29,11 @@
       "content": "footer"
     },
     {
+      "id": "compliance-disclaimer-footer",
+      "variant": "standard",
+      "content": "compliance"
+    },
+    {
       "id": "whatsapp-float",
       "variant": "standard",
       "content": "whatsapp"

--- a/sites/fun4me/pages/reserva-en-tienda.json
+++ b/sites/fun4me/pages/reserva-en-tienda.json
@@ -39,6 +39,11 @@
       "content": "footer"
     },
     {
+      "id": "compliance-disclaimer-footer",
+      "variant": "standard",
+      "content": "compliance"
+    },
+    {
       "id": "whatsapp-float",
       "variant": "standard",
       "content": "whatsapp"

--- a/sites/fun4me/pages/size-guide.json
+++ b/sites/fun4me/pages/size-guide.json
@@ -44,6 +44,11 @@
       "content": "footer"
     },
     {
+      "id": "compliance-disclaimer-footer",
+      "variant": "standard",
+      "content": "compliance"
+    },
+    {
       "id": "whatsapp-float",
       "variant": "standard",
       "content": "whatsapp"

--- a/sites/fun4me/pages/store.json
+++ b/sites/fun4me/pages/store.json
@@ -39,6 +39,11 @@
       "content": "footer"
     },
     {
+      "id": "compliance-disclaimer-footer",
+      "variant": "standard",
+      "content": "compliance"
+    },
+    {
       "id": "whatsapp-float",
       "variant": "standard",
       "content": "whatsapp"

--- a/sites/fun4me/pages/suscripciones.json
+++ b/sites/fun4me/pages/suscripciones.json
@@ -54,6 +54,11 @@
       "content": "footer"
     },
     {
+      "id": "compliance-disclaimer-footer",
+      "variant": "standard",
+      "content": "compliance"
+    },
+    {
       "id": "whatsapp-float",
       "variant": "standard",
       "content": "whatsapp"

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -9228,6 +9228,11 @@ export const PAGES: Record<string, JsonRecord> = {
         "variant": "standard"
       },
       {
+        "content": "compliance",
+        "id": "compliance-disclaimer-footer",
+        "variant": "standard"
+      },
+      {
         "content": "whatsapp",
         "id": "whatsapp-float",
         "variant": "standard"
@@ -9262,6 +9267,11 @@ export const PAGES: Record<string, JsonRecord> = {
       {
         "content": "footer",
         "id": "footer",
+        "variant": "standard"
+      },
+      {
+        "content": "compliance",
+        "id": "compliance-disclaimer-footer",
         "variant": "standard"
       },
       {
@@ -9309,6 +9319,11 @@ export const PAGES: Record<string, JsonRecord> = {
       {
         "content": "footer",
         "id": "footer",
+        "variant": "standard"
+      },
+      {
+        "content": "compliance",
+        "id": "compliance-disclaimer-footer",
         "variant": "standard"
       },
       {
@@ -9386,6 +9401,11 @@ export const PAGES: Record<string, JsonRecord> = {
       {
         "content": "footer",
         "id": "footer",
+        "variant": "standard"
+      },
+      {
+        "content": "compliance",
+        "id": "compliance-disclaimer-footer",
         "variant": "standard"
       },
       {
@@ -9488,6 +9508,11 @@ export const PAGES: Record<string, JsonRecord> = {
         "variant": "standard"
       },
       {
+        "content": "compliance",
+        "id": "compliance-disclaimer-footer",
+        "variant": "standard"
+      },
+      {
         "content": "whatsapp",
         "id": "whatsapp-float",
         "variant": "standard"
@@ -9522,6 +9547,11 @@ export const PAGES: Record<string, JsonRecord> = {
       {
         "content": "footer",
         "id": "footer",
+        "variant": "standard"
+      },
+      {
+        "content": "compliance",
+        "id": "compliance-disclaimer-footer",
         "variant": "standard"
       },
       {
@@ -9569,6 +9599,11 @@ export const PAGES: Record<string, JsonRecord> = {
       {
         "content": "footer",
         "id": "footer",
+        "variant": "standard"
+      },
+      {
+        "content": "compliance",
+        "id": "compliance-disclaimer-footer",
         "variant": "standard"
       },
       {
@@ -9624,6 +9659,11 @@ export const PAGES: Record<string, JsonRecord> = {
         "variant": "standard"
       },
       {
+        "content": "compliance",
+        "id": "compliance-disclaimer-footer",
+        "variant": "standard"
+      },
+      {
         "content": "whatsapp",
         "id": "whatsapp-float",
         "variant": "standard"
@@ -9668,6 +9708,11 @@ export const PAGES: Record<string, JsonRecord> = {
       {
         "content": "footer",
         "id": "footer",
+        "variant": "standard"
+      },
+      {
+        "content": "compliance",
+        "id": "compliance-disclaimer-footer",
         "variant": "standard"
       },
       {
@@ -9730,6 +9775,11 @@ export const PAGES: Record<string, JsonRecord> = {
       {
         "content": "footer",
         "id": "footer",
+        "variant": "standard"
+      },
+      {
+        "content": "compliance",
+        "id": "compliance-disclaimer-footer",
         "variant": "standard"
       },
       {
@@ -17484,6 +17534,16 @@ export const CONTENT: Record<string, JsonRecord> = {
         "description": "Kits armados para ahorrar. Primera vez, parejas, aniversario, BDSM, solitario. Cada kit ahorra vs comprar por separado.",
         "title": "Kits Curados Fun4Me | Combinaciones con ahorro"
       }
+    },
+    "compliance": {
+      "licenseNumbers": [],
+      "linkHref": "/s/es/fun4me/legal",
+      "linkText": "Leer política de privacidad completa",
+      "paragraphs": [
+        "fun4me es un comercio de venta de productos para adultos. El acceso al sitio está restringido a personas mayores de 18 años. Al ingresar, confirmás que sos mayor de edad bajo las leyes de la República del Paraguay.",
+        "Las imágenes y descripciones de productos son de carácter comercial. Los productos se comercializan conforme a la Ley de Defensa del Consumidor Nº 1334/98 y demás normativa aplicable.",
+        "Los envíos se realizan en empaque neutro sin referencias al contenido. fun4me no comparte datos personales con terceros salvo lo estrictamente necesario para procesar el pedido (empresa de envíos, procesador de pagos)."
+      ]
     },
     "contacto": {
       "faq": {

--- a/web/lib/engine/site-renderer.tsx
+++ b/web/lib/engine/site-renderer.tsx
@@ -46,6 +46,7 @@ import { EnhancedFAQSection } from '@/components/sections/enhanced-faq-section'
 import { OurStorySection } from '@/components/sections/our-story-section'
 import { B2BWholesaleSection } from '@/components/sections/b2b-wholesale-section'
 import { RecipeSection } from '@/components/sections/recipe-section'
+import { ComplianceDisclaimerFooterSection } from '@/components/sections/compliance-disclaimer-footer-section'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const COMPONENTS: Record<string, React.ComponentType<any>> = {
@@ -87,6 +88,7 @@ const COMPONENTS: Record<string, React.ComponentType<any>> = {
   'our-story': OurStorySection,
   'b2b-wholesale': B2BWholesaleSection,
   recipes: RecipeSection,
+  'compliance-disclaimer-footer': ComplianceDisclaimerFooterSection,
 }
 
 export function renderPage(page: ResolvedPage): React.ReactNode {


### PR DESCRIPTION
## Summary
- Wires the existing \`ComplianceDisclaimerFooterSection\` into \`site-renderer.tsx\` (it was in the codebase but never added to the COMPONENTS map, so no tenant could use it).
- Adds the section to all 10 customer-facing fun4me pages with fun4me-specific legal copy (adult-content attestation under PY law, Ley 1334/98, neutral-packaging privacy commitment).
- Closes a compliance gap: previously only the age-gate modal surfaced legal language; the disclaimer footer makes the legal posture persistent across every page visit.

## Test plan
- [x] Engine tests pass (24/24)
- [x] fun4me composes cleanly (15 home sections, +1 compliance on every page)
- [ ] Deploy → compliance text visible at bottom of every fun4me page
- [ ] Link to /legal works

🤖 Generated with [Claude Code](https://claude.com/claude-code)