### PR TITLE
feat(fun4me): promo-banner + newsletter-signup adopted

### DIFF
--- a/sites/fun4me/content/es.json
+++ b/sites/fun4me/content/es.json
@@ -420,6 +420,41 @@
           "icon": "Truck"
         }
       ]
+    },
+    "promoBanner": {
+      "promotions": [
+        {
+          "id": "bienvenida10",
+          "title": "Cupón BIENVENIDA10 — 10% OFF en tu primera compra",
+          "description": "Usá el código BIENVENIDA10 al pagar y ahorrá 10%. Válido hasta fin de mes.",
+          "code": "BIENVENIDA10",
+          "bgColor": "#7c3aed",
+          "textColor": "#ffffff",
+          "link": "/s/es/fun4me/tienda"
+        },
+        {
+          "id": "envio-gratis",
+          "title": "Envío gratis en pedidos sobre Gs 300.000",
+          "description": "Motoenvío gratis en Gran Asunción y encomienda sin cargo al interior.",
+          "bgColor": "#0891b2",
+          "textColor": "#ffffff",
+          "link": "/s/es/fun4me/tienda"
+        }
+      ],
+      "autoRotate": true,
+      "rotateInterval": 6000,
+      "dismissible": true,
+      "position": "top",
+      "variant": "carousel"
+    },
+    "newsletter": {
+      "title": "Novedades fun4me",
+      "subtitle": "Recibí avisos de lanzamientos, cupones exclusivos y guías de uso. Sin spam, sin compartir tu email.",
+      "placeholder": "tu@email.com",
+      "submitLabel": "Suscribirme",
+      "successMessage": "Listo. Revisá tu casilla para confirmar.",
+      "consentLabel": "Acepto recibir novedades y promociones de fun4me.",
+      "tenantSlug": "fun4me"
     }
   },
   "about": {

--- a/sites/fun4me/pages/home.json
+++ b/sites/fun4me/pages/home.json
@@ -9,6 +9,11 @@
       "content": "home.ageGate"
     },
     {
+      "id": "promo-banner",
+      "variant": "carousel",
+      "content": "home.promoBanner"
+    },
+    {
       "id": "header",
       "variant": "standard",
       "content": "navigation"
@@ -57,6 +62,11 @@
       "id": "faq",
       "variant": "accordion",
       "content": "home.faq"
+    },
+    {
+      "id": "newsletter-signup",
+      "variant": "standard",
+      "content": "home.newsletter"
     },
     {
       "id": "contact",

--- a/src/verticals/retail-local/vertical.json
+++ b/src/verticals/retail-local/vertical.json
@@ -19,7 +19,8 @@
     "commerce-catalog", "featured-products", "trust-signals", "age-gate", "trust-badges",
     "why-destination", "process-timeline", "enhanced-faq",
     "programs-comparison", "our-story", "team", "b2b-wholesale",
-    "booking-embed", "compliance-disclaimer-footer"
+    "booking-embed", "compliance-disclaimer-footer",
+    "promo-banner", "newsletter-signup"
   ],
   "defaultStarterKit": "minimal",
   "locales": ["es"]

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -9344,6 +9344,11 @@ export const PAGES: Record<string, JsonRecord> = {
         "variant": "modal"
       },
       {
+        "content": "home.promoBanner",
+        "id": "promo-banner",
+        "variant": "carousel"
+      },
+      {
         "content": "navigation",
         "id": "header",
         "variant": "standard"
@@ -9392,6 +9397,11 @@ export const PAGES: Record<string, JsonRecord> = {
         "content": "home.faq",
         "id": "faq",
         "variant": "accordion"
+      },
+      {
+        "content": "home.newsletter",
+        "id": "newsletter-signup",
+        "variant": "standard"
       },
       {
         "content": "home.contact",
@@ -17903,6 +17913,15 @@ export const CONTENT: Record<string, JsonRecord> = {
         "headline": "Tu Tienda de Placer",
         "subheadline": "Haz tus compras online o veni a visitarnos. Delivery a todo el pais con total discrecion."
       },
+      "newsletter": {
+        "consentLabel": "Acepto recibir novedades y promociones de fun4me.",
+        "placeholder": "tu@email.com",
+        "submitLabel": "Suscribirme",
+        "subtitle": "Recibí avisos de lanzamientos, cupones exclusivos y guías de uso. Sin spam, sin compartir tu email.",
+        "successMessage": "Listo. Revisá tu casilla para confirmar.",
+        "tenantSlug": "fun4me",
+        "title": "Novedades fun4me"
+      },
       "partners": {
         "logos": [
           {
@@ -17957,6 +17976,32 @@ export const CONTENT: Record<string, JsonRecord> = {
         "enabled": true,
         "href": "/fun4me/store",
         "text": "Envio GRATIS en compras mayores a Gs. 200.000"
+      },
+      "promoBanner": {
+        "autoRotate": true,
+        "dismissible": true,
+        "position": "top",
+        "promotions": [
+          {
+            "bgColor": "#7c3aed",
+            "code": "BIENVENIDA10",
+            "description": "Usá el código BIENVENIDA10 al pagar y ahorrá 10%. Válido hasta fin de mes.",
+            "id": "bienvenida10",
+            "link": "/s/es/fun4me/tienda",
+            "textColor": "#ffffff",
+            "title": "Cupón BIENVENIDA10 — 10% OFF en tu primera compra"
+          },
+          {
+            "bgColor": "#0891b2",
+            "description": "Motoenvío gratis en Gran Asunción y encomienda sin cargo al interior.",
+            "id": "envio-gratis",
+            "link": "/s/es/fun4me/tienda",
+            "textColor": "#ffffff",
+            "title": "Envío gratis en pedidos sobre Gs 300.000"
+          }
+        ],
+        "rotateInterval": 6000,
+        "variant": "carousel"
       },
       "seo": {
         "description": "Juguetes para adultos, lenceria, accesorios y mas. Compra online con envio discreto a todo Paraguay. Tienda fisica en Asuncion. Solo mayores de 18.",
@@ -26698,7 +26743,9 @@ export const VERTICALS: Record<string, JsonRecord> = {
       "team",
       "b2b-wholesale",
       "booking-embed",
-      "compliance-disclaimer-footer"
+      "compliance-disclaimer-footer",
+      "promo-banner",
+      "newsletter-signup"
     ],
     "baseType": "retail_base",
     "defaultStarterKit": "minimal",

--- a/web/lib/engine/section-registry.ts
+++ b/web/lib/engine/section-registry.ts
@@ -329,6 +329,17 @@ export const SECTION_CATALOG: Record<string, SectionManifest> = {
     variants: ['grid'],
     requiredContentFields: ['business'],
   },
+  'promo-banner': {
+    id: 'promo-banner',
+    defaultVariant: 'countdown',
+    variants: ['countdown', 'simple', 'carousel'],
+    requiredContentFields: ['promotions'],
+  },
+  'newsletter-signup': {
+    id: 'newsletter-signup',
+    defaultVariant: 'standard',
+    variants: ['standard'],
+  },
 }
 
 /**

--- a/web/lib/engine/site-renderer.tsx
+++ b/web/lib/engine/site-renderer.tsx
@@ -47,6 +47,8 @@ import { OurStorySection } from '@/components/sections/our-story-section'
 import { B2BWholesaleSection } from '@/components/sections/b2b-wholesale-section'
 import { RecipeSection } from '@/components/sections/recipe-section'
 import { ComplianceDisclaimerFooterSection } from '@/components/sections/compliance-disclaimer-footer-section'
+import { PromoBannerSection } from '@/components/sections/promo-banner-section'
+import { NewsletterSignupSection } from '@/components/sections/newsletter-signup-section'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const COMPONENTS: Record<string, React.ComponentType<any>> = {
@@ -89,6 +91,8 @@ const COMPONENTS: Record<string, React.ComponentType<any>> = {
   'b2b-wholesale': B2BWholesaleSection,
   recipes: RecipeSection,
   'compliance-disclaimer-footer': ComplianceDisclaimerFooterSection,
+  'promo-banner': PromoBannerSection,
+  'newsletter-signup': NewsletterSignupSection,
 }
 
 export function renderPage(page: ResolvedPage): React.ReactNode {


### PR DESCRIPTION
## Summary
Wires two more previously-unused sections into the platform and enables them for fun4me.

**PromoBannerSection** — auto-rotating top banner with two promotions (\`BIENVENIDA10\` 10% off + envío gratis >Gs 300k). Dismissible, carousel variant.

**NewsletterSignupSection** — email capture between FAQ and contact on the home page. POSTs to the existing \`/api/newsletter\` Mailchimp endpoint (double opt-in). Copy framed around discretion.

Both components existed in \`web/components/sections/\` but were unreachable: not in the \`section-registry\`, not wired into \`site-renderer.tsx\`, not in \`retail-local\` \`allowedSections\`. This PR closes all three gaps.

## Test plan
- [x] 62/62 engine + component tests pass
- [x] fun4me home composes with 17 sections (was 15)
- [ ] Deploy → top banner rotates through BIENVENIDA10 and envío gratis
- [ ] Deploy → newsletter form accepts email + consent, gets 200 from /api/newsletter

🤖 Generated with [Claude Code](https://claude.com/claude-code)