### PR TITLE
feat(fun4me): /quienes-somos page + adoption status

### DIFF
--- a/sites/fun4me/content/es.json
+++ b/sites/fun4me/content/es.json
@@ -30,6 +30,10 @@
         "href": "/fun4me/store"
       },
       {
+        "label": "Nosotros",
+        "href": "/fun4me/quienes-somos"
+      },
+      {
         "label": "Kits",
         "href": "/fun4me/bundles"
       },
@@ -458,40 +462,61 @@
     }
   },
   "about": {
-    "intro": {
-      "title": "Sobre Fun4Me",
-      "text": "Fun4Me nacio en 2018 con la mision de ofrecer productos de calidad para adultos en Paraguay, con la discrecion y el profesionalismo que nuestros clientes merecen. Desde nuestra tienda en Herrera 875, Asuncion, atendemos a clientes de todo el pais con envios discretos y seguros. Creemos que cada persona tiene derecho a explorar su intimidad de manera segura y sin juicios."
+    "seo": {
+      "title": "Quiénes Somos — fun4me",
+      "description": "Conocé el proyecto detrás de fun4me: un comercio discreto y profesional de productos para adultos en Paraguay."
     },
-    "mission": {
-      "title": "Nuestra Mision",
-      "text": "Ofrecer productos de calidad para adultos con total discrecion, profesionalismo y respeto. Queremos que cada cliente se sienta comodo explorando su intimidad con productos seguros y de las mejores marcas."
+    "hero": {
+      "headline": "Un proyecto pensado en Paraguay",
+      "subheadline": "Nacimos para dar acceso profesional y discreto a una categoría que todavía carga estigma en nuestra región. Sin juzgar, sin vender lo que no conocemos, sin comprometer tu privacidad.",
+      "ctaPrimaryText": "Ver catálogo",
+      "ctaPrimaryHref": "/s/es/fun4me/tienda",
+      "ctaSecondaryText": "Hablar con nosotros",
+      "ctaSecondaryHref": "/s/es/fun4me#contacto",
+      "eyebrow": "Sobre fun4me"
     },
-    "vision": {
-      "title": "Nuestra Vision",
-      "text": "Ser la tienda de referencia en Paraguay para productos de adultos, reconocida por la calidad, la discrecion de nuestro servicio y la confianza que generamos en nuestros clientes."
+    "values": {
+      "eyebrow": "Cómo trabajamos",
+      "title": "Principios que guían todas nuestras decisiones",
+      "pillars": [
+        {
+          "icon": "Shield",
+          "title": "Discreción por diseño",
+          "description": "No es un feature: es el punto de partida. Empaque neutro, facturación opcional, WhatsApp privado, sin tu nombre en estados de cuenta.",
+          "bullets": [
+            "Empaque sin marca",
+            "Factura a nombre genérico",
+            "Datos no se comparten"
+          ]
+        },
+        {
+          "icon": "Award",
+          "title": "Curaduría honesta",
+          "description": "Solo vendemos productos que testeamos, de marcas establecidas con trayectoria en la industria. Si no lo recomendaríamos a alguien cercano, no está en el catálogo.",
+          "bullets": [
+            "Marcas internacionales",
+            "Guías de uso detalladas",
+            "Soporte post-venta real"
+          ]
+        },
+        {
+          "icon": "Heart",
+          "title": "Educación antes que venta",
+          "description": "El placer y la salud sexual son temas serios que merecen información seria. Por eso publicamos guías prácticas y respondemos consultas sin vender.",
+          "bullets": [
+            "Blog con contenido de salud",
+            "Consultas sin obligación de compra",
+            "Producto correcto, no el más caro"
+          ]
+        }
+      ],
+      "honestNote": "Somos un equipo pequeño basado en Paraguay. No somos multinacionales — somos gente que cree que este mercado merece un servicio mejor del que históricamente tuvo."
     },
-    "values": [
-      {
-        "icon": "eye-slash",
-        "title": "Discrecion Total",
-        "text": "Entendemos la importancia de la privacidad. Desde el empaque hasta la facturacion, todo es 100% discreto."
-      },
-      {
-        "icon": "truck",
-        "title": "Envio a Todo el Pais",
-        "text": "Delivery rapido y seguro a cualquier punto de Paraguay con total confidencialidad."
-      },
-      {
-        "icon": "shield-check",
-        "title": "Productos de Calidad",
-        "text": "Seleccionamos productos de marcas reconocidas para garantizar tu satisfaccion y seguridad."
-      },
-      {
-        "icon": "heart",
-        "title": "Atencion Sin Juicios",
-        "text": "Nuestro equipo esta capacitado para asesorarte con respeto y profesionalismo."
-      }
-    ]
+    "cta": {
+      "title": "¿Dudas? Hablemos por WhatsApp",
+      "buttonText": "Escribir",
+      "buttonHref": "https://wa.me/595981324569?text=Hola%2C%20vengo%20de%20fun4me"
+    }
   },
   "legal": {
     "seo": {

--- a/sites/fun4me/docs/integracion-reutilizables.md
+++ b/sites/fun4me/docs/integracion-reutilizables.md
@@ -2,6 +2,10 @@
 
 _Última actualización: 2026-04-21_
 
+> **Estado de ejecución (2026-04-21 cierre):** Fases 0 y 1 mayormente
+> shipped en PRs #193–#196 salvo lo marcado como "refactor-pending" abajo.
+> Ver sección final "Estado de ejecución" para detalle PR-por-PR.
+
 Auditoría de **todo lo construido en la plataforma** (sections, lib, commerce,
 infra, otros tenants) cruzado contra **lo que fun4me ya usa** para identificar
 qué podemos enchufar sin construir nada nuevo.
@@ -106,6 +110,23 @@ Las pongo para cerrar el circuito — así queda claro qué descartamos y por qu
 | `countdown-timer` | Útil solo para flash sales — **reconsiderar cuando activemos campañas** |
 | `savings-calculator`, `bulk-calculator`, `delivery-calculator` | No hay caso de uso directo (shipping ya se calcula en checkout) |
 | `instagram-feed` | Podría servir si fun4me tiene IG activo — **maybe** |
+
+### Backlog de refactor de plataforma
+
+Durante la adopción encontramos 5 sections que están en el repo pero con
+**contenido hardcoded granja-cabral-específico** dentro del componente.
+No son drop-in reutilizables hasta que se parametricen:
+
+| Sección | Hardcoded que bloquea | Refactor necesario |
+|---------|----------------------|---------------------|
+| `enhanced-faq-section.tsx` | Array FAQS interno con preguntas de granja (huevos, gallinas, maples) | Aceptar `items[]` desde content prop |
+| `our-story-section.tsx` | Icons Egg/Bird/Sprout hardcoded + shape de `BusinessData` con `sustainability.composting/biogas/waterRecycling` | Aceptar story/values/stats genéricos desde content; icons por key |
+| `b2b-wholesale-section.tsx` | Copy granja en el componente | Aceptar tiers/benefits/copy desde content |
+| `smart-whatsapp-section.tsx` | `WHATSAPP_TEMPLATES` con "huevos/semana", "maple gratis" | Aceptar templates[] desde content prop |
+| `referral-section.tsx` | Prefijo "CABAL", URL granjacabral.com.py, emoji de huevo, "maple de huevos gratis" | Aceptar businessName, codePrefix, rewardCopy, baseUrl desde props |
+
+Cada uno es ~30min-2h de refactor. Recomendación: hacerlo cuando un
+tenant concreto lo pida; mientras tanto, no usar en fun4me.
 
 ### Categoría D — Libs y utilidades que no estamos usando
 
@@ -219,6 +240,50 @@ Si la respuesta a las 6 es "sí" → 2-3 semanas de trabajo, nada nuevo que
 construir, todo es adaptación + content.
 
 ---
+
+## Estado de ejecución (cierre 2026-04-21)
+
+### Shipped
+
+| PR | Contenido |
+|----|-----------|
+| #193 | Vertical whitelist update + home: trust-signals, why-destination, process-timeline. suscripciones: programs-comparison matrix. |
+| #194 | compliance-disclaimer-footer wired en site-renderer + agregado a 10 páginas fun4me. |
+| #195 | promo-banner (carousel BIENVENIDA10 + envío gratis) + newsletter-signup (Mailchimp) wired y usados en home. |
+| #196 | Nueva página `/quienes-somos` (about) con why-destination `alternating` + trust-signals + testimonials. Agregado a nav. |
+
+Schema.org Product/Offer en PDP, RecentlyViewedRail, BackInStockSignup,
+WishlistButton, ProductShare y stock-indicator vía `lowStockThreshold` en
+product-card — **todos estos ya estaban shipped antes de esta sesión**.
+
+### No shipped (y por qué)
+
+- `enhanced-faq`, `our-story`, `b2b-wholesale`, `smart-whatsapp`,
+  `referral-section` → necesitan refactor de parametrización antes de ser
+  usables por fun4me. Ver "Backlog de refactor de plataforma" arriba.
+- **EN locale** → requiere traducir ~1000 líneas de `es.json` + routing;
+  pendiente de decisión humana sobre prioridad del mercado turista.
+- **Team section** → fun4me probablemente prefiere mantener anonimato;
+  pendiente conversación con cliente.
+- **Booking-embed consultas** → necesita URL de Calendly (o equivalente)
+  de una educadora sexual que contrate fun4me.
+- **countdown-timer standalone** → redundante con `promo-banner` variant
+  `countdown`. Dejar como está.
+- **Cart-recovery cron trigger** → el outbox + template ya existen; falta
+  sólo el cron que escanea carritos abandonados >24h. 2h de trabajo.
+- **Referral UI integration** → referral-section necesita refactor; los
+  archivos WIP `lib/commerce/referral.ts` en `stash@{0}` tienen imports
+  rotos (`@/lib/supabase/server-client` no existe). Orden: refactor
+  componente → refactor lib → shippear.
+
+### Próximos pasos sugeridos (si seguimos)
+
+1. Refactor de `enhanced-faq` para aceptar items desde content (30min).
+2. Refactor de `our-story` para aceptar shape genérico (1h).
+3. Fix de imports en `lib/commerce/referral.ts` + refactor de
+   `referral-section` para parametrizar (2-3h).
+4. Cron trigger de cart-recovery (1-2h).
+5. EN locale traducción si el negocio lo necesita (1-2 días).
 
 ## Apéndice — Dónde está cada pieza
 

--- a/sites/fun4me/pages/quienes-somos.json
+++ b/sites/fun4me/pages/quienes-somos.json
@@ -1,0 +1,62 @@
+{
+  "slug": "quienes-somos",
+  "titleKey": "about.seo.title",
+  "descriptionKey": "about.seo.description",
+  "sections": [
+    {
+      "id": "age-gate",
+      "variant": "modal",
+      "content": "home.ageGate"
+    },
+    {
+      "id": "promo-banner",
+      "variant": "carousel",
+      "content": "home.promoBanner"
+    },
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "image",
+      "content": "about.hero"
+    },
+    {
+      "id": "trust-signals",
+      "variant": "credentials",
+      "content": "home.trustSignals"
+    },
+    {
+      "id": "why-destination",
+      "variant": "alternating",
+      "content": "about.values"
+    },
+    {
+      "id": "testimonials",
+      "variant": "grid",
+      "content": "home.testimonials"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "gradient",
+      "content": "about.cta"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "compliance-disclaimer-footer",
+      "variant": "standard",
+      "content": "compliance"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
+  ]
+}

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -11,7 +11,7 @@
  */
 
 export type JsonRecord = Record<string, unknown>
-/** Counts: sites=117, pages=147, content=137, blog=25, verticals=23. */
+/** Counts: sites=117, pages=148, content=137, blog=25, verticals=23. */
 export const SITE_SLUGS: readonly string[] = [
   "dayah-litworks",
   "de-abasto-a-casa",
@@ -9573,6 +9573,68 @@ export const PAGES: Record<string, JsonRecord> = {
     "slug": "placer-plus",
     "titleKey": "loyalty.seo.title"
   },
+  "fun4me:quienes-somos": {
+    "descriptionKey": "about.seo.description",
+    "sections": [
+      {
+        "content": "home.ageGate",
+        "id": "age-gate",
+        "variant": "modal"
+      },
+      {
+        "content": "home.promoBanner",
+        "id": "promo-banner",
+        "variant": "carousel"
+      },
+      {
+        "content": "navigation",
+        "id": "header",
+        "variant": "standard"
+      },
+      {
+        "content": "about.hero",
+        "id": "hero",
+        "variant": "image"
+      },
+      {
+        "content": "home.trustSignals",
+        "id": "trust-signals",
+        "variant": "credentials"
+      },
+      {
+        "content": "about.values",
+        "id": "why-destination",
+        "variant": "alternating"
+      },
+      {
+        "content": "home.testimonials",
+        "id": "testimonials",
+        "variant": "grid"
+      },
+      {
+        "content": "about.cta",
+        "id": "cta-banner",
+        "variant": "gradient"
+      },
+      {
+        "content": "footer",
+        "id": "footer",
+        "variant": "standard"
+      },
+      {
+        "content": "compliance",
+        "id": "compliance-disclaimer-footer",
+        "variant": "standard"
+      },
+      {
+        "content": "whatsapp",
+        "id": "whatsapp-float",
+        "variant": "standard"
+      }
+    ],
+    "slug": "quienes-somos",
+    "titleKey": "about.seo.title"
+  },
   "fun4me:reserva-en-tienda": {
     "descriptionKey": "storeReserve.seo.description",
     "sections": [
@@ -17320,39 +17382,60 @@ export const CONTENT: Record<string, JsonRecord> = {
       "translationQuality": "native"
     },
     "about": {
-      "intro": {
-        "text": "Fun4Me nacio en 2018 con la mision de ofrecer productos de calidad para adultos en Paraguay, con la discrecion y el profesionalismo que nuestros clientes merecen. Desde nuestra tienda en Herrera 875, Asuncion, atendemos a clientes de todo el pais con envios discretos y seguros. Creemos que cada persona tiene derecho a explorar su intimidad de manera segura y sin juicios.",
-        "title": "Sobre Fun4Me"
+      "cta": {
+        "buttonHref": "https://wa.me/595981324569?text=Hola%2C%20vengo%20de%20fun4me",
+        "buttonText": "Escribir",
+        "title": "¿Dudas? Hablemos por WhatsApp"
       },
-      "mission": {
-        "text": "Ofrecer productos de calidad para adultos con total discrecion, profesionalismo y respeto. Queremos que cada cliente se sienta comodo explorando su intimidad con productos seguros y de las mejores marcas.",
-        "title": "Nuestra Mision"
+      "hero": {
+        "ctaPrimaryHref": "/s/es/fun4me/tienda",
+        "ctaPrimaryText": "Ver catálogo",
+        "ctaSecondaryHref": "/s/es/fun4me#contacto",
+        "ctaSecondaryText": "Hablar con nosotros",
+        "eyebrow": "Sobre fun4me",
+        "headline": "Un proyecto pensado en Paraguay",
+        "subheadline": "Nacimos para dar acceso profesional y discreto a una categoría que todavía carga estigma en nuestra región. Sin juzgar, sin vender lo que no conocemos, sin comprometer tu privacidad."
       },
-      "values": [
-        {
-          "icon": "eye-slash",
-          "text": "Entendemos la importancia de la privacidad. Desde el empaque hasta la facturacion, todo es 100% discreto.",
-          "title": "Discrecion Total"
-        },
-        {
-          "icon": "truck",
-          "text": "Delivery rapido y seguro a cualquier punto de Paraguay con total confidencialidad.",
-          "title": "Envio a Todo el Pais"
-        },
-        {
-          "icon": "shield-check",
-          "text": "Seleccionamos productos de marcas reconocidas para garantizar tu satisfaccion y seguridad.",
-          "title": "Productos de Calidad"
-        },
-        {
-          "icon": "heart",
-          "text": "Nuestro equipo esta capacitado para asesorarte con respeto y profesionalismo.",
-          "title": "Atencion Sin Juicios"
-        }
-      ],
-      "vision": {
-        "text": "Ser la tienda de referencia en Paraguay para productos de adultos, reconocida por la calidad, la discrecion de nuestro servicio y la confianza que generamos en nuestros clientes.",
-        "title": "Nuestra Vision"
+      "seo": {
+        "description": "Conocé el proyecto detrás de fun4me: un comercio discreto y profesional de productos para adultos en Paraguay.",
+        "title": "Quiénes Somos — fun4me"
+      },
+      "values": {
+        "eyebrow": "Cómo trabajamos",
+        "honestNote": "Somos un equipo pequeño basado en Paraguay. No somos multinacionales — somos gente que cree que este mercado merece un servicio mejor del que históricamente tuvo.",
+        "pillars": [
+          {
+            "bullets": [
+              "Empaque sin marca",
+              "Factura a nombre genérico",
+              "Datos no se comparten"
+            ],
+            "description": "No es un feature: es el punto de partida. Empaque neutro, facturación opcional, WhatsApp privado, sin tu nombre en estados de cuenta.",
+            "icon": "Shield",
+            "title": "Discreción por diseño"
+          },
+          {
+            "bullets": [
+              "Marcas internacionales",
+              "Guías de uso detalladas",
+              "Soporte post-venta real"
+            ],
+            "description": "Solo vendemos productos que testeamos, de marcas establecidas con trayectoria en la industria. Si no lo recomendaríamos a alguien cercano, no está en el catálogo.",
+            "icon": "Award",
+            "title": "Curaduría honesta"
+          },
+          {
+            "bullets": [
+              "Blog con contenido de salud",
+              "Consultas sin obligación de compra",
+              "Producto correcto, no el más caro"
+            ],
+            "description": "El placer y la salud sexual son temas serios que merecen información seria. Por eso publicamos guías prácticas y respondemos consultas sin vender.",
+            "icon": "Heart",
+            "title": "Educación antes que venta"
+          }
+        ],
+        "title": "Principios que guían todas nuestras decisiones"
       }
     },
     "blog": {
@@ -18457,6 +18540,10 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/fun4me/store",
           "label": "Tienda"
+        },
+        {
+          "href": "/fun4me/quienes-somos",
+          "label": "Nosotros"
         },
         {
           "href": "/fun4me/bundles",

--- a/web/lib/engine/static-sites.ts
+++ b/web/lib/engine/static-sites.ts
@@ -38,7 +38,7 @@ export const SITES = {
     domain: '',
     defaultLocale: 'es',
     locales: ['es'],
-    pages: ['home'],
+    pages: ['home', 'quienes-somos', 'suscripciones', 'store', 'bundles', 'placer-plus', 'gift-cards', 'loyalty', 'blog', 'legal', 'reserva-en-tienda', 'size-guide'],
   },
   'dayah-litworks': {
     slug: 'dayah-litworks',


### PR DESCRIPTION
## Summary
- New \`/s/es/fun4me/quienes-somos\` (about) page built from existing sections — hero, trust-signals, why-destination (alternating), testimonials grid, cta-banner, compliance footer.
- "Nosotros" nav item added (between Tienda and Kits).
- Registered all 11 existing fun4me pages in \`static-sites.ts\` (previously only 'home' was listed).
- Updates the adoption doc with PR-by-PR shipped status and a **refactor backlog** for 5 sections that have granja-cabral-hardcoded content (enhanced-faq, our-story, b2b-wholesale, smart-whatsapp, referral-section) — these need parametrization before fun4me can use them.

## Test plan
- [x] 24/24 engine tests pass
- [x] quienes-somos composes with 11 sections
- [ ] Deploy → /s/es/fun4me/quienes-somos renders end-to-end
- [ ] Nav shows "Nosotros" and routes correctly within tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)