### PR TITLE
feat(tienda): Round 1 — repoint nav, quick-filters, mobile drawer, per-page

### DIFF
--- a/sites/fun4me/content/es.json
+++ b/sites/fun4me/content/es.json
@@ -27,7 +27,7 @@
       },
       {
         "label": "Tienda",
-        "href": "/fun4me/store"
+        "href": "/fun4me/tienda"
       },
       {
         "label": "Nosotros",

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -13,6 +13,7 @@ import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { ProductCard } from '@/components/commerce/product-card'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { TiendaToolbar } from '@/components/commerce/tienda-toolbar'
+import { TiendaQuickFilters } from '@/components/commerce/tienda-quick-filters'
 import { TiendaPagination } from '@/components/commerce/tienda-pagination'
 import { loadPygRates } from '@/lib/commerce/currency-server'
 
@@ -20,7 +21,9 @@ export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic' // search/sort/filter params kill static caching
 
 const VALID_SORTS: ProductSort[] = ['newest', 'price-asc', 'price-desc', 'name-asc']
-const PAGE_SIZE = 24
+const DEFAULT_PER_PAGE = 12
+const PER_PAGE_OPTIONS = [12, 24, 48, 96]
+const MAX_PER_PAGE = 96
 
 function parseSort(raw: string | undefined): ProductSort {
   return raw && (VALID_SORTS as string[]).includes(raw) ? (raw as ProductSort) : 'newest'
@@ -30,6 +33,12 @@ function parsePositiveInt(raw: string | undefined): number {
   if (!raw) return 0
   const n = parseInt(raw, 10)
   return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+function parsePerPage(raw: string | undefined): number {
+  const n = parsePositiveInt(raw)
+  if (!n) return DEFAULT_PER_PAGE
+  return PER_PAGE_OPTIONS.includes(n) ? n : Math.min(n, MAX_PER_PAGE)
 }
 
 export default async function StorePage({
@@ -46,6 +55,7 @@ export default async function StorePage({
     in_stock?: string
     on_sale?: string
     page?: string
+    per_page?: string
   }>
 }) {
   const { site, locale } = await params
@@ -60,8 +70,9 @@ export default async function StorePage({
   const maxPriceCents = parsePositiveInt(sp.max)
   const inStockOnly = sp.in_stock === '1' || sp.in_stock === 'true'
   const onSaleOnly = sp.on_sale === '1' || sp.on_sale === 'true'
+  const perPage = parsePerPage(sp.per_page)
   const page = Math.max(1, parsePositiveInt(sp.page) || 1)
-  const offset = (page - 1) * PAGE_SIZE
+  const offset = (page - 1) * perPage
 
   const filterOpts = {
     search,
@@ -73,7 +84,7 @@ export default async function StorePage({
   }
 
   const [products, totalCount, rates, availableCategories] = await Promise.all([
-    listActiveProducts(business.id, { ...filterOpts, limit: PAGE_SIZE, offset, sort: sortKey }),
+    listActiveProducts(business.id, { ...filterOpts, limit: perPage, offset, sort: sortKey }),
     countActiveProducts(business.id, filterOpts),
     loadPygRates(),
     listDistinctCategories(business.id),
@@ -90,7 +101,7 @@ export default async function StorePage({
     })
   }
 
-  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
+  const totalPages = Math.max(1, Math.ceil(totalCount / perPage))
   const hasActiveFilters = Boolean(
     search || category || minPriceCents || maxPriceCents || inStockOnly || onSaleOnly,
   )
@@ -103,6 +114,7 @@ export default async function StorePage({
       <main className="mx-auto max-w-6xl px-4 py-8">
         <h1 className="mb-6 text-3xl font-bold text-[color:var(--text,#111)]">Nuestra tienda</h1>
 
+        <TiendaQuickFilters />
         <TiendaToolbar
           initialQuery={search}
           initialSort={sortKey}
@@ -114,6 +126,7 @@ export default async function StorePage({
           initialMaxPrice={maxPriceCents}
           initialInStockOnly={inStockOnly}
           initialOnSaleOnly={onSaleOnly}
+          initialPerPage={perPage}
         />
 
         {products.length === 0 ? (

--- a/web/components/commerce/tienda-quick-filters.tsx
+++ b/web/components/commerce/tienda-quick-filters.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
+import { useTransition } from 'react'
+import { cn } from '@/lib/utils'
+
+interface QuickFilter {
+  key: string
+  label: string
+  params: Record<string, string | null>
+  /** Which current URL state means this is active. */
+  matches: (sp: URLSearchParams) => boolean
+}
+
+/**
+ * Pre-baked URL-param shortcuts above the full filter toolbar. Each chip
+ * sets or clears a handful of params in one click — no separate state.
+ * When a chip is already "active", clicking it clears its params.
+ */
+const FILTERS: QuickFilter[] = [
+  {
+    key: 'on-sale',
+    label: 'En oferta',
+    params: { on_sale: '1', min: null, max: null },
+    matches: (sp) => sp.get('on_sale') === '1',
+  },
+  {
+    key: 'under-100k',
+    label: 'Hasta Gs 100k',
+    params: { min: null, max: '10000000', on_sale: null },
+    matches: (sp) => !sp.get('min') && sp.get('max') === '10000000',
+  },
+  {
+    key: '100-300k',
+    label: 'Gs 100k – 300k',
+    params: { min: '10000000', max: '30000000', on_sale: null },
+    matches: (sp) => sp.get('min') === '10000000' && sp.get('max') === '30000000',
+  },
+  {
+    key: 'over-300k',
+    label: 'Más de Gs 300k',
+    params: { min: '30000000', max: null, on_sale: null },
+    matches: (sp) => sp.get('min') === '30000000' && !sp.get('max'),
+  },
+  {
+    key: 'in-stock',
+    label: 'Solo en stock',
+    params: { in_stock: '1' },
+    matches: (sp) => sp.get('in_stock') === '1',
+  },
+]
+
+export function TiendaQuickFilters() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [pending, startTransition] = useTransition()
+
+  function toggle(filter: QuickFilter) {
+    const params = new URLSearchParams(searchParams.toString())
+    const isActive = filter.matches(params)
+    if (isActive) {
+      for (const key of Object.keys(filter.params)) params.delete(key)
+    } else {
+      for (const [key, value] of Object.entries(filter.params)) {
+        if (value === null) params.delete(key)
+        else params.set(key, value)
+      }
+    }
+    params.delete('page')
+    const qs = params.toString()
+    startTransition(() => {
+      router.push(qs ? `${pathname}?${qs}` : pathname)
+    })
+  }
+
+  return (
+    <div className="mb-3 flex flex-wrap items-center gap-2" aria-label="Filtros rápidos">
+      <span className="text-xs font-medium text-[color:var(--text-muted,#6b7280)]">Rápido:</span>
+      {FILTERS.map((f) => {
+        const active = f.matches(searchParams)
+        return (
+          <button
+            key={f.key}
+            type="button"
+            onClick={() => toggle(f)}
+            disabled={pending}
+            aria-pressed={active}
+            className={cn(
+              'rounded-full border px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50',
+              active
+                ? 'border-[color:var(--secondary,#b8860b)] bg-[color:var(--secondary,#b8860b)] text-white'
+                : 'border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] hover:bg-[color:var(--surface-muted,#f3f4f6)]',
+            )}
+          >
+            {f.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/components/commerce/tienda-toolbar.tsx
+++ b/web/components/commerce/tienda-toolbar.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from 'react'
 import { useRouter, useSearchParams, usePathname } from 'next/navigation'
 import type { ProductSort } from '@/lib/commerce/products'
+import { cn } from '@/lib/utils'
 
 interface Props {
   initialQuery: string
@@ -18,7 +19,11 @@ interface Props {
   initialMaxPrice: number
   initialInStockOnly: boolean
   initialOnSaleOnly: boolean
+  /** Current page size. Defaults to 12. */
+  initialPerPage: number
 }
+
+const PER_PAGE_OPTIONS = [12, 24, 48, 96]
 
 const SORT_OPTIONS: Array<{ value: ProductSort; label: string }> = [
   { value: 'newest', label: 'Más nuevos' },
@@ -36,6 +41,7 @@ type FilterUpdate = {
   in_stock?: string | null
   on_sale?: string | null
   page?: string | null
+  per_page?: string | null
 }
 
 function formatPyg(cents: number): string {
@@ -58,6 +64,7 @@ export function TiendaToolbar({
   initialMaxPrice,
   initialInStockOnly,
   initialOnSaleOnly,
+  initialPerPage,
 }: Props) {
   const router = useRouter()
   const pathname = usePathname()
@@ -66,6 +73,7 @@ export function TiendaToolbar({
   const [minPrice, setMinPrice] = useState(initialMinPrice ? String(initialMinPrice) : '')
   const [maxPrice, setMaxPrice] = useState(initialMaxPrice ? String(initialMaxPrice) : '')
   const [pending, startTransition] = useTransition()
+  const [advancedOpen, setAdvancedOpen] = useState(false)
 
   function pushParams(next: FilterUpdate) {
     const params = new URLSearchParams(searchParams.toString())
@@ -174,22 +182,60 @@ export function TiendaToolbar({
           </button>
         </form>
 
-        <label className="flex items-center gap-2 text-sm">
-          <span className="text-xs text-[color:var(--text-muted,#6b7280)]">Ordenar:</span>
-          <select
-            value={initialSort}
-            onChange={(e) => pushParams({ sort: e.target.value === 'newest' ? null : e.target.value })}
-            className="rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-2 py-1 text-sm"
-          >
-            {SORT_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className="flex flex-wrap items-center gap-3 text-sm">
+          <label className="flex items-center gap-2">
+            <span className="text-xs text-[color:var(--text-muted,#6b7280)]">Ordenar:</span>
+            <select
+              value={initialSort}
+              onChange={(e) => pushParams({ sort: e.target.value === 'newest' ? null : e.target.value })}
+              className="rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-2 py-1 text-sm"
+            >
+              {SORT_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2">
+            <span className="text-xs text-[color:var(--text-muted,#6b7280)]">Por página:</span>
+            <select
+              value={initialPerPage}
+              onChange={(e) => pushParams({ per_page: e.target.value === '12' ? null : e.target.value })}
+              className="rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-2 py-1 text-sm"
+            >
+              {PER_PAGE_OPTIONS.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
       </div>
 
+      {/* Mobile-only toggle for advanced filters. Hidden md+ where the
+          filters always show inline. */}
+      <button
+        type="button"
+        onClick={() => setAdvancedOpen((v) => !v)}
+        aria-expanded={advancedOpen}
+        className="flex items-center justify-between rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm md:hidden"
+      >
+        <span className="flex items-center gap-2">
+          <svg aria-hidden="true" className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 4h18M6 12h12M10 20h4" />
+          </svg>
+          Filtros
+          {(initialCategory || initialMinPrice || initialMaxPrice || initialInStockOnly || initialOnSaleOnly) ? (
+            <span className="rounded-full bg-[color:var(--secondary,#b8860b)] px-1.5 py-0.5 text-[10px] font-semibold text-white">•</span>
+          ) : null}
+        </span>
+        <span aria-hidden="true">{advancedOpen ? '▲' : '▼'}</span>
+      </button>
+
+      {/* Advanced filters: always visible on md+, collapsible on mobile. */}
+      <div className={cn('flex flex-col gap-3', advancedOpen ? 'block' : 'hidden', 'md:flex')}>
       {/* Category pills */}
       {availableCategories.length > 0 ? (
         <div className="flex flex-wrap gap-2">
@@ -275,6 +321,7 @@ export function TiendaToolbar({
             <span>En oferta</span>
           </label>
         </div>
+      </div>
       </div>
 
       {/* Active filter chips + result count + clear-all */}

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -18538,7 +18538,7 @@ export const CONTENT: Record<string, JsonRecord> = {
           "label": "Inicio"
         },
         {
-          "href": "/fun4me/store",
+          "href": "/fun4me/tienda",
           "label": "Tienda"
         },
         {


### PR DESCRIPTION
## Summary
Round 1 of the \`/fun4me/store\` → \`/tienda\` improvement plan — fixes the single biggest UX regression on the site and adds three conversion-focused toolbar upgrades.

### The headline fix
Fun4me nav "Tienda" was pointing at \`/fun4me/store\` (bare \`commerce-catalog-section\` — no search, no filters, no sort, no pagination). It now points at \`/fun4me/tienda\` which already has the full TiendaToolbar. Same user, completely different store.

### New: \`TiendaQuickFilters\` component
Pre-baked URL-param shortcuts above the main toolbar:
- En oferta
- Hasta Gs 100k
- Gs 100k – 300k
- Más de Gs 300k
- Solo en stock

Each chip toggles — clicking an active chip clears it.

### Mobile filter drawer
Below \`md\` breakpoint the category pills + price range + stock/sale toggles collapse behind a "Filtros" button with a dot indicator when a filter is active. Search + sort + per-page + active-chip summary always visible. \`md+\` unchanged.

### Items-per-page selector
12 / 24 / 48 / 96 via \`per_page\` URL param. Default reduced from 24 to 12 (mobile-first perceived load).

## Test plan
- [x] 24/24 engine tests pass
- [ ] Deploy → click "Tienda" in fun4me nav — lands on \`/tienda\` not \`/store\`
- [ ] Deploy → quick-filter chips toggle URL params and highlight when active
- [ ] Deploy mobile → "Filtros" button opens the advanced panel
- [ ] Deploy → per-page selector changes grid density

🤖 Generated with [Claude Code](https://claude.com/claude-code)