### PR TITLE
feat(tienda): R2a — NUEVO badge + faceted counts + multi-category + popular searches

### DIFF
--- a/web/app/s/[locale]/[site]/tienda/categoria/[category]/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/categoria/[category]/page.tsx
@@ -131,11 +131,13 @@ export default async function CategoryPage({
           resultCount={products.length}
           totalCount={totalCount}
           initialCategory={match}
+          initialCategories={[match]}
           availableCategories={available}
           initialMinPrice={minPriceCents}
           initialMaxPrice={maxPriceCents}
           initialInStockOnly={inStockOnly}
           initialOnSaleOnly={onSaleOnly}
+          initialPerPage={12}
         />
 
         {products.length === 0 ? (

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -5,9 +5,10 @@ import {
   listActiveProducts,
   countActiveProducts,
   listDistinctCategories,
+  listCategoryCounts,
   type ProductSort,
 } from '@/lib/commerce/products'
-import { recordSearchEvent } from '@/lib/commerce/search-events'
+import { recordSearchEvent, listTopSearches } from '@/lib/commerce/search-events'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { ProductCard } from '@/components/commerce/product-card'
@@ -65,7 +66,13 @@ export default async function StorePage({
 
   const search = (sp.q ?? '').trim()
   const sortKey = parseSort(sp.sort)
-  const category = (sp.category ?? '').trim()
+  // Supports "a,b,c" comma-delimited multi-select; single "a" stays as a
+  // one-element array. Empty/undefined → empty array.
+  const categories = (sp.category ?? '')
+    .split(',')
+    .map((c) => c.trim())
+    .filter(Boolean)
+  const category = categories[0] ?? ''
   const minPriceCents = parsePositiveInt(sp.min)
   const maxPriceCents = parsePositiveInt(sp.max)
   const inStockOnly = sp.in_stock === '1' || sp.in_stock === 'true'
@@ -76,19 +83,27 @@ export default async function StorePage({
 
   const filterOpts = {
     search,
-    category: category || undefined,
+    categories: categories.length > 0 ? categories : undefined,
     minPriceCents: minPriceCents || undefined,
     maxPriceCents: maxPriceCents || undefined,
     inStockOnly,
     onSaleOnly,
   }
 
-  const [products, totalCount, rates, availableCategories] = await Promise.all([
+  const [products, totalCount, rates, availableCategories, categoryCounts, topSearches] = await Promise.all([
     listActiveProducts(business.id, { ...filterOpts, limit: perPage, offset, sort: sortKey }),
     countActiveProducts(business.id, filterOpts),
     loadPygRates(),
     listDistinctCategories(business.id),
+    listCategoryCounts(business.id),
+    listTopSearches(business.id, { windowDays: 30, limit: 8 }),
   ])
+  // Only surface suggestions with at least 1 result (non-zero-result).
+  // Dedup by normalized form, keep pretty sampleQuery.
+  const popularQueries = topSearches
+    .filter((s) => s.avgResults >= 1)
+    .slice(0, 5)
+    .map((s) => s.sampleQuery)
 
   // Record shopper searches only when there's an actual query term — avoids
   // a log entry on every tienda page view. Fire-and-forget, non-blocking.
@@ -103,7 +118,7 @@ export default async function StorePage({
 
   const totalPages = Math.max(1, Math.ceil(totalCount / perPage))
   const hasActiveFilters = Boolean(
-    search || category || minPriceCents || maxPriceCents || inStockOnly || onSaleOnly,
+    search || categories.length > 0 || minPriceCents || maxPriceCents || inStockOnly || onSaleOnly,
   )
 
   return (
@@ -115,13 +130,29 @@ export default async function StorePage({
         <h1 className="mb-6 text-3xl font-bold text-[color:var(--text,#111)]">Nuestra tienda</h1>
 
         <TiendaQuickFilters />
+        {!search && popularQueries.length > 0 ? (
+          <div className="mb-3 flex flex-wrap items-center gap-2 text-xs">
+            <span className="font-medium text-[color:var(--text-muted,#6b7280)]">Búsquedas populares:</span>
+            {popularQueries.map((q) => (
+              <Link
+                key={q}
+                href={`/s/${locale}/${site}/tienda?q=${encodeURIComponent(q)}`}
+                className="rounded-full border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-3 py-1 hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+              >
+                {q}
+              </Link>
+            ))}
+          </div>
+        ) : null}
         <TiendaToolbar
           initialQuery={search}
           initialSort={sortKey}
           resultCount={products.length}
           totalCount={totalCount}
           initialCategory={category}
+          initialCategories={categories}
           availableCategories={availableCategories}
+          categoryCounts={categoryCounts}
           initialMinPrice={minPriceCents}
           initialMaxPrice={maxPriceCents}
           initialInStockOnly={inStockOnly}

--- a/web/components/commerce/product-card.tsx
+++ b/web/components/commerce/product-card.tsx
@@ -55,6 +55,15 @@ export function ProductCard({ siteSlug, product, priority, rates, locale = 'es' 
     product.compareAtPriceCents && product.compareAtPriceCents > product.priceCents
       ? Math.round(((product.compareAtPriceCents - product.priceCents) / product.compareAtPriceCents) * 100)
       : null
+  // "Nuevo" badge for anything created in the last 14 days. Parsed lazily to
+  // avoid a `new Date()` during SSR hydration mismatch — createdAt is ISO from
+  // the DB so Date parsing is deterministic.
+  const isNew = (() => {
+    if (!product.createdAt) return false
+    const t = Date.parse(product.createdAt)
+    if (!Number.isFinite(t)) return false
+    return Date.now() - t < 14 * 24 * 60 * 60 * 1000
+  })()
 
   const saved = useSyncExternalStore(
     subscribeWishlist,
@@ -134,6 +143,16 @@ export function ProductCard({ siteSlug, product, priority, rates, locale = 'es' 
           {discount ? (
             <span className="absolute left-2 top-2 rounded bg-red-600 px-2 py-0.5 text-xs font-semibold text-white" aria-label={`Descuento del ${discount} por ciento`}>
               −{discount}%
+            </span>
+          ) : null}
+          {isNew && !discount ? (
+            <span className="absolute left-2 top-2 rounded bg-emerald-600 px-2 py-0.5 text-xs font-semibold text-white">
+              NUEVO
+            </span>
+          ) : null}
+          {isNew && discount ? (
+            <span className="absolute left-2 top-9 rounded bg-emerald-600 px-2 py-0.5 text-xs font-semibold text-white">
+              NUEVO
             </span>
           ) : null}
           {lowStock ? (

--- a/web/components/commerce/tienda-toolbar.tsx
+++ b/web/components/commerce/tienda-toolbar.tsx
@@ -10,10 +10,14 @@ interface Props {
   initialSort: ProductSort
   resultCount: number
   totalCount: number
-  /** Active category filter (empty string = all). */
+  /** Active category filter (empty string = all). Deprecated — use initialCategories. */
   initialCategory: string
+  /** Active categories (multi-select). Empty array = all. */
+  initialCategories: string[]
   /** Distinct categories offered (from DB). */
   availableCategories: string[]
+  /** Product counts per category for faceted display. */
+  categoryCounts?: Record<string, number>
   /** Price bounds in cents, active filter (0 = no bound). */
   initialMinPrice: number
   initialMaxPrice: number
@@ -59,7 +63,9 @@ export function TiendaToolbar({
   resultCount,
   totalCount,
   initialCategory,
+  initialCategories,
   availableCategories,
+  categoryCounts,
   initialMinPrice,
   initialMaxPrice,
   initialInStockOnly,
@@ -104,6 +110,14 @@ export function TiendaToolbar({
     pushParams({ min: cleanMin || null, max: cleanMax || null })
   }
 
+  function toggleCategory(cat: string) {
+    const set = new Set(initialCategories)
+    if (set.has(cat)) set.delete(cat)
+    else set.add(cat)
+    const next = Array.from(set)
+    pushParams({ category: next.length === 0 ? null : next.join(',') })
+  }
+
   function clearAll() {
     setQuery('')
     setMinPrice('')
@@ -124,11 +138,14 @@ export function TiendaToolbar({
       },
     })
   }
-  if (initialCategory) {
+  for (const cat of initialCategories) {
     activeFilters.push({
-      key: 'category',
-      label: initialCategory,
-      clear: () => pushParams({ category: null }),
+      key: `category:${cat}`,
+      label: cat,
+      clear: () => {
+        const next = initialCategories.filter((c) => c !== cat)
+        pushParams({ category: next.length === 0 ? null : next.join(',') })
+      },
     })
   }
   if (initialMinPrice || initialMaxPrice) {
@@ -242,30 +259,37 @@ export function TiendaToolbar({
           <button
             type="button"
             onClick={() => pushParams({ category: null })}
-            aria-pressed={!initialCategory}
+            aria-pressed={initialCategories.length === 0}
             className={`rounded-full border px-3 py-1 text-xs ${
-              !initialCategory
+              initialCategories.length === 0
                 ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
                 : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
             }`}
           >
             Todo
           </button>
-          {availableCategories.map((cat) => (
-            <button
-              key={cat}
-              type="button"
-              onClick={() => pushParams({ category: cat })}
-              aria-pressed={initialCategory === cat}
-              className={`rounded-full border px-3 py-1 text-xs capitalize ${
-                initialCategory === cat
-                  ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
-                  : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
-              }`}
-            >
-              {cat}
-            </button>
-          ))}
+          {availableCategories.map((cat) => {
+            const count = categoryCounts?.[cat]
+            const active = initialCategories.includes(cat)
+            return (
+              <button
+                key={cat}
+                type="button"
+                onClick={() => toggleCategory(cat)}
+                aria-pressed={active}
+                className={`rounded-full border px-3 py-1 text-xs capitalize ${
+                  active
+                    ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
+                    : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
+                }`}
+              >
+                {cat}
+                {typeof count === 'number' ? (
+                  <span className="ml-1 opacity-70">({count})</span>
+                ) : null}
+              </button>
+            )
+          })}
         </div>
       ) : null}
 

--- a/web/lib/commerce/products.ts
+++ b/web/lib/commerce/products.ts
@@ -54,7 +54,10 @@ function rowToProduct(row: ProductRow): Product {
 export type ProductSort = 'newest' | 'price-asc' | 'price-desc' | 'name-asc'
 
 export interface ListActiveProductsOpts {
+  /** Single-category filter — convenient when you already have one value. */
   category?: string
+  /** Multi-category filter. Takes precedence over `category` when both set. */
+  categories?: string[]
   limit?: number
   offset?: number
   /** Free-text search — matches name OR description OR SKU (ilike). Empty string is no filter. */
@@ -98,7 +101,11 @@ export async function listActiveProducts(
   const { data } = await scoped.select<ProductRow>('products', '*', {
     filter: (q) => {
       let query = q.eq('status', 'active').order(sort.column, { ascending: sort.ascending })
-      if (opts.category) query = query.eq('category', opts.category)
+      if (opts.categories && opts.categories.length > 0) {
+        query = query.in('category', opts.categories)
+      } else if (opts.category) {
+        query = query.eq('category', opts.category)
+      }
       if (opts.search && opts.search.trim()) {
         // Accent-insensitive search. The DB carries a generated
         // `search_haystack` column = lower(unaccent(name+desc+sku)). We
@@ -153,7 +160,11 @@ export async function countActiveProducts(
     .select('id', { count: 'exact', head: true })
     .eq('business_id', businessId)
     .eq('status', 'active')
-  if (opts.category) query = query.eq('category', opts.category)
+  if (opts.categories && opts.categories.length > 0) {
+    query = query.in('category', opts.categories)
+  } else if (opts.category) {
+    query = query.eq('category', opts.category)
+  }
   if (opts.search && opts.search.trim()) {
     // See listActiveProducts for rationale — match the same shape as the
     // DB-side search_haystack column.
@@ -186,6 +197,32 @@ export async function listDistinctCategories(businessId: string): Promise<string
     if (row.category) set.add(row.category)
   }
   return Array.from(set).sort((a, b) => a.localeCompare(b, 'es'))
+}
+
+/**
+ * Category counts for faceted filtering. Pulls every active product's
+ * category in one query and aggregates client-side — cheap enough for the
+ * product counts we care about (<5k active per tenant).
+ *
+ * Returns a map so the UI can render "Juguetes (12)" next to each pill.
+ * Categories with zero products are omitted.
+ */
+export async function listCategoryCounts(
+  businessId: string,
+): Promise<Record<string, number>> {
+  const supabase = await createAdminClient()
+  const { data } = await supabase
+    .from('products')
+    .select('category')
+    .eq('business_id', businessId)
+    .eq('status', 'active')
+    .not('category', 'is', null)
+  const counts: Record<string, number> = {}
+  for (const row of (Array.isArray(data) ? data : []) as Array<{ category: string | null }>) {
+    if (!row.category) continue
+    counts[row.category] = (counts[row.category] ?? 0) + 1
+  }
+  return counts
 }
 
 export async function getProductBySlug(businessId: string, slug: string): Promise<Product | null> {


### PR DESCRIPTION
## Summary
Round 2 first half — four filter/discovery upgrades.

- **NUEVO badge** on products created in last 14 days
- **Faceted counts** on category pills ("Juguetes (12)")
- **Multi-select categories** — URL accepts \`?category=a,b,c\`
- **Popular searches** row reads from \`search_events\` (30-day window, non-zero-result, top 5)

Price range slider deferred — R1's quick-filter chips cover the range UX at current 12-product scale.

Brand + tags filters deferred to R2b — requires DB migration.

## Test plan
- [x] 139/139 tests pass
- [ ] Deploy → NUEVO badge shows on products with recent created_at
- [ ] Deploy → category pills show (N) counts
- [ ] Deploy → clicking multiple categories adds both to URL, pills stay toggled
- [ ] Deploy → "Búsquedas populares" row appears above quick-filters when no active search

🤖 Generated with [Claude Code](https://claude.com/claude-code)