### PR TITLE
feat(tienda): R3 — reviews stack (stars, list, form, moderation-gated)

### DIFF
--- a/web/app/api/storefront/[site]/reviews/route.ts
+++ b/web/app/api/storefront/[site]/reviews/route.ts
@@ -1,0 +1,63 @@
+/**
+ * POST /api/storefront/[site]/reviews — submit a new product review.
+ *
+ * Always inserts with is_approved=false. An admin must approve before the
+ * review becomes visible. Rate limit: 5 reviews / IP / hour (in-memory —
+ * swap for Redis when horizontal). No auth: reviews are public-contributed
+ * content behind moderation.
+ */
+
+import { NextResponse } from 'next/server'
+import { ReviewCreateSchema } from '@/lib/schemas/commerce/review'
+import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
+import { createReview } from '@/lib/commerce/reviews'
+import { withRequestLog } from '@/lib/api/with-request-log'
+
+export const runtime = 'nodejs'
+
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000
+const RATE_LIMIT_MAX = 5
+const attempts = new Map<string, number[]>()
+
+function allowedByRateLimit(ip: string): boolean {
+  const now = Date.now()
+  const arr = (attempts.get(ip) ?? []).filter((t) => now - t < RATE_LIMIT_WINDOW_MS)
+  if (arr.length >= RATE_LIMIT_MAX) return false
+  arr.push(now)
+  attempts.set(ip, arr)
+  return true
+}
+
+export const POST = withRequestLog<{ site: string }>(async (request, _ctx, { site }) => {
+  if (!site) {
+    return NextResponse.json({ error: 'site_required' }, { status: 400 })
+  }
+  const business = await resolveBusinessBySlug(site)
+  if (!business) {
+    return NextResponse.json({ error: 'site_not_found' }, { status: 404 })
+  }
+
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown'
+  if (!allowedByRateLimit(ip)) {
+    return NextResponse.json({ error: 'rate_limited' }, { status: 429 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+
+  const parsed = ReviewCreateSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation_failed', issues: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const review = await createReview(business.id, parsed.data)
+  if (!review) {
+    return NextResponse.json({ error: 'create_failed' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true, pending: true }, { status: 201 })
+})

--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -16,6 +16,13 @@ import { BackInStockSignup } from '@/components/commerce/back-in-stock-signup'
 import { RecordRecentVisit } from '@/components/commerce/record-recent-visit'
 import { RecentlyViewedRail } from '@/components/commerce/recently-viewed-rail'
 import { PriceDisplay } from '@/components/commerce/price-display'
+import { ReviewList } from '@/components/commerce/review-list'
+import { ReviewForm } from '@/components/commerce/review-form'
+import { ReviewStars } from '@/components/commerce/review-stars'
+import {
+  listApprovedReviews,
+  getReviewAggregatesByBusiness,
+} from '@/lib/commerce/reviews'
 import { loadPygRates } from '@/lib/commerce/currency-server'
 import { env } from '@/lib/env'
 
@@ -49,10 +56,13 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
   if (!product || product.status !== 'active') notFound()
 
   const cover = product.images.find((i) => i.isCover) ?? product.images[0]
-  const [rates, related] = await Promise.all([
+  const [rates, related, reviews, aggregates] = await Promise.all([
     loadPygRates(),
     listRelatedProducts(business.id, { excludeId: product.id, category: product.category, limit: 4 }),
+    listApprovedReviews(business.id, product.id, { limit: 50 }),
+    getReviewAggregatesByBusiness(business.id),
   ])
+  const aggregate = aggregates[product.id]
 
   const structuredData = {
     '@context': 'https://schema.org',
@@ -107,6 +117,14 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
 
         <div>
           <h1 className="text-3xl font-bold text-[color:var(--text,#111)]">{product.name}</h1>
+          {aggregate ? (
+            <div className="mt-1">
+              <a href="#reviews-heading" className="inline-flex items-center gap-2 text-sm hover:underline">
+                <ReviewStars rating={aggregate.avg} count={aggregate.count} size="md" />
+                <span className="text-[color:var(--text-muted,#6b7280)]">Leer reseñas</span>
+              </a>
+            </div>
+          ) : null}
           {product.currency === 'PYG' ? (
             <PriceDisplay className="mt-2 block text-2xl font-semibold" pygCents={product.priceCents} rates={rates} />
           ) : (
@@ -175,6 +193,15 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
       />
 
       <RecentlyViewedRail siteSlug={site} locale={locale} excludeId={product.id} />
+
+      <div className="mx-auto max-w-5xl px-4 pb-6">
+        <ReviewList
+          reviews={reviews}
+          averageRating={aggregate?.avg}
+          totalCount={aggregate?.count}
+        />
+        <ReviewForm siteSlug={site} productId={product.id} />
+      </div>
 
       {related.length > 0 ? (
         <section aria-labelledby="related-heading" className="mx-auto max-w-5xl px-4 pb-12">

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -11,6 +11,7 @@ import {
   type ProductSort,
 } from '@/lib/commerce/products'
 import { recordSearchEvent, listTopSearches } from '@/lib/commerce/search-events'
+import { getReviewAggregatesByBusiness } from '@/lib/commerce/reviews'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { ProductCard } from '@/components/commerce/product-card'
@@ -104,7 +105,7 @@ export default async function StorePage({
     onSaleOnly,
   }
 
-  const [products, totalCount, rates, availableCategories, categoryCounts, topSearches, availableBrands, availableTags] =
+  const [products, totalCount, rates, availableCategories, categoryCounts, topSearches, availableBrands, availableTags, reviewAggregates] =
     await Promise.all([
       listActiveProducts(business.id, { ...filterOpts, limit: perPage, offset, sort: sortKey }),
       countActiveProducts(business.id, filterOpts),
@@ -114,6 +115,7 @@ export default async function StorePage({
       listTopSearches(business.id, { windowDays: 30, limit: 8 }),
       listDistinctBrands(business.id),
       listDistinctTags(business.id),
+      getReviewAggregatesByBusiness(business.id),
     ])
   // Only surface suggestions with at least 1 result (non-zero-result).
   // Dedup by normalized form, keep pretty sampleQuery.
@@ -236,6 +238,7 @@ export default async function StorePage({
                   priority={idx < 4}
                   rates={rates}
                   locale={locale}
+                  reviewAggregate={reviewAggregates[product.id]}
                 />
               ))}
             </div>

--- a/web/components/commerce/product-card.tsx
+++ b/web/components/commerce/product-card.tsx
@@ -13,6 +13,7 @@ import {
   removeFromWishlist,
 } from '@/lib/stores/wishlist'
 import { QuickViewModal } from './quick-view-modal'
+import { ReviewStars } from './review-stars'
 
 interface Props {
   siteSlug: string
@@ -20,6 +21,8 @@ interface Props {
   priority?: boolean
   rates?: Record<string, number>
   locale?: string
+  /** Optional review aggregate for rendering stars on the card. */
+  reviewAggregate?: { avg: number; count: number }
 }
 
 const WISHLIST_EVENT = 'paragu:wishlist-change'
@@ -37,7 +40,7 @@ function getServerWishlistSnapshot(): boolean {
   return false
 }
 
-export function ProductCard({ siteSlug, product, priority, rates, locale = 'es' }: Props) {
+export function ProductCard({ siteSlug, product, priority, rates, locale = 'es', reviewAggregate }: Props) {
   const addItem = useCartStore((s) => s.addItem)
   const [adding, setAdding] = useState(false)
   const [quickViewOpen, setQuickViewOpen] = useState(false)
@@ -172,6 +175,11 @@ export function ProductCard({ siteSlug, product, priority, rates, locale = 'es' 
 
       <div className="mt-3 flex flex-1 flex-col">
         <h3 className="text-sm font-medium text-[color:var(--text,#111)] line-clamp-2">{product.name}</h3>
+        {reviewAggregate && reviewAggregate.count > 0 ? (
+          <div className="mt-1">
+            <ReviewStars rating={reviewAggregate.avg} count={reviewAggregate.count} size="sm" />
+          </div>
+        ) : null}
         <div className="mt-1 flex items-baseline gap-2">
           {rates && product.currency === 'PYG' ? (
             <PriceDisplay className="text-base font-semibold text-[color:var(--text,#111)]" pygCents={product.priceCents} rates={rates} />

--- a/web/components/commerce/review-form.tsx
+++ b/web/components/commerce/review-form.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Props {
+  siteSlug: string
+  productId: string
+}
+
+/**
+ * Lightweight review form. POSTs to the storefront endpoint which inserts
+ * with is_approved=false — submissions are queued until an admin approves.
+ * The copy sets that expectation so users don't refresh and wonder where
+ * their review went.
+ */
+export function ReviewForm({ siteSlug, productId }: Props) {
+  const [name, setName] = useState('')
+  const [rating, setRating] = useState<number | null>(null)
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const [state, setState] = useState<'idle' | 'submitting' | 'ok' | 'err'>('idle')
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!rating || !name || !content) return
+    setState('submitting')
+    try {
+      const res = await fetch(`/api/storefront/${siteSlug}/reviews`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ productId, authorName: name, rating, title: title || undefined, content }),
+      })
+      setState(res.ok ? 'ok' : 'err')
+      if (res.ok) {
+        setName('')
+        setRating(null)
+        setTitle('')
+        setContent('')
+      }
+    } catch {
+      setState('err')
+    }
+  }
+
+  return (
+    <section aria-labelledby="review-form-heading" className="mt-8 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4">
+      <h3 id="review-form-heading" className="mb-1 text-lg font-semibold">Escribí una reseña</h3>
+      <p className="mb-3 text-xs text-[color:var(--text-muted,#6b7280)]">
+        Las reseñas son revisadas antes de publicarse. Puede demorar 24–48 hs.
+      </p>
+      {state === 'ok' ? (
+        <p className="rounded bg-emerald-50 p-3 text-sm text-emerald-800">
+          Gracias, tu reseña quedó pendiente de aprobación.
+        </p>
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-3">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium">Tu puntaje:</span>
+            <div className="flex gap-1">
+              {[1, 2, 3, 4, 5].map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  onClick={() => setRating(n)}
+                  aria-pressed={rating === n}
+                  aria-label={`${n} estrella${n === 1 ? '' : 's'}`}
+                  className={`text-2xl leading-none transition-colors ${
+                    rating !== null && n <= rating ? 'text-amber-500' : 'text-[color:var(--border,#d1d5db)]'
+                  }`}
+                >
+                  ★
+                </button>
+              ))}
+            </div>
+          </div>
+          <label className="block text-sm">
+            Tu nombre (o alias):
+            <input
+              type="text"
+              required
+              maxLength={80}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+              placeholder="Ej. Ana, LuciC, etc."
+            />
+          </label>
+          <label className="block text-sm">
+            Título (opcional):
+            <input
+              type="text"
+              maxLength={160}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="mt-1 block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+              placeholder="Ej. Excelente calidad"
+            />
+          </label>
+          <label className="block text-sm">
+            Tu experiencia:
+            <textarea
+              required
+              minLength={10}
+              maxLength={4000}
+              rows={4}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              className="mt-1 block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+              placeholder="Contanos qué te pareció. Mínimo 10 caracteres."
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={state === 'submitting' || !rating || !name || content.length < 10}
+            className="rounded bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-medium text-[color:var(--primary-foreground,#fff)] disabled:opacity-50"
+          >
+            {state === 'submitting' ? 'Enviando…' : 'Enviar reseña'}
+          </button>
+          {state === 'err' ? (
+            <p className="text-sm text-red-700">No pudimos enviar tu reseña. Probá de nuevo en un momento.</p>
+          ) : null}
+        </form>
+      )}
+    </section>
+  )
+}

--- a/web/components/commerce/review-list.tsx
+++ b/web/components/commerce/review-list.tsx
@@ -1,0 +1,65 @@
+import type { Review } from '@/lib/schemas/commerce/review'
+import { ReviewStars } from './review-stars'
+
+interface Props {
+  reviews: Review[]
+  averageRating?: number
+  totalCount?: number
+}
+
+export function ReviewList({ reviews, averageRating, totalCount }: Props) {
+  if (reviews.length === 0) {
+    return (
+      <section aria-labelledby="reviews-heading" className="mt-10">
+        <h2 id="reviews-heading" className="mb-2 text-xl font-semibold text-[color:var(--text,#111)]">
+          Reseñas
+        </h2>
+        <p className="text-sm text-[color:var(--text-muted,#6b7280)]">
+          Todavía no hay reseñas aprobadas para este producto.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section aria-labelledby="reviews-heading" className="mt-10">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 id="reviews-heading" className="text-xl font-semibold text-[color:var(--text,#111)]">
+          Reseñas
+        </h2>
+        {typeof averageRating === 'number' && totalCount ? (
+          <div className="flex items-center gap-2 text-sm">
+            <ReviewStars rating={averageRating} size="md" />
+            <span className="font-medium">{averageRating.toFixed(1)}</span>
+            <span className="text-[color:var(--text-muted,#6b7280)]">
+              ({totalCount} {totalCount === 1 ? 'reseña' : 'reseñas'})
+            </span>
+          </div>
+        ) : null}
+      </div>
+
+      <ul className="space-y-4">
+        {reviews.map((r) => (
+          <li key={r.id} className="rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4">
+            <div className="mb-2 flex items-center gap-2 text-sm">
+              <ReviewStars rating={r.rating} size="sm" />
+              <span className="font-medium text-[color:var(--text,#111)]">{r.authorName}</span>
+              {r.isVerifiedPurchase ? (
+                <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-semibold text-emerald-700">
+                  Compra verificada
+                </span>
+              ) : null}
+              <span className="ml-auto text-xs text-[color:var(--text-muted,#6b7280)]">
+                {new Date(r.createdAt).toLocaleDateString('es-PY', { year: 'numeric', month: 'short', day: 'numeric' })}
+              </span>
+            </div>
+            {r.title ? (
+              <p className="mb-1 font-semibold text-[color:var(--text,#111)]">{r.title}</p>
+            ) : null}
+            <p className="whitespace-pre-line text-sm text-[color:var(--text,#111)]">{r.content}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/web/components/commerce/review-stars.tsx
+++ b/web/components/commerce/review-stars.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/utils'
+
+interface Props {
+  /** Average rating, 0–5. Renders 5 stars, partially filled via width trick. */
+  rating: number
+  /** Review count to render next to the stars ("(12)"). Hidden when undefined or 0. */
+  count?: number
+  size?: 'sm' | 'md' | 'lg'
+  className?: string
+}
+
+const SIZE_CLASS: Record<NonNullable<Props['size']>, string> = {
+  sm: 'text-xs',
+  md: 'text-sm',
+  lg: 'text-base',
+}
+
+export function ReviewStars({ rating, count, size = 'sm', className }: Props) {
+  const clamped = Math.max(0, Math.min(5, rating))
+  const fullPct = (clamped / 5) * 100
+  return (
+    <div className={cn('inline-flex items-center gap-1', SIZE_CLASS[size], className)} aria-label={`${clamped.toFixed(1)} de 5`}>
+      <span className="relative inline-block leading-none" aria-hidden="true">
+        <span className="text-[color:var(--border,#e5e7eb)]">★★★★★</span>
+        <span
+          className="absolute inset-0 overflow-hidden text-amber-500"
+          style={{ width: `${fullPct}%` }}
+        >
+          ★★★★★
+        </span>
+      </span>
+      {typeof count === 'number' && count > 0 ? (
+        <span className="text-[color:var(--text-muted,#6b7280)]">({count})</span>
+      ) : null}
+    </div>
+  )
+}

--- a/web/lib/commerce/reviews.ts
+++ b/web/lib/commerce/reviews.ts
@@ -1,0 +1,138 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import type { Review, ReviewAggregate, ReviewCreate } from '@/lib/schemas/commerce/review'
+import { logger } from '@/lib/logger'
+
+interface ReviewRow {
+  id: string
+  business_id: string
+  product_id: string
+  author_name: string
+  author_email: string | null
+  rating: number
+  title: string | null
+  content: string
+  is_verified_purchase: boolean | null
+  is_approved: boolean | null
+  created_at: string
+  updated_at: string
+}
+
+function rowToReview(row: ReviewRow): Review {
+  return {
+    id: row.id,
+    businessId: row.business_id,
+    productId: row.product_id,
+    authorName: row.author_name,
+    authorEmail: row.author_email,
+    rating: row.rating,
+    title: row.title,
+    content: row.content,
+    isVerifiedPurchase: Boolean(row.is_verified_purchase),
+    isApproved: Boolean(row.is_approved),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+/** Public-facing list: approved only, newest first. */
+export async function listApprovedReviews(
+  businessId: string,
+  productId: string,
+  opts: { limit?: number } = {},
+): Promise<Review[]> {
+  const limit = opts.limit ?? 50
+  const supabase = await createAdminClient()
+  const { data, error } = await supabase
+    .from('reviews')
+    .select('*')
+    .eq('business_id', businessId)
+    .eq('product_id', productId)
+    .eq('is_approved', true)
+    .order('created_at', { ascending: false })
+    .limit(limit)
+  if (error) {
+    logger.error('[reviews] listApproved failed', {
+      action: 'reviews.list_approved',
+      businessId,
+      productId,
+      error: error.message,
+    })
+    return []
+  }
+  return (Array.isArray(data) ? data : []).map((r) => rowToReview(r as ReviewRow))
+}
+
+/**
+ * Aggregate ratings for ALL active products of a tenant in one query.
+ * Returns a Record<productId, { count, avg }> so product-card and tienda
+ * can render stars without N+1 queries.
+ *
+ * Only counts approved reviews.
+ */
+export async function getReviewAggregatesByBusiness(
+  businessId: string,
+): Promise<Record<string, ReviewAggregate>> {
+  const supabase = await createAdminClient()
+  const { data, error } = await supabase
+    .from('reviews')
+    .select('product_id, rating')
+    .eq('business_id', businessId)
+    .eq('is_approved', true)
+  if (error) {
+    logger.error('[reviews] aggregate query failed', {
+      action: 'reviews.aggregate',
+      businessId,
+      error: error.message,
+    })
+    return {}
+  }
+  const acc: Record<string, { sum: number; count: number }> = {}
+  for (const r of (Array.isArray(data) ? data : []) as Array<{ product_id: string; rating: number }>) {
+    const existing = acc[r.product_id] ?? { sum: 0, count: 0 }
+    existing.sum += r.rating
+    existing.count += 1
+    acc[r.product_id] = existing
+  }
+  const out: Record<string, ReviewAggregate> = {}
+  for (const [productId, { sum, count }] of Object.entries(acc)) {
+    out[productId] = { productId, count, avg: count > 0 ? sum / count : 0 }
+  }
+  return out
+}
+
+/**
+ * Creates a pending (un-approved) review. Admin must approve before it
+ * appears on the storefront. Spam is mitigated by the is_approved=false
+ * default + rate limiting at the API boundary.
+ */
+export async function createReview(
+  businessId: string,
+  input: ReviewCreate,
+): Promise<Review | null> {
+  const supabase = await createAdminClient()
+  const { data, error } = await supabase
+    .from('reviews')
+    .insert({
+      business_id: businessId,
+      product_id: input.productId,
+      author_name: input.authorName,
+      author_email: input.authorEmail ?? null,
+      rating: input.rating,
+      title: input.title ?? null,
+      content: input.content,
+      is_verified_purchase: false,
+      is_approved: false,
+    })
+    .select('*')
+    .single()
+  if (error || !data) {
+    logger.error('[reviews] create failed', {
+      action: 'reviews.create',
+      businessId,
+      productId: input.productId,
+      error: error?.message ?? 'no data',
+    })
+    return null
+  }
+  return rowToReview(data as ReviewRow)
+}

--- a/web/lib/schemas/commerce/review.ts
+++ b/web/lib/schemas/commerce/review.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod'
+
+export const ReviewSchema = z.object({
+  id: z.string().uuid(),
+  businessId: z.string().uuid(),
+  productId: z.string().uuid(),
+  authorName: z.string().min(1).max(80),
+  authorEmail: z.string().email().nullable(),
+  rating: z.number().int().min(1).max(5),
+  title: z.string().max(160).nullable(),
+  content: z.string().min(1).max(4000),
+  isVerifiedPurchase: z.boolean(),
+  isApproved: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+export type Review = z.infer<typeof ReviewSchema>
+
+export const ReviewCreateSchema = z.object({
+  productId: z.string().uuid(),
+  authorName: z.string().min(1).max(80),
+  authorEmail: z.string().email().optional(),
+  rating: z.number().int().min(1).max(5),
+  title: z.string().max(160).optional(),
+  content: z.string().min(10).max(4000),
+})
+export type ReviewCreate = z.infer<typeof ReviewCreateSchema>
+
+export interface ReviewAggregate {
+  productId: string
+  count: number
+  avg: number
+}


### PR DESCRIPTION
## Summary
Full reviews feature — stars on product cards, review list + submit form on PDP, API with rate limit + moderation queue.

### New files
- \`lib/schemas/commerce/review.ts\` — Review + ReviewCreate + ReviewAggregate
- \`lib/commerce/reviews.ts\` — listApprovedReviews + getReviewAggregatesByBusiness (one-query) + createReview
- \`components/commerce/review-stars.tsx\` — partial-fill stars, sm/md/lg
- \`components/commerce/review-list.tsx\` — server-rendered list
- \`components/commerce/review-form.tsx\` — client form, "pending approval" copy
- \`app/api/storefront/[site]/reviews/route.ts\` — POST, Zod-validated, 5/hr/IP, always inserts with \`is_approved=false\`

### Wiring
- PDP: loads reviews + aggregates in parallel, renders stars near title (linking to review section), full list + form below
- Tienda: one aggregates query, passes per-product \`reviewAggregate\` to each \`ProductCard\`
- ProductCard: renders stars + count under title when aggregate exists

### Moderation
DB-only for now (toggle \`is_approved=true\`). Admin UI not in scope.

## Test plan
- [x] 139/139 tests pass
- [ ] Deploy → PDP shows "Todavía no hay reseñas aprobadas" for all 12 fun4me products initially
- [ ] Deploy → submit a review via form, get 201 with \`{pending:true}\`
- [ ] Flip \`is_approved=true\` via SQL → review appears on PDP + stars appear on card
- [ ] Tienda page shows stars on cards for products with approved reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)