### PR TITLE
feat(header): product search in engine HeaderSection — opt-in per tenant

### DIFF
--- a/sites/fun4me/content/es.json
+++ b/sites/fun4me/content/es.json
@@ -59,7 +59,8 @@
       }
     ],
     "ctaText": "WhatsApp",
-    "ctaHref": "https://wa.me/595976569739"
+    "ctaHref": "https://wa.me/595976569739",
+    "enableSearch": true
   },
   "home": {
     "seo": {

--- a/web/components/sections/header-section.tsx
+++ b/web/components/sections/header-section.tsx
@@ -7,6 +7,7 @@ import { LOCALE_LABELS, type Locale } from '@/lib/i18n/config'
 import { buildLocaleUrl } from '@/lib/i18n/routing'
 import { cn } from '@/lib/utils'
 import { Menu, X } from 'lucide-react'
+import { HeaderSearch } from '@/components/commerce/header-search'
 
 export interface NavItem {
   label: string
@@ -21,6 +22,13 @@ export interface HeaderSectionProps {
   items?: NavItem[]
   ctaText?: string
   ctaHref?: string
+  /**
+   * Show the commerce header-search box (with autocomplete + recent
+   * searches) between the logo and the nav. Opt-in per tenant via content
+   * file — defaults to false so non-commerce tenants don't get a dead
+   * search bar.
+   */
+  enableSearch?: boolean
   __siteSlug?: string
   __locale?: Locale
   __availableLocales?: Locale[]
@@ -44,6 +52,7 @@ export function HeaderSection({
   items,
   ctaText,
   ctaHref = '#contacto',
+  enableSearch = false,
   __siteSlug,
   __locale,
   __availableLocales,
@@ -149,6 +158,14 @@ export function HeaderSection({
             {businessName}
           </a>
 
+          {/* Desktop search (opt-in via content). Hidden on mobile where the
+              nav's hamburger is the entry point. */}
+          {enableSearch && __siteSlug ? (
+            <div className="mx-4 hidden max-w-sm flex-1 md:block">
+              <HeaderSearch siteSlug={__siteSlug} locale={__locale ?? 'es'} />
+            </div>
+          ) : null}
+
           {/* Desktop Nav */}
           <nav className="hidden items-center gap-1 md:flex">
             {navItems.map((item) => (
@@ -207,6 +224,11 @@ export function HeaderSection({
           )}
         >
           <nav className="border-t border-[var(--surface-light)] py-4">
+            {enableSearch && __siteSlug ? (
+              <div className="mb-3 px-1">
+                <HeaderSearch siteSlug={__siteSlug} locale={__locale ?? 'es'} />
+              </div>
+            ) : null}
             {navItems.map((item) => (
               <a
                 key={item.href}

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -18480,6 +18480,7 @@ export const CONTENT: Record<string, JsonRecord> = {
       "businessName": "Fun4Me",
       "ctaHref": "https://wa.me/595976569739",
       "ctaText": "WhatsApp",
+      "enableSearch": true,
       "items": [
         {
           "href": "/",


### PR DESCRIPTION
## Summary
Engine \`HeaderSection\` (used across all tenant marketing pages) now optionally mounts \`HeaderSearch\` (autocomplete + recent searches) between logo and nav.

- New prop \`enableSearch?: boolean\` (default false)
- Desktop: between logo and nav, max-w-sm
- Mobile: top of hamburger drawer
- Uses existing \`/api/storefront/[site]/search-suggest\` (220ms debounce, ≥2 char trigger)

Enabled for fun4me via a one-line content flag. Non-commerce tenants unaffected.

### Why
Shoppers on fun4me home / quienes-somos / blog had to click "Tienda" before they could search. Now search is one click from any tenant page.

## Test plan
- [x] 24/24 engine tests pass
- [ ] Deploy → fun4me home shows search box in header
- [ ] Deploy → typing "vibrador" shows suggestions dropdown
- [ ] Deploy → recent searches persist + show on focus
- [ ] Deploy → other tenants (nexa, granja) unchanged (no search bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)