### PR TITLE
feat(admin): brand + tags fields in product create/edit forms

### DIFF
--- a/web/app/admin/commerce/[businessId]/products/[id]/page.tsx
+++ b/web/app/admin/commerce/[businessId]/products/[id]/page.tsx
@@ -14,6 +14,8 @@ interface ProductRow {
   name: string
   description: string | null
   category: string | null
+  brand: string | null
+  tags: string[] | null
   price_cents: number
   inventory_qty: number
   inventory_policy: 'deny' | 'continue'
@@ -55,6 +57,8 @@ export default async function EditProductPage({ params }: { params: Promise<{ bu
           name: product.name,
           description: product.description ?? '',
           category: product.category ?? '',
+          brand: product.brand ?? '',
+          tags: product.tags ?? [],
           priceCents: product.price_cents,
           inventoryQty: product.inventory_qty,
           status: product.status,

--- a/web/components/admin/commerce/edit-product-form.tsx
+++ b/web/components/admin/commerce/edit-product-form.tsx
@@ -9,6 +9,8 @@ interface ProductProps {
   name: string
   description: string
   category: string
+  brand: string
+  tags: string[]
   priceCents: number
   inventoryQty: number
   status: 'active' | 'draft' | 'archived'
@@ -31,10 +33,22 @@ export function EditProductForm({ businessId, product }: Props) {
     setSubmitting(true)
     setError(null)
     const form = new FormData(event.currentTarget)
+    const tagsRaw = String(form.get('tags') ?? '').trim()
     const payload = {
       name: String(form.get('name') ?? ''),
       description: String(form.get('description') ?? '') || undefined,
       category: String(form.get('category') ?? '') || undefined,
+      brand: String(form.get('brand') ?? '') || undefined,
+      tags: tagsRaw
+        ? Array.from(
+            new Set(
+              tagsRaw
+                .split(/[,\s]+/)
+                .map((t) => t.trim().toLowerCase())
+                .filter(Boolean),
+            ),
+          )
+        : [],
       priceCents: parseInt(String(form.get('priceCents') ?? '0').replace(/[^0-9]/g, ''), 10),
       inventoryQty: parseInt(String(form.get('inventoryQty') ?? '0'), 10) || 0,
       status: String(form.get('status') ?? 'active') as 'active' | 'draft' | 'archived',
@@ -91,7 +105,16 @@ export function EditProductForm({ businessId, product }: Props) {
           className="w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
         />
       </label>
-      <Field label="Categoría" name="category" defaultValue={product.category} />
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Categoría" name="category" defaultValue={product.category} />
+        <Field label="Marca" name="brand" defaultValue={product.brand} hint="Opcional — habilita el filtro de marca en la tienda." />
+      </div>
+      <Field
+        label="Etiquetas"
+        name="tags"
+        defaultValue={product.tags.join(', ')}
+        hint="Coma-separadas. Ej: silicona, impermeable, recargable. Se usan en los filtros de #Características."
+      />
       <div className="grid grid-cols-2 gap-4">
         <Field label="Precio (Gs)" name="priceCents" defaultValue={String(product.priceCents)} required />
         <Field label="Stock" name="inventoryQty" type="number" defaultValue={String(product.inventoryQty)} required />

--- a/web/components/admin/commerce/new-product-form.tsx
+++ b/web/components/admin/commerce/new-product-form.tsx
@@ -31,11 +31,23 @@ export function NewProductForm({ businessId }: Props) {
     setSubmitting(true)
     setError(null)
     const form = new FormData(event.currentTarget)
+    const tagsRaw = String(form.get('tags') ?? '').trim()
     const payload = {
       slug: slug || slugify(name),
       name,
       description: String(form.get('description') ?? '') || undefined,
       category: String(form.get('category') ?? '') || undefined,
+      brand: String(form.get('brand') ?? '') || undefined,
+      tags: tagsRaw
+        ? Array.from(
+            new Set(
+              tagsRaw
+                .split(/[,\s]+/)
+                .map((t) => t.trim().toLowerCase())
+                .filter(Boolean),
+            ),
+          )
+        : [],
       priceCents: parseInt(String(form.get('priceCents') ?? '0').replace(/[^0-9]/g, ''), 10),
       inventoryQty: parseInt(String(form.get('inventoryQty') ?? '0'), 10) || 0,
       inventoryPolicy: 'deny' as const,
@@ -84,7 +96,15 @@ export function NewProductForm({ businessId }: Props) {
         <span className="mb-1 block text-xs font-medium text-[color:var(--text-muted,#6b7280)]">Descripción</span>
         <textarea name="description" rows={4} className="w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm" />
       </label>
-      <Field label="Categoría" name="category" placeholder="ej: mujer, hombre, accesorios" />
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Categoría" name="category" placeholder="ej: mujer, hombre, accesorios" />
+        <Field label="Marca" name="brand" placeholder="Opcional" />
+      </div>
+      <Field
+        label="Etiquetas"
+        name="tags"
+        placeholder="silicona, impermeable, recargable"
+      />
       <div className="grid grid-cols-2 gap-4">
         <Field label="Precio (Gs)" name="priceCents" type="text" placeholder="150000" required />
         <Field label="Stock" name="inventoryQty" type="number" placeholder="10" required />

--- a/web/lib/commerce/products.ts
+++ b/web/lib/commerce/products.ts
@@ -354,6 +354,8 @@ export async function createProduct(
     name: input.name,
     description: input.description ?? null,
     category: input.category ?? null,
+    brand: input.brand ?? null,
+    tags: input.tags ?? [],
     price_cents: input.priceCents,
     compare_at_price_cents: input.compareAtPriceCents ?? null,
     currency: input.currency,
@@ -384,6 +386,8 @@ export async function updateProduct(
   if (patch.name !== undefined) dbPatch.name = patch.name
   if (patch.description !== undefined) dbPatch.description = patch.description
   if (patch.category !== undefined) dbPatch.category = patch.category
+  if (patch.brand !== undefined) dbPatch.brand = patch.brand
+  if (patch.tags !== undefined) dbPatch.tags = patch.tags
   if (patch.priceCents !== undefined) dbPatch.price_cents = patch.priceCents
   if (patch.compareAtPriceCents !== undefined) dbPatch.compare_at_price_cents = patch.compareAtPriceCents
   if (patch.currency !== undefined) dbPatch.currency = patch.currency


### PR DESCRIPTION
## Summary
Makes the \`brand\` + \`tags\` columns (added in PR #199) actually editable by the client. Without this, the filter UI in \`tienda\` surfaced tenant data that only the ops team could set via SQL.

- \`edit-product-form.tsx\` + \`new-product-form.tsx\` — new \"Marca\" (optional) + \"Etiquetas\" (comma-delimited → normalized to lower-cased, deduped string array) fields
- \`admin [id]/page.tsx\` — loads and threads brand + tags from DB
- \`lib/commerce/products.ts\` — \`createProduct\` writes brand + tags on insert; \`updateProduct\` maps brand + tags patch keys to the right columns

## Test plan
- [x] 115/115 commerce tests pass
- [ ] Deploy → admin product edit shows Marca + Etiquetas fields pre-filled from DB
- [ ] Save edited tags → tienda filters reflect the change
- [ ] Create a new product with tags → appears with #Características on card

🤖 Generated with [Claude Code](https://claude.com/claude-code)