### PR TITLE
feat(pdp): mobile sticky add-to-cart bar

### DIFF
--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -19,6 +19,7 @@ import { PriceDisplay } from '@/components/commerce/price-display'
 import { ReviewList } from '@/components/commerce/review-list'
 import { ReviewForm } from '@/components/commerce/review-form'
 import { ReviewStars } from '@/components/commerce/review-stars'
+import { PdpStickyMobileCta } from '@/components/commerce/pdp-sticky-mobile-cta'
 import {
   listApprovedReviews,
   getReviewAggregatesByBusiness,
@@ -166,7 +167,7 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
             <p className="mt-6 whitespace-pre-line text-[color:var(--text,#111)]">{product.description}</p>
           ) : null}
 
-          <div className="mt-6">
+          <div id="pdp-main-add-to-cart" className="mt-6">
             <ProductDetailActions siteSlug={site} productId={product.id} inventoryQty={product.inventoryQty} inventoryPolicy={product.inventoryPolicy} />
           </div>
 
@@ -233,6 +234,20 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
           </div>
         </section>
       ) : null}
+
+      {/* Mobile-only sticky CTA. Extra bottom padding on the page so content
+          isn't hidden behind the bar on mobile. */}
+      <div aria-hidden className="h-16 md:hidden" />
+      <PdpStickyMobileCta
+        siteSlug={site}
+        productId={product.id}
+        productName={product.name}
+        priceCents={product.priceCents}
+        currency={product.currency}
+        inventoryQty={product.inventoryQty}
+        inventoryPolicy={product.inventoryPolicy}
+        imageUrl={cover?.url ?? null}
+      />
     </div>
   )
 }

--- a/web/components/commerce/pdp-sticky-mobile-cta.tsx
+++ b/web/components/commerce/pdp-sticky-mobile-cta.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useCartStore } from '@/lib/stores/cart-store'
+import { formatCents } from '@/lib/commerce/compute-totals'
+
+interface Props {
+  siteSlug: string
+  productId: string
+  productName: string
+  priceCents: number
+  currency: string
+  inventoryQty: number
+  inventoryPolicy: 'deny' | 'continue'
+  imageUrl?: string | null
+  /**
+   * Selector of the main in-page add-to-cart element. When that element is
+   * visible in the viewport the sticky bar hides — avoids double-CTA
+   * awkwardness. When it scrolls off, the sticky bar appears.
+   */
+  mainCtaSelector?: string
+}
+
+/**
+ * Mobile-only sticky "Agregar al carrito" bar fixed to the bottom of the
+ * viewport. Hidden on md+ (desktop has the inline CTA in the main column).
+ * Watches the main CTA via IntersectionObserver so it only shows after the
+ * shopper scrolls past the real button.
+ */
+export function PdpStickyMobileCta({
+  siteSlug,
+  productId,
+  productName,
+  priceCents,
+  currency,
+  inventoryQty,
+  inventoryPolicy,
+  imageUrl,
+  mainCtaSelector = '#pdp-main-add-to-cart',
+}: Props) {
+  const addItem = useCartStore((s) => s.addItem)
+  const [adding, setAdding] = useState(false)
+  const [visible, setVisible] = useState(false)
+  const observerRef = useRef<IntersectionObserver | null>(null)
+
+  const outOfStock = inventoryPolicy === 'deny' && inventoryQty === 0
+
+  useEffect(() => {
+    const target = document.querySelector(mainCtaSelector)
+    if (!target) {
+      setVisible(true)
+      return
+    }
+    const obs = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0]
+        setVisible(!entry.isIntersecting)
+      },
+      { rootMargin: '0px 0px -20px 0px' },
+    )
+    obs.observe(target)
+    observerRef.current = obs
+    return () => obs.disconnect()
+  }, [mainCtaSelector])
+
+  const handleAdd = async () => {
+    if (outOfStock || adding) return
+    setAdding(true)
+    try {
+      await addItem(siteSlug, productId, 1)
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  return (
+    <div
+      className={`fixed inset-x-0 bottom-0 z-40 border-t border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] shadow-[0_-4px_12px_rgba(0,0,0,0.08)] transition-transform duration-200 md:hidden ${
+        visible ? 'translate-y-0' : 'translate-y-full'
+      }`}
+      aria-hidden={!visible}
+    >
+      <div className="flex items-center gap-3 px-4 py-3">
+        {imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element -- keep <img> to avoid next/image layout shift in a fixed bar
+          <img src={imageUrl} alt="" className="h-10 w-10 rounded object-cover" />
+        ) : null}
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-xs text-[color:var(--text,#111)]">{productName}</p>
+          <p className="text-sm font-semibold text-[color:var(--text,#111)]">
+            {formatCents(priceCents, currency)}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleAdd}
+          disabled={outOfStock || adding}
+          className="rounded-lg bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-semibold text-[color:var(--primary-foreground,#fff)] disabled:opacity-50"
+        >
+          {outOfStock ? 'Agotado' : adding ? 'Agregando…' : 'Agregar'}
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Classic mobile conversion polish. Once a shopper scrolls past the main CTA on a PDP, a persistent bar at the bottom of the viewport keeps "Agregar al carrito" one tap away.

### PdpStickyMobileCta
- Fixed bottom of viewport, \`md:hidden\`
- Cover thumbnail + name + price + Agregar button
- \`IntersectionObserver\` on \`#pdp-main-add-to-cart\` — bar hides while the main CTA is in the viewport, slides up when scrolled past
- "Agotado" disabled state when out of stock
- Same \`cart-store.addItem\` flow so cart + notifications are consistent

### Wiring
- PDP adds \`id="pdp-main-add-to-cart"\` to the primary action container
- 16px spacer at page bottom so content isn't hidden behind the bar

## Test plan
- [x] 24/24 engine tests pass
- [ ] Mobile → open PDP, scroll past main CTA → sticky bar appears
- [ ] Tap Agregar in sticky bar → item added to cart + MiniCartBadge count updates
- [ ] Scroll back up → sticky bar hides
- [ ] Desktop → no bar renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)