### PR TITLE
feat(commerce): Mejor valorados sort + auto verified-purchase

### DIFF
--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -26,7 +26,7 @@ import { loadPygRates } from '@/lib/commerce/currency-server'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic' // search/sort/filter params kill static caching
 
-const VALID_SORTS: ProductSort[] = ['newest', 'price-asc', 'price-desc', 'name-asc', 'popularity']
+const VALID_SORTS: ProductSort[] = ['newest', 'price-asc', 'price-desc', 'name-asc', 'popularity', 'rating']
 const DEFAULT_PER_PAGE = 12
 const PER_PAGE_OPTIONS = [12, 24, 48, 96]
 const MAX_PER_PAGE = 96
@@ -107,11 +107,12 @@ export default async function StorePage({
     onSaleOnly,
   }
 
-  // Popularity sort requires all matching rows up front so we can re-sort by
-  // the order_items aggregate before paginating. For any other sort the DB
+  // Popularity + rating sorts require all matching rows up front so we can
+  // re-sort by aggregates before paginating. For any other sort the DB
   // paginates natively.
-  const fetchLimit = sortKey === 'popularity' ? 500 : perPage
-  const fetchOffset = sortKey === 'popularity' ? 0 : offset
+  const needsPostSort = sortKey === 'popularity' || sortKey === 'rating'
+  const fetchLimit = needsPostSort ? 500 : perPage
+  const fetchOffset = needsPostSort ? 0 : offset
 
   const [fetchedProducts, totalCount, rates, availableCategories, categoryCounts, topSearches, availableBrands, availableTags, reviewAggregates, popularityMap] =
     await Promise.all([
@@ -127,11 +128,27 @@ export default async function StorePage({
       sortKey === 'popularity' ? getPopularityByBusiness(business.id) : Promise.resolve(new Map<string, number>()),
     ])
 
-  const products = sortKey === 'popularity'
-    ? [...fetchedProducts]
-        .sort((a, b) => (popularityMap.get(b.id) ?? 0) - (popularityMap.get(a.id) ?? 0))
-        .slice(offset, offset + perPage)
-    : fetchedProducts
+  let products = fetchedProducts
+  if (sortKey === 'popularity') {
+    products = [...fetchedProducts]
+      .sort((a, b) => (popularityMap.get(b.id) ?? 0) - (popularityMap.get(a.id) ?? 0))
+      .slice(offset, offset + perPage)
+  } else if (sortKey === 'rating') {
+    // Rank by avg rating desc, tiebreak by count desc, tiebreak by created_at desc.
+    products = [...fetchedProducts]
+      .sort((a, b) => {
+        const ra = reviewAggregates[a.id]
+        const rb = reviewAggregates[b.id]
+        const aAvg = ra?.avg ?? 0
+        const bAvg = rb?.avg ?? 0
+        if (bAvg !== aAvg) return bAvg - aAvg
+        const aCount = ra?.count ?? 0
+        const bCount = rb?.count ?? 0
+        if (bCount !== aCount) return bCount - aCount
+        return Date.parse(b.createdAt) - Date.parse(a.createdAt)
+      })
+      .slice(offset, offset + perPage)
+  }
   // Only surface suggestions with at least 1 result (non-zero-result).
   // Dedup by normalized form, keep pretty sampleQuery.
   const popularQueries = topSearches

--- a/web/components/commerce/review-form.tsx
+++ b/web/components/commerce/review-form.tsx
@@ -15,6 +15,7 @@ interface Props {
  */
 export function ReviewForm({ siteSlug, productId }: Props) {
   const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
   const [rating, setRating] = useState<number | null>(null)
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
@@ -28,11 +29,19 @@ export function ReviewForm({ siteSlug, productId }: Props) {
       const res = await fetch(`/api/storefront/${siteSlug}/reviews`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ productId, authorName: name, rating, title: title || undefined, content }),
+        body: JSON.stringify({
+          productId,
+          authorName: name,
+          authorEmail: email.trim() || undefined,
+          rating,
+          title: title || undefined,
+          content,
+        }),
       })
       setState(res.ok ? 'ok' : 'err')
       if (res.ok) {
         setName('')
+        setEmail('')
         setRating(null)
         setTitle('')
         setContent('')
@@ -84,6 +93,20 @@ export function ReviewForm({ siteSlug, productId }: Props) {
               className="mt-1 block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
               placeholder="Ej. Ana, LuciC, etc."
             />
+          </label>
+          <label className="block text-sm">
+            Email <span className="text-[color:var(--text-muted,#6b7280)]">(opcional, no se publica)</span>:
+            <input
+              type="email"
+              maxLength={160}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="mt-1 block w-full rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm"
+              placeholder="tu@email.com"
+            />
+            <span className="mt-1 block text-xs text-[color:var(--text-muted,#6b7280)]">
+              Si usás el mismo email que en tu pedido, tu reseña se marca como "Compra verificada".
+            </span>
           </label>
           <label className="block text-sm">
             Título (opcional):

--- a/web/components/commerce/tienda-toolbar.tsx
+++ b/web/components/commerce/tienda-toolbar.tsx
@@ -40,6 +40,7 @@ const PER_PAGE_OPTIONS = [12, 24, 48, 96]
 const SORT_OPTIONS: Array<{ value: ProductSort; label: string }> = [
   { value: 'newest', label: 'Más nuevos' },
   { value: 'popularity', label: 'Más vendidos' },
+  { value: 'rating', label: 'Mejor valorados' },
   { value: 'price-asc', label: 'Precio: menor a mayor' },
   { value: 'price-desc', label: 'Precio: mayor a menor' },
   { value: 'name-asc', label: 'Nombre A→Z' },

--- a/web/lib/commerce/products.ts
+++ b/web/lib/commerce/products.ts
@@ -55,7 +55,7 @@ function rowToProduct(row: ProductRow): Product {
   }
 }
 
-export type ProductSort = 'newest' | 'price-asc' | 'price-desc' | 'name-asc' | 'popularity'
+export type ProductSort = 'newest' | 'price-asc' | 'price-desc' | 'name-asc' | 'popularity' | 'rating'
 
 /**
  * Aggregate: units sold per product for a business. Sums order_items.quantity
@@ -107,9 +107,10 @@ const SORT_FIELDS: Record<ProductSort, { column: string; ascending: boolean }> =
   'price-asc': { column: 'price_cents', ascending: true },
   'price-desc': { column: 'price_cents', ascending: false },
   'name-asc': { column: 'name', ascending: true },
-  // popularity is handled post-query (see listActiveProducts) — default fallback
-  // is newest so the DB order is deterministic if we ever forget to re-sort.
+  // popularity + rating are handled post-query (see /tienda/page.tsx) —
+  // default DB order is newest so the fallback is deterministic.
   popularity: { column: 'created_at', ascending: false },
+  rating: { column: 'created_at', ascending: false },
 }
 
 /**

--- a/web/lib/commerce/reviews.ts
+++ b/web/lib/commerce/reviews.ts
@@ -101,15 +101,58 @@ export async function getReviewAggregatesByBusiness(
 }
 
 /**
+ * Auto-detect verified-purchase status. Joins orders (customer_email match)
+ * with order_items (product match) for the business, filtered to completed
+ * states. Returns true if the author actually bought the product from this
+ * business. Email comparison is case-insensitive.
+ *
+ * Kept separate from createReview so the query can be reused (e.g., a
+ * batch job that retroactively marks verified older reviews).
+ */
+export async function isVerifiedPurchase(
+  businessId: string,
+  productId: string,
+  email: string,
+): Promise<boolean> {
+  if (!email) return false
+  const supabase = await createAdminClient()
+  const { data, error } = await supabase
+    .from('orders')
+    .select('id, order_items!inner(product_id)')
+    .eq('business_id', businessId)
+    .ilike('customer_email', email.trim())
+    .in('status', ['paid', 'fulfilled', 'shipped', 'delivered'])
+    .eq('order_items.product_id', productId)
+    .limit(1)
+  if (error) {
+    logger.warn('[reviews] verified-purchase query failed', {
+      action: 'reviews.verify_purchase',
+      businessId,
+      productId,
+      error: error.message,
+    })
+    return false
+  }
+  return Array.isArray(data) && data.length > 0
+}
+
+/**
  * Creates a pending (un-approved) review. Admin must approve before it
  * appears on the storefront. Spam is mitigated by the is_approved=false
  * default + rate limiting at the API boundary.
+ *
+ * If `authorEmail` is provided, auto-detects verified-purchase status
+ * so legit buyers get the "Compra verificada" badge without admin
+ * intervention once approved.
  */
 export async function createReview(
   businessId: string,
   input: ReviewCreate,
 ): Promise<Review | null> {
   const supabase = await createAdminClient()
+  const verified = input.authorEmail
+    ? await isVerifiedPurchase(businessId, input.productId, input.authorEmail)
+    : false
   const { data, error } = await supabase
     .from('reviews')
     .insert({
@@ -120,7 +163,7 @@ export async function createReview(
       rating: input.rating,
       title: input.title ?? null,
       content: input.content,
-      is_verified_purchase: false,
+      is_verified_purchase: verified,
       is_approved: false,
     })
     .select('*')


### PR DESCRIPTION
## Summary
Two ratings-related upgrades.

### "Mejor valorados" sort
New \`rating\` ProductSort. Ranks by avg rating desc, tiebreaks by count desc, then created_at desc. Same fetch-all-then-post-sort pattern as popularity (cap 500 products).

### Auto verified-purchase
ReviewForm gains an optional email field. On submit, server checks whether that email matches any paid/shipped/delivered order containing the product for this business. If yes, the review lands with \`is_verified_purchase=true\` — once an admin approves, it auto-gets the "Compra verificada" badge.

New helper \`isVerifiedPurchase\` kept separate so a future batch can retroactively mark older reviews.

## Test plan
- [x] 115/115 tests pass
- [ ] Deploy → "Mejor valorados" appears in sort dropdown, reordering respects avg rating
- [ ] Submit review with email matching an order → approved review shows "Compra verificada"
- [ ] Submit review with no email → lands unverified, admin can still approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)