### PR TITLE
feat(seo): per-tenant sitemap — real pages + categories + products

### DIFF
--- a/web/app/[business]/sitemap/route.ts
+++ b/web/app/[business]/sitemap/route.ts
@@ -1,32 +1,127 @@
+/**
+ * Per-tenant sitemap.xml at /[business]/sitemap.
+ *
+ * Pulls the tenant's actual pages (from the static-sites config) across
+ * every locale plus, for commerce tenants, every category landing and
+ * every active product page. Falls back to a minimal sitemap if the
+ * tenant isn't found rather than 500ing.
+ */
 import { NextResponse } from 'next/server'
-import { loadAllSlugs } from '@/lib/engine/data-loader'
+import { SITES } from '@/lib/engine/static-sites'
 import { withRequestLog } from '@/lib/api/with-request-log'
+import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
+import { isCommerceEnabled } from '@/lib/commerce/capability'
+import {
+  listActiveProducts,
+  listDistinctCategories,
+} from '@/lib/commerce/products'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
+export const revalidate = 3600 // 1 hour — SEO crawls are infrequent enough
 
-export const GET = withRequestLog(async (_request, { log }) => {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://paragu-ai.builder'
-  const pages = ['servicios', 'galeria', 'equipo', 'contacto']
+interface UrlEntry {
+  loc: string
+  lastmod?: string
+  changefreq?: 'daily' | 'weekly' | 'monthly'
+  priority?: number
+}
 
-  const slugs = await loadAllSlugs()
-  const urls = slugs.flatMap((slug) => [
-    `${baseUrl}/${slug}`,
-    ...pages.map((page) => `${baseUrl}/${slug}/${page}`),
-  ])
+function xmlEscape(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' }[c]!))
+}
 
-  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urls.map((url) => `  <url>
-    <loc>${url}</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>`).join('\n')}
-</urlset>`
+function renderSitemap(entries: UrlEntry[]): string {
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+  ]
+  for (const e of entries) {
+    lines.push('  <url>')
+    lines.push(`    <loc>${xmlEscape(e.loc)}</loc>`)
+    if (e.lastmod) lines.push(`    <lastmod>${e.lastmod}</lastmod>`)
+    if (e.changefreq) lines.push(`    <changefreq>${e.changefreq}</changefreq>`)
+    if (typeof e.priority === 'number') lines.push(`    <priority>${e.priority.toFixed(1)}</priority>`)
+    lines.push('  </url>')
+  }
+  lines.push('</urlset>')
+  return lines.join('\n')
+}
 
-  log.debug('Sitemap generated', { slugCount: slugs.length, urlCount: urls.length })
+export const GET = withRequestLog<{ business: string }>(async (_request, { log }, { business }) => {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '') || 'https://paragu-ai.com'
+  const site = SITES[business as keyof typeof SITES]
+  if (!site) {
+    return new NextResponse(renderSitemap([]), {
+      status: 404,
+      headers: { 'Content-Type': 'application/xml' },
+    })
+  }
 
-  return new NextResponse(sitemap, {
-    headers: { 'Content-Type': 'application/xml' },
+  const entries: UrlEntry[] = []
+  const locales = site.locales.length > 0 ? site.locales : ['es']
+
+  // Core pages — every locale, every page in the tenant's config.
+  for (const locale of locales) {
+    for (const page of site.pages) {
+      const path = page === 'home' ? '' : `/${page}`
+      entries.push({
+        loc: `${baseUrl}/s/${locale}/${business}${path}`,
+        changefreq: 'weekly',
+        priority: page === 'home' ? 1.0 : 0.8,
+      })
+    }
+  }
+
+  // Commerce additions: categories + products (one locale; avoids duplicate-
+  // content penalties when all the locales point at the same product slug).
+  const canonicalLocale = site.defaultLocale ?? locales[0]
+  try {
+    const biz = await resolveBusinessBySlug(business)
+    if (biz && (await isCommerceEnabled(biz.type))) {
+      const [categories, products] = await Promise.all([
+        listDistinctCategories(biz.id),
+        // Cap at 2000 products; tenants beyond that should split into
+        // multiple sitemaps (sitemap index). Not our problem today.
+        listActiveProducts(biz.id, { limit: 2000, sort: 'newest' }),
+      ])
+
+      for (const cat of categories) {
+        entries.push({
+          loc: `${baseUrl}/s/${canonicalLocale}/${business}/tienda/categoria/${encodeURIComponent(cat)}`,
+          changefreq: 'weekly',
+          priority: 0.7,
+        })
+      }
+
+      entries.push({
+        loc: `${baseUrl}/s/${canonicalLocale}/${business}/tienda`,
+        changefreq: 'daily',
+        priority: 0.9,
+      })
+
+      for (const product of products) {
+        entries.push({
+          loc: `${baseUrl}/s/${canonicalLocale}/${business}/producto/${product.slug}`,
+          lastmod: product.updatedAt.slice(0, 10),
+          changefreq: 'weekly',
+          priority: 0.6,
+        })
+      }
+    }
+  } catch (err) {
+    log.warn('sitemap.commerce_section_failed', {
+      business,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    // Keep whatever we already have in entries; don't fail the whole sitemap.
+  }
+
+  log.debug('sitemap.generated', { business, urlCount: entries.length })
+  return new NextResponse(renderSitemap(entries), {
+    headers: {
+      'Content-Type': 'application/xml',
+      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+    },
   })
 })


### PR DESCRIPTION
## Summary
Old \`/[business]/sitemap\` hardcoded a legacy page list (servicios/galeria/equipo/contacto) that matched no live tenant. fun4me PDPs + category landings were invisible to search engines.

Rewritten to:
- Iterate each locale × each page from \`static-sites\` config
- Commerce tenants: add \`/tienda\`, each \`/tienda/categoria/[cat]\`, and every active \`/producto/[slug]\` (cap 2000)
- One canonical locale for product/category URLs → avoids duplicate-content
- Per-URL \`lastmod\` from \`updated_at\`, priority home=1.0 / tienda=0.9 / pages=0.8 / category=0.7 / product=0.6
- Commerce section in try/catch → DB hiccup degrades gracefully
- \`Cache-Control: public, max-age=3600, s-maxage=86400\`

## Test plan
- [x] 24/24 tests pass
- [ ] Deploy → GET /fun4me/sitemap returns ~30+ URLs
- [ ] GET /granja-cabral/sitemap returns only marketing pages
- [ ] GET /nonexistent-slug/sitemap returns 404 empty urlset

🤖 Generated with [Claude Code](https://claude.com/claude-code)