### PR TITLE
feat(commerce): unified breadcrumbs + BreadcrumbList schema.org

### DIFF
--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -20,6 +20,7 @@ import { ReviewList } from '@/components/commerce/review-list'
 import { ReviewForm } from '@/components/commerce/review-form'
 import { ReviewStars } from '@/components/commerce/review-stars'
 import { PdpStickyMobileCta } from '@/components/commerce/pdp-sticky-mobile-cta'
+import { Breadcrumbs } from '@/components/commerce/breadcrumbs'
 import {
   listApprovedReviews,
   getReviewAggregatesByBusiness,
@@ -108,19 +109,17 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
 
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
 
-      <nav aria-label="Migas de pan" className="mx-auto max-w-5xl px-4 pt-4 text-sm text-[color:var(--text-muted,#6b7280)]">
-        <ol className="flex flex-wrap items-center gap-1.5">
-          <li>
-            <Link href={`/s/${locale}/${site}`} className="hover:underline">{business.name}</Link>
-          </li>
-          <li aria-hidden="true">/</li>
-          <li>
-            <Link href={`/s/${locale}/${site}/tienda`} className="hover:underline">Tienda</Link>
-          </li>
-          <li aria-hidden="true">/</li>
-          <li className="truncate text-[color:var(--text,#111)]" aria-current="page">{product.name}</li>
-        </ol>
-      </nav>
+      <Breadcrumbs
+        absoluteBaseUrl={env.APP_URL}
+        items={[
+          { label: business.name, href: `/s/${locale}/${site}` },
+          { label: 'Tienda', href: `/s/${locale}/${site}/tienda` },
+          ...(product.category
+            ? [{ label: product.category, href: `/s/${locale}/${site}/tienda/categoria/${encodeURIComponent(product.category)}` }]
+            : []),
+          { label: product.name },
+        ]}
+      />
 
       <main className="mx-auto grid max-w-5xl gap-8 px-4 py-8 md:grid-cols-2">
         <div>

--- a/web/app/s/[locale]/[site]/tienda/categoria/[category]/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/categoria/[category]/page.tsx
@@ -9,6 +9,8 @@ import {
 } from '@/lib/commerce/products'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
+import { Breadcrumbs } from '@/components/commerce/breadcrumbs'
+import { env } from '@/lib/env'
 import { ProductCard } from '@/components/commerce/product-card'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { TiendaToolbar } from '@/components/commerce/tienda-toolbar'
@@ -103,20 +105,16 @@ export default async function CategoryPage({
       <CartStoreHydrator siteSlug={site} initialCart={null} />
       <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
 
+      <Breadcrumbs
+        absoluteBaseUrl={env.APP_URL}
+        items={[
+          { label: business.name, href: `/s/${locale}/${site}` },
+          { label: 'Tienda', href: `/s/${locale}/${site}/tienda` },
+          { label: match },
+        ]}
+      />
+
       <main className="mx-auto max-w-6xl px-4 py-8">
-        <nav aria-label="Migas de pan" className="mb-4 text-sm text-[color:var(--text-muted,#6b7280)]">
-          <ol className="flex flex-wrap items-center gap-1.5">
-            <li>
-              <Link href={`/s/${locale}/${site}`} className="hover:underline">{business.name}</Link>
-            </li>
-            <li aria-hidden="true">/</li>
-            <li>
-              <Link href={`/s/${locale}/${site}/tienda`} className="hover:underline">Tienda</Link>
-            </li>
-            <li aria-hidden="true">/</li>
-            <li className="text-[color:var(--text,#111)] capitalize" aria-current="page">{match}</li>
-          </ol>
-        </nav>
 
         <div className="mb-6 rounded-lg bg-[color:var(--primary,#111)] p-6 text-[color:var(--primary-foreground,#fff)] sm:p-8">
           <h1 className="text-3xl font-bold capitalize">{match}</h1>

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -21,6 +21,8 @@ import { TiendaToolbar } from '@/components/commerce/tienda-toolbar'
 import { TiendaQuickFilters } from '@/components/commerce/tienda-quick-filters'
 import { TiendaPagination } from '@/components/commerce/tienda-pagination'
 import { RecentlyViewedRail } from '@/components/commerce/recently-viewed-rail'
+import { Breadcrumbs } from '@/components/commerce/breadcrumbs'
+import { env } from '@/lib/env'
 import { loadPygRates } from '@/lib/commerce/currency-server'
 
 export const runtime = 'nodejs'
@@ -183,6 +185,14 @@ export default async function StorePage({
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <CartStoreHydrator siteSlug={site} initialCart={null} />
       <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+
+      <Breadcrumbs
+        absoluteBaseUrl={env.APP_URL}
+        items={[
+          { label: business.name, href: `/s/${locale}/${site}` },
+          { label: 'Tienda' },
+        ]}
+      />
 
       <main className="mx-auto max-w-6xl px-4 py-8">
         <h1 className="mb-6 text-3xl font-bold text-[color:var(--text,#111)]">Nuestra tienda</h1>

--- a/web/components/commerce/breadcrumbs.tsx
+++ b/web/components/commerce/breadcrumbs.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link'
+
+export interface BreadcrumbItem {
+  label: string
+  /** Omit href on the terminal (current) item so it renders as plain text. */
+  href?: string
+}
+
+interface Props {
+  items: BreadcrumbItem[]
+  /** Base URL used to absolute-ize schema.org itemid values. Required for
+   * valid structured data — Google rejects relative breadcrumb URLs. */
+  absoluteBaseUrl?: string
+}
+
+/**
+ * Breadcrumb nav + matching BreadcrumbList JSON-LD. The visible crumbs
+ * and the schema entries share the same source so they can't drift.
+ *
+ * Renders nothing for 0- or 1-item trails (a breadcrumb of just the
+ * current page is noise).
+ */
+export function Breadcrumbs({ items, absoluteBaseUrl }: Props) {
+  if (items.length < 2) return null
+
+  const base = absoluteBaseUrl?.replace(/\/$/, '') ?? ''
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: item.label,
+      item: item.href ? `${base}${item.href}` : undefined,
+    })),
+  }
+
+  return (
+    <nav aria-label="Migas de pan" className="mx-auto mb-4 max-w-6xl px-4 pt-4 text-sm text-[color:var(--text-muted,#6b7280)]">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <ol className="flex flex-wrap items-center gap-1.5">
+        {items.map((item, i) => {
+          const isLast = i === items.length - 1
+          return (
+            <li key={`${i}-${item.label}`} className="flex items-center gap-1.5">
+              {i > 0 ? <span aria-hidden="true">/</span> : null}
+              {isLast || !item.href ? (
+                <span
+                  className="truncate text-[color:var(--text,#111)]"
+                  aria-current={isLast ? 'page' : undefined}
+                >
+                  {item.label}
+                </span>
+              ) : (
+                <Link href={item.href} className="hover:underline">
+                  {item.label}
+                </Link>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
Replaces ad-hoc inline breadcrumb \`<nav>\`s on /tienda, /producto/[slug], /tienda/categoria/[cat] with a single \`Breadcrumbs\` component that:

- Renders clean flex list with terminal marked \`aria-current\`
- Emits matching \`application/ld+json\` \`BreadcrumbList\` — absolute URLs so Google rich results pick them up
- Hides itself for 1-crumb trails
- Terminal item isn't a link

PDP trail now includes the product's category when set: Tienda → <category> → <product>

## Test plan
- [x] 139/139 tests pass
- [ ] Deploy → PDP shows 3-4 segment breadcrumb with working links
- [ ] Deploy → view-source shows BreadcrumbList JSON-LD
- [ ] Deploy → /tienda shows 2 segments; /categoria/X shows 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)