### PR TITLE
feat(analytics): GA4 purchase + begin_checkout trackers

### DIFF
--- a/web/app/s/[locale]/[site]/checkout/page.tsx
+++ b/web/app/s/[locale]/[site]/checkout/page.tsx
@@ -4,6 +4,7 @@ import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { CheckoutForm } from '@/components/commerce/checkout-form'
+import { CheckoutTracker } from '@/components/commerce/checkout-tracker'
 
 export const runtime = 'nodejs'
 
@@ -19,6 +20,7 @@ export default async function CheckoutPage({ params }: { params: Promise<{ site:
       <main className="mx-auto max-w-5xl px-4 py-8">
         <h1 className="mb-6 text-2xl font-bold">Finalizar compra</h1>
         <CheckoutForm siteSlug={site} locale={locale} />
+        <CheckoutTracker />
       </main>
     </div>
   )

--- a/web/app/s/[locale]/[site]/orden/[id]/page.tsx
+++ b/web/app/s/[locale]/[site]/orden/[id]/page.tsx
@@ -4,6 +4,7 @@ import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { getOrder, CheckoutError } from '@/lib/commerce/orders'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { OrderConfirmation } from '@/components/commerce/order-confirmation'
+import { PurchaseTracker } from '@/components/commerce/purchase-tracker'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -36,6 +37,7 @@ export default async function OrderPage({
         <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
       </div>
       <OrderConfirmation siteSlug={site} locale={locale} businessName={business.name} initialOrder={order} initialStatus={initial} />
+      <PurchaseTracker order={order} />
     </div>
   )
 }

--- a/web/components/commerce/checkout-tracker.tsx
+++ b/web/components/commerce/checkout-tracker.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useCartStore, cartSubtotalCents } from '@/lib/stores/cart-store'
+import { trackBeginCheckout } from '@/lib/analytics/commerce-events'
+
+/**
+ * Fires GA4 `begin_checkout` once per checkout-page mount with at least
+ * one cart item. Mounted in /checkout via the server page so the big
+ * CheckoutForm component doesn't need analytics concerns embedded.
+ */
+export function CheckoutTracker() {
+  const cart = useCartStore((s) => s.cart)
+  const fired = useRef(false)
+  useEffect(() => {
+    if (fired.current) return
+    const items = cart?.items ?? []
+    if (items.length === 0) return
+    fired.current = true
+    const currency = cart?.currency ?? 'PYG'
+    trackBeginCheckout(
+      items.map((it) => ({
+        itemId: it.productId,
+        itemName: it.productName ?? 'Producto',
+        price: it.unitPriceCents,
+        currency,
+        quantity: it.quantity,
+      })),
+      currency,
+      cartSubtotalCents(cart),
+    )
+  }, [cart])
+  return null
+}

--- a/web/components/commerce/purchase-tracker.tsx
+++ b/web/components/commerce/purchase-tracker.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import type { Order } from '@/lib/schemas/commerce/order'
+import { trackPurchase } from '@/lib/analytics/commerce-events'
+
+/**
+ * Fires GA4 `purchase` once when an order's status indicates successful
+ * completion. Separate from OrderConfirmation so the big stateful
+ * component doesn't need to carry analytics concerns + so this can be
+ * dropped onto any order-detail page consistently.
+ */
+export function PurchaseTracker({ order }: { order: Order }) {
+  const fired = useRef(false)
+  useEffect(() => {
+    if (fired.current) return
+    if (!['paid', 'fulfilled', 'shipped', 'delivered'].includes(order.status)) return
+    fired.current = true
+    trackPurchase({
+      transactionId: order.orderNumber,
+      currency: order.currency,
+      valueCents: order.totalCents,
+      taxCents: order.taxCents,
+      shippingCents: order.shippingCents,
+      items: (order.items ?? []).map((it) => ({
+        itemId: it.productId,
+        itemName: it.productSnapshot.name,
+        price: it.unitPriceCents,
+        currency: order.currency,
+        quantity: it.quantity,
+      })),
+    })
+  }, [order.status, order.orderNumber, order.currency, order.totalCents, order.taxCents, order.shippingCents, order.items])
+  return null
+}


### PR DESCRIPTION
## Summary
Closes the GA4 ecommerce funnel: view_item (#216) → add_to_cart (#216) → **begin_checkout** → **purchase**.

Kept as isolated client components mounted from server pages — the cart-drawer + order-confirmation files have been unstable (hot-reverted by background processes), so embedding trackers there would lose changes. These standalone trackers have a single import + mount point each and don't touch stateful components.

- \`PurchaseTracker\`: reads Order prop, fires once on status ∈ {paid/fulfilled/shipped/delivered}. Mounted on \`/orden/[id]\`.
- \`CheckoutTracker\`: reads cart store, fires once on mount when items present. Mounted on \`/checkout\`.

Both no-op without \`gtag\`. view_cart deferred — needs cart-drawer hook.

## Test plan
- [x] Zero TS errors
- [ ] Deploy → GA4 DebugView: begin_checkout fires on /checkout, purchase fires on /orden/[id] with real items array

🤖 Generated with [Claude Code](https://claude.com/claude-code)