### PR TITLE
fix(deploy): surface real docker build errors + auto-sync deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,19 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H 72.61.44.159 >> ~/.ssh/known_hosts
 
+      - name: Checkout (for deploy-vps.sh)
+        uses: actions/checkout@v4
+
+      - name: Sync deploy script to VPS
+        # Keeps the on-VPS deploy.sh in lockstep with scripts/deploy-vps.sh
+        # in the repo. Before this step every change to the script needed a
+        # manual scp; now CI does it.
+        run: |
+          scp -o StrictHostKeyChecking=yes scripts/deploy-vps.sh \
+            root@72.61.44.159:/opt/stacks/paragu-ai-builder/deploy.sh
+          ssh -o StrictHostKeyChecking=yes root@72.61.44.159 \
+            "chmod +x /opt/stacks/paragu-ai-builder/deploy.sh"
+
       - name: Deploy on VPS
         run: |
           ssh -o StrictHostKeyChecking=yes root@72.61.44.159 \

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -50,17 +50,21 @@ APP_URL="https://paragu-ai.com"
 # shellcheck disable=SC1090
 set -a; source "$SECRETS"; set +a
 
+# Note: full docker build output is logged. Previously we piped through
+# `| tail -5` which hid every actual TS/build error behind Docker's stage
+# summary. If your CI job's log becomes huge, add log rotation instead —
+# don't drop signal.
 docker build -f web/Dockerfile \
   --build-arg NEXT_PUBLIC_SUPABASE_URL="$NEXT_PUBLIC_SUPABASE_URL" \
   --build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY="$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
   --build-arg SUPABASE_SERVICE_ROLE_KEY="$SUPABASE_SERVICE_ROLE_KEY" \
   --build-arg NEXT_PUBLIC_APP_URL="$APP_URL" \
-  -t "$TAG" . 2>&1 | tail -5
+  -t "$TAG" .
 
 SERVICE="paragu-ai_web"
 [ "$ENV" = "staging" ] && SERVICE="paragu-ai-staging_web"
 
 # --force triggers a new task even when tag is reused (build digest differs)
-docker service update --with-registry-auth --force --image "$TAG" "$SERVICE" 2>&1 | tail -5
+docker service update --with-registry-auth --force --image "$TAG" "$SERVICE"
 
 echo "[deploy] done. service=$SERVICE tag=$TAG"


### PR DESCRIPTION
## The visibility problem
scripts/deploy-vps.sh piped \`docker build … | tail -5\` which collapsed every build error into "exit code 1" with zero context. Last 3 failed deploys (since PR #220 merged) show nothing useful in CI logs.

## Fix
- Remove \`| tail -5\` from docker build + docker service update — full output streams to CI
- deploy.yml now scp's scripts/deploy-vps.sh to the VPS before each run, then chmods +x. The on-VPS copy was drifting from the repo copy with no sync — now CI handles it

## What should happen after this merges
1. Next Main push triggers deploy
2. CI log shows the full docker build output
3. We see the actual failure cause

Likely suspects (narrow after seeing the real log):
- OOM on the 33k-line tenant-data.ts
- A PR #220 change that works locally but trips something in node:20-alpine
- Network flake on npm install

## Test plan
- [x] Local build works (verified: \`npm run build\` succeeds end-to-end)
- [ ] Deploy → CI log shows complete build output (not just tail 5)
- [ ] Real error visible → follow-up fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)