### PR TITLE
fix(whatsapp-float): guard undefined phone + normalize granja/fun4me content

### DIFF
--- a/sites/fun4me/content/es.json
+++ b/sites/fun4me/content/es.json
@@ -675,9 +675,9 @@
     "legalHref": "/fun4me/legal"
   },
   "whatsapp": {
-    "number": "595976569739",
     "message": "Hola! Quiero consultar sobre un producto.",
-    "label": "Chat con Fun4Me"
+    "label": "Chat con Fun4Me",
+    "phone": "595976569739"
   },
   "store": {
     "seo": {

--- a/sites/granja-cabral/content/es.json
+++ b/sites/granja-cabral/content/es.json
@@ -110,9 +110,18 @@
       "title": "Sobre Granja Cabral",
       "content": "Somos una granja familiar en Coronel Oviedo dedicada a la produccion local de huevos frescos. Nuestras gallinas son criadas en ambiente natural, con alimentacion balanceada y cuidado diario. Recolectamos los huevos todos los dias para garantizar maxima frescura.",
       "stats": [
-        { "value": "500+", "label": "Gallinas ponedoras" },
-        { "value": "100%", "label": "Produccion local" },
-        { "value": "Diario", "label": "Recoleccion fresca" }
+        {
+          "value": "500+",
+          "label": "Gallinas ponedoras"
+        },
+        {
+          "value": "100%",
+          "label": "Produccion local"
+        },
+        {
+          "value": "Diario",
+          "label": "Recoleccion fresca"
+        }
       ]
     },
     "team": {
@@ -185,11 +194,26 @@
           ]
         },
         "stats": [
-          { "value": "500+", "label": "Gallinas ponedoras" },
-          { "value": "100%", "label": "Produccion local" },
-          { "value": "Diario", "label": "Recoleccion fresca" },
-          { "value": "300+", "label": "Negocios atendidos" },
-          { "value": "4-5", "label": "Semanas de frescura" }
+          {
+            "value": "500+",
+            "label": "Gallinas ponedoras"
+          },
+          {
+            "value": "100%",
+            "label": "Produccion local"
+          },
+          {
+            "value": "Diario",
+            "label": "Recoleccion fresca"
+          },
+          {
+            "value": "300+",
+            "label": "Negocios atendidos"
+          },
+          {
+            "value": "4-5",
+            "label": "Semanas de frescura"
+          }
         ],
         "sustainability": {
           "composting": true,
@@ -208,10 +232,22 @@
           "delivery": "/sites/granja-cabral/images/trust/delivery.png"
         },
         "process": [
-          { "step": "Recolección diaria", "imageUrl": "/sites/granja-cabral/images/process/recoleccion.png" },
-          { "step": "Selección y control de calidad", "imageUrl": "/sites/granja-cabral/images/process/seleccion.png" },
-          { "step": "Empaque cuidadoso", "imageUrl": "/sites/granja-cabral/images/process/empaque.png" },
-          { "step": "Entrega puntual", "imageUrl": "/sites/granja-cabral/images/process/entrega.png" }
+          {
+            "step": "Recolección diaria",
+            "imageUrl": "/sites/granja-cabral/images/process/recoleccion.png"
+          },
+          {
+            "step": "Selección y control de calidad",
+            "imageUrl": "/sites/granja-cabral/images/process/seleccion.png"
+          },
+          {
+            "step": "Empaque cuidadoso",
+            "imageUrl": "/sites/granja-cabral/images/process/empaque.png"
+          },
+          {
+            "step": "Entrega puntual",
+            "imageUrl": "/sites/granja-cabral/images/process/entrega.png"
+          }
         ],
         "gallery": [
           "/sites/granja-cabral/images/gallery/coop.png",
@@ -231,9 +267,18 @@
         "city": "Coronel Oviedo",
         "heroImage": "/sites/granja-cabral/images/b2b/hero.png",
         "industries": [
-          { "name": "Panaderías", "imageUrl": "/sites/granja-cabral/images/b2b/panaderia.png" },
-          { "name": "Restaurantes", "imageUrl": "/sites/granja-cabral/images/b2b/restaurante.png" },
-          { "name": "Supermercados", "imageUrl": "/sites/granja-cabral/images/b2b/supermercado.png" }
+          {
+            "name": "Panaderías",
+            "imageUrl": "/sites/granja-cabral/images/b2b/panaderia.png"
+          },
+          {
+            "name": "Restaurantes",
+            "imageUrl": "/sites/granja-cabral/images/b2b/restaurante.png"
+          },
+          {
+            "name": "Supermercados",
+            "imageUrl": "/sites/granja-cabral/images/b2b/supermercado.png"
+          }
         ]
       }
     },
@@ -265,6 +310,7 @@
     "copyright": "© 2026 Granja Cabral"
   },
   "whatsapp": {
-    "defaultMessage": "Hola! Vi su pagina web y me interesa hacer un pedido de huevos. Me podes dar mas información?"
+    "phone": "+595981324569",
+    "message": "Hola! Vi su pagina web y me interesa hacer un pedido de huevos. Me podes dar mas información?"
   }
 }

--- a/web/components/sections/whatsapp-float.tsx
+++ b/web/components/sections/whatsapp-float.tsx
@@ -15,7 +15,12 @@ const WHATSAPP_DEFAULTS: Record<string, { message: string; ariaLabel: string }> 
 
 export function WhatsAppFloat({ phone, message, __locale }: WhatsAppFloatProps) {
   const L = WHATSAPP_DEFAULTS[__locale ?? 'es'] || WHATSAPP_DEFAULTS.es
+  // Defensive: some tenant content blocks historically shipped `number` /
+  // `defaultMessage` instead of `phone` — render nothing rather than
+  // crashing the whole page with a .replace-on-undefined.
+  if (!phone || typeof phone !== 'string') return null
   const cleanPhone = phone.replace(/\D/g, '')
+  if (!cleanPhone) return null
   const encodedMessage = encodeURIComponent(message || L.message)
 
   return (


### PR DESCRIPTION
## Bug
\`/granja-cabral\` 500s since launch. Local repro:
\`\`\`
TypeError: Cannot read properties of undefined (reading 'replace')
digest: '1415829488'
\`\`\`

\`WhatsAppFloat\` does \`phone.replace(/\D/g, '')\` unconditionally. Three tenants shipped three different content shapes:
| Tenant | Shape | Result |
|--------|-------|--------|
| nexa-paraguay | \`{ phone, message }\` | ✅ |
| fun4me | \`{ number, message, label }\` | 💥 wrong key |
| granja-cabral | \`{ defaultMessage }\` | 💥 no phone |

## Fix
1. \`WhatsAppFloat\`: return \`null\` when phone missing/empty
2. \`sites/granja-cabral/content/es.json\`: add \`whatsapp.phone\`, rename \`defaultMessage\` → \`message\`
3. \`sites/fun4me/content/es.json\`: rename \`whatsapp.number\` → \`whatsapp.phone\`

## Test plan
- [x] Local prod build: \`/granja-cabral\` 200, \`/fun4me\` 200, \`/nexa-paraguay\` 200
- [ ] Deploy → https://paragu-ai.com/granja-cabral returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)