### PR TITLE
fix: two 500s — gallery lightbox boundary + missing testimonial.author

### DIFF
--- a/web/components/sections/gallery-section.tsx
+++ b/web/components/sections/gallery-section.tsx
@@ -1,3 +1,11 @@
+'use client'
+
+// Turbopack strictly forbids functions crossing the server→client
+// boundary. The lightbox variant below uses a render-prop children
+// (`<ImageLightbox>{({open}) => ...}</ImageLightbox>`) — that pattern
+// is only valid when this parent is ALSO a client component. Making
+// the whole section client is the cheapest fix; the non-lightbox
+// branch renders plain img grids and has no interactive cost.
 import Image from 'next/image'
 import { Container } from '@/components/ui/container'
 import { Heading } from '@/components/ui/heading'

--- a/web/components/sections/testimonials-section.tsx
+++ b/web/components/sections/testimonials-section.tsx
@@ -63,7 +63,14 @@ export function TestimonialsSection({
   columns = 3,
   __locale,
 }: TestimonialsSectionProps) {
-  const resolved = testimonials || items || []
+  // Normalize: some tenant content files ship {name, role, quote} instead of
+  // {author, role, quote}. Accept either so a missing `author` doesn't crash
+  // the avatar fallback (`.charAt(0)` on undefined) — previously 500'd the
+  // whole page when any testimonial lacked an explicit `author`.
+  const resolved = (testimonials || items || []).map((t) => ({
+    ...t,
+    author: t.author || (t as unknown as { name?: string }).name || 'Cliente',
+  }))
   if (resolved.length === 0) return null
 
   const gridCols = columns === 2 ? 'md:grid-cols-2' : 'md:grid-cols-2 lg:grid-cols-3'


### PR DESCRIPTION
## Bugs found in cross-tenant audit

### \`/nexa-paraguay/sobre\` 500
\`GallerySection\` (server component) uses \`ImageLightbox\` with a render-prop children:
\`\`\`tsx
<ImageLightbox ...>{({ open }) => grid(...)}</ImageLightbox>
\`\`\`
\`ImageLightbox\` is \`'use client'\`. Turbopack forbids functions crossing server→client: "Event handlers cannot be passed to Client Component props". Added \`'use client'\` to \`gallery-section.tsx\`.

### \`/nexa-paraguay/casos-de-exito\` 500
\`TestimonialsSection\` does \`testimonial.author.charAt(0)\` but nexa's content ships \`{name, role, quote}\`. Normalized in resolved array: \`author = author || name || 'Cliente'\`. No content change needed.

## Test plan
- [x] Local build clean
- [ ] Deploy → \`/sobre\` + \`/casos-de-exito\` return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)