### PR TITLE
fix(middleware): narrow matcher so /<tenant>/sitemap.xml routes correctly

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -213,6 +213,13 @@ function pickBestLocale(acceptLanguage: string, enabled: readonly string[]): str
 
 export const config = {
   matcher: [
-    '/((?!api|_next/static|_next/image|favicon.ico|.*\\.[\\w]+$).*)',
+    // Run middleware for everything EXCEPT API / Next internals / favicons /
+    // static assets. We explicitly list static asset extensions (css, js,
+    // fonts, images) so that meaningful content paths like /<tenant>/
+    // sitemap.xml and /<tenant>/robots.txt still go through the flat-slug
+    // rewrite — without this, tenant sitemaps 500 because they fall to
+    // the legacy `[business]/[page]` route instead of the canonical
+    // `/s/<locale>/<site>/sitemap.xml` handler.
+    '/((?!api|_next/static|_next/image|favicon\\.ico|.*\\.(?:css|js|mjs|map|woff2?|ttf|eot|otf|svg|png|jpg|jpeg|gif|webp|avif|ico|mp4|webm)$).*)',
   ],
 }


### PR DESCRIPTION
Audit surfaced that \`/fun4me/sitemap.xml\` + \`/nexa-paraguay/sitemap.xml\` 500. Middleware matcher excluded ALL paths with file extensions (\`.*\\.[\\w]+$\`), so the flat-slug rewrite never fired and \`.xml\` fell through to the legacy \`[business]/[page]\` page route, which tried to render "sitemap.xml" as a page slug.

Fix: matcher now excludes only actual static-asset extensions (css, js, fonts, images, video). .xml / .json / .txt / .pdf now flow through middleware like any other path.

After merge:
- \`/fun4me/sitemap.xml\` → \`/s/es/fun4me/sitemap.xml\` → 200
- \`/nexa-paraguay/sitemap.xml\` → \`/s/nl/nexa-paraguay/sitemap.xml\` → 200
- Static assets still bypass middleware (explicit extension allowlist)

## Test plan
- [ ] Deploy → \`curl -sI https://paragu-ai.com/fun4me/sitemap.xml\` returns 200
- [ ] Deploy → \`curl -sI https://paragu-ai.com/nexa-paraguay/sitemap.xml\` returns 200
- [ ] Tenant pages still work (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)