### PR TITLE
fix(nexa-paraguay): remove dead /prensa nav + footer links

### DIFF
--- a/sites/nexa-paraguay/content/de.json
+++ b/sites/nexa-paraguay/content/de.json
@@ -48,10 +48,6 @@
         "href": "/s/de/nexa-paraguay/recursos"
       },
       {
-        "label": "Presse",
-        "href": "/s/de/nexa-paraguay/prensa"
-      },
-      {
         "label": "Kontakt",
         "href": "/s/de/nexa-paraguay/contacto"
       }
@@ -968,10 +964,6 @@
       {
         "label": "Warum Paraguay",
         "href": "/s/de/nexa-paraguay/por-que-paraguay"
-      },
-      {
-        "label": "Presse",
-        "href": "/s/de/nexa-paraguay/prensa"
       },
       {
         "label": "Lebensqualität",

--- a/sites/nexa-paraguay/content/en.json
+++ b/sites/nexa-paraguay/content/en.json
@@ -45,10 +45,6 @@
         "href": "/s/en/nexa-paraguay/recursos"
       },
       {
-        "label": "Press",
-        "href": "/s/en/nexa-paraguay/prensa"
-      },
-      {
         "label": "Contact",
         "href": "/s/en/nexa-paraguay/contacto"
       }
@@ -949,10 +945,6 @@
       {
         "label": "Why Paraguay",
         "href": "/s/en/nexa-paraguay/por-que-paraguay"
-      },
-      {
-        "label": "Press",
-        "href": "/s/en/nexa-paraguay/prensa"
       },
       {
         "label": "Quality of life",

--- a/sites/nexa-paraguay/content/es.json
+++ b/sites/nexa-paraguay/content/es.json
@@ -45,10 +45,6 @@
         "href": "/s/es/nexa-paraguay/recursos"
       },
       {
-        "label": "Prensa",
-        "href": "/s/es/nexa-paraguay/prensa"
-      },
-      {
         "label": "Contacto",
         "href": "/s/es/nexa-paraguay/contacto"
       }
@@ -965,10 +961,6 @@
       {
         "label": "Por qué Paraguay",
         "href": "/s/es/nexa-paraguay/por-que-paraguay"
-      },
-      {
-        "label": "Prensa",
-        "href": "/s/es/nexa-paraguay/prensa"
       },
       {
         "label": "Calidad de vida",

--- a/sites/nexa-paraguay/content/nl.json
+++ b/sites/nexa-paraguay/content/nl.json
@@ -45,10 +45,6 @@
         "href": "/s/nl/nexa-paraguay/recursos"
       },
       {
-        "label": "Pers",
-        "href": "/s/nl/nexa-paraguay/prensa"
-      },
-      {
         "label": "Contact",
         "href": "/s/nl/nexa-paraguay/contacto"
       }
@@ -965,10 +961,6 @@
       {
         "label": "Waarom Paraguay",
         "href": "/s/nl/nexa-paraguay/por-que-paraguay"
-      },
-      {
-        "label": "Pers",
-        "href": "/s/nl/nexa-paraguay/prensa"
       },
       {
         "label": "Levenskwaliteit",

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -20560,10 +20560,6 @@ export const CONTENT: Record<string, JsonRecord> = {
           "label": "Warum Paraguay"
         },
         {
-          "href": "/s/de/nexa-paraguay/prensa",
-          "label": "Presse"
-        },
-        {
           "href": "/s/de/nexa-paraguay/calidad-de-vida",
           "label": "Lebensqualität"
         },
@@ -21460,10 +21456,6 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/de/nexa-paraguay/recursos",
           "label": "Ressourcen"
-        },
-        {
-          "href": "/s/de/nexa-paraguay/prensa",
-          "label": "Presse"
         },
         {
           "href": "/s/de/nexa-paraguay/contacto",
@@ -22487,10 +22479,6 @@ export const CONTENT: Record<string, JsonRecord> = {
           "label": "Why Paraguay"
         },
         {
-          "href": "/s/en/nexa-paraguay/prensa",
-          "label": "Press"
-        },
-        {
           "href": "/s/en/nexa-paraguay/calidad-de-vida",
           "label": "Quality of life"
         },
@@ -23387,10 +23375,6 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/en/nexa-paraguay/recursos",
           "label": "Resources"
-        },
-        {
-          "href": "/s/en/nexa-paraguay/prensa",
-          "label": "Press"
         },
         {
           "href": "/s/en/nexa-paraguay/contacto",
@@ -24399,10 +24383,6 @@ export const CONTENT: Record<string, JsonRecord> = {
           "label": "Por qué Paraguay"
         },
         {
-          "href": "/s/es/nexa-paraguay/prensa",
-          "label": "Prensa"
-        },
-        {
           "href": "/s/es/nexa-paraguay/calidad-de-vida",
           "label": "Calidad de vida"
         },
@@ -25299,10 +25279,6 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/es/nexa-paraguay/recursos",
           "label": "Recursos"
-        },
-        {
-          "href": "/s/es/nexa-paraguay/prensa",
-          "label": "Prensa"
         },
         {
           "href": "/s/es/nexa-paraguay/contacto",
@@ -26325,10 +26301,6 @@ export const CONTENT: Record<string, JsonRecord> = {
           "label": "Waarom Paraguay"
         },
         {
-          "href": "/s/nl/nexa-paraguay/prensa",
-          "label": "Pers"
-        },
-        {
           "href": "/s/nl/nexa-paraguay/calidad-de-vida",
           "label": "Levenskwaliteit"
         },
@@ -27225,10 +27197,6 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/nl/nexa-paraguay/recursos",
           "label": "Bronnen"
-        },
-        {
-          "href": "/s/nl/nexa-paraguay/prensa",
-          "label": "Pers"
         },
         {
           "href": "/s/nl/nexa-paraguay/contacto",


### PR DESCRIPTION
## Summary
- `/prensa` page doesn't exist — clicking the nav link 404'd. Remove the entries across all 4 locales in header nav + footer until there's real press content to point to.
- Better silence than a coming-soon placeholder with no timeline.

## Scope
- `sites/nexa-paraguay/content/{es,en,nl,de}.json` — remove Prensa/Press/Pers/Presse from `navigation.navItems` and `footer.navLinks`
- `web/lib/engine/generated/tenant-data.ts` — regenerated

## Test plan
- [x] validate-sites clean
- [x] tsc --noEmit clean
- [ ] CI green (Lint, Build, Validate, Unit Tests, Secrets, Lighthouse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)