### PR TITLE
feat(fun4me+platform): enhanced-faq + PDP rich-results + commerce sitemap

### DIFF
--- a/sites/fun4me/content/es.json
+++ b/sites/fun4me/content/es.json
@@ -323,6 +323,97 @@
         }
       ]
     },
+    "enhancedFaq": {
+      "title": "Preguntas frecuentes",
+      "subtitle": "Buscá por palabra clave o filtrá por tema. Si no encontrás lo que buscás, escribinos por WhatsApp.",
+      "business": {
+        "name": "Fun4Me",
+        "whatsapp": "+595976569739",
+        "phone": "+595976569739"
+      },
+      "items": [
+        {
+          "question": "¿El envío es realmente discreto?",
+          "answer": "100% discreto. El paquete no tiene logos, nombres ni ninguna indicación del contenido. Nadie sabrá qué hay dentro excepto vos.",
+          "category": "Privacidad"
+        },
+        {
+          "question": "¿Qué aparece en mi estado de cuenta?",
+          "answer": "El cargo aparece como 'F4M COMERCIAL' — sin referencias explícitas al tipo de productos. Podés pedir también facturación a otro nombre comercial si lo preferís.",
+          "category": "Privacidad"
+        },
+        {
+          "question": "¿Pueden usar un nombre distinto al mío para el envío?",
+          "answer": "Sí. En el checkout podés ingresar cualquier nombre para el destinatario. Solo necesitamos un documento válido al momento de la entrega.",
+          "category": "Privacidad"
+        },
+        {
+          "question": "¿Qué formas de pago aceptan?",
+          "answer": "Tarjetas de crédito/débito (Visa, Mastercard), transferencia bancaria, billeteras electrónicas (Tigo Money, Personal Pay), y efectivo contra entrega en Asunción.",
+          "category": "Pagos"
+        },
+        {
+          "question": "¿Tienen envío gratis?",
+          "answer": "Sí, el envío es gratis en compras mayores a Gs. 200.000 a todo el país.",
+          "category": "Pagos"
+        },
+        {
+          "question": "¿Cuánto tarda el envío?",
+          "answer": "Asunción: 24-48 horas. Gran Asunción: 48-72 horas. Interior: 3-5 días hábiles. Envío express disponible con entrega el mismo día en Asunción (si pedís antes de las 15:00, Gs. 50.000 extra).",
+          "category": "Envío"
+        },
+        {
+          "question": "¿A qué ciudades envían?",
+          "answer": "Enviamos a todo Paraguay. Gran Asunción (Asunción, Fernando de la Mora, San Lorenzo, Lambaré, Luque) en 24-72 h. Interior vía encomienda rastreable. Consultá por WhatsApp para tiempos específicos.",
+          "category": "Envío"
+        },
+        {
+          "question": "¿Puedo retirar en la tienda física en vez de esperar envío?",
+          "answer": "Sí. Elegí 'retiro en tienda' en el checkout y te esperamos en Herrera 875, Asunción. Lunes a viernes 09:00-20:00, sábados 09:00-18:00.",
+          "category": "Envío"
+        },
+        {
+          "question": "¿Qué hago si nadie está cuando llegue el pedido?",
+          "answer": "El moto te avisa por WhatsApp antes de llegar. Si no podés recibirlo, coordinamos una segunda entrega sin costo o retiro en la tienda.",
+          "category": "Envío"
+        },
+        {
+          "question": "¿Puedo devolver un producto?",
+          "answer": "Por razones de higiene, no aceptamos devoluciones de productos íntimos una vez abiertos. Si el producto llega defectuoso o dañado, lo reemplazamos sin costo. Lencería sin usar con etiquetas puede devolverse en 7 días.",
+          "category": "Garantía"
+        },
+        {
+          "question": "¿Los productos tienen garantía?",
+          "answer": "Los productos electrónicos tienen garantía según el fabricante. Satisfyer: 15 años. LELO: 1 año. We-Vibe: 2 años. Para hacer efectiva la garantía, contactanos por WhatsApp con el número de pedido.",
+          "category": "Garantía"
+        },
+        {
+          "question": "¿Los productos son seguros?",
+          "answer": "Trabajamos con productos de marcas reconocidas. Todos nuestros vibradores son de silicona médica, ABS libre de ftalatos, o materiales seguros para el cuerpo certificados por los fabricantes.",
+          "category": "Productos"
+        },
+        {
+          "question": "¿Qué es el lubricante ideal para juguetes de silicona?",
+          "answer": "Lubricante a base de agua. Los lubricantes a base de silicona reaccionan con los juguetes de silicona y los dañan. Tenemos ambos tipos; al agregar al carrito te sugerimos el compatible.",
+          "category": "Productos"
+        },
+        {
+          "question": "¿Cómo limpio mis juguetes?",
+          "answer": "Agua tibia + jabón neutro o limpiador específico para juguetes (disponible en la tienda). Secar al aire. Tenemos una guía completa en el blog: 'Cómo limpiar juguetes sexuales'.",
+          "category": "Productos"
+        },
+        {
+          "question": "¿Puedo visitar la tienda física?",
+          "answer": "¡Claro! Te esperamos en Herrera 875, Asunción. Lunes a viernes de 09:00 a 20:00 y sábados de 09:00 a 18:00. Asesoría discreta y sin compromiso.",
+          "category": "Tienda física"
+        },
+        {
+          "question": "¿Necesito presentar documento al entrar a la tienda?",
+          "answer": "Sí. Como toda tienda del rubro, verificamos que seas mayor de 18 años al entrar. Aceptamos cédula paraguaya o pasaporte vigente.",
+          "category": "Tienda física"
+        }
+      ]
+    },
     "cta": {
       "title": "Tenes alguna consulta?",
       "subtitle": "Escribinos por WhatsApp y te asesoramos sin compromiso.",

--- a/sites/fun4me/pages/home.json
+++ b/sites/fun4me/pages/home.json
@@ -59,9 +59,9 @@
       "content": "home.partners"
     },
     {
-      "id": "faq",
-      "variant": "accordion",
-      "content": "home.faq"
+      "id": "enhanced-faq",
+      "variant": "searchable",
+      "content": "home.enhancedFaq"
     },
     {
       "id": "newsletter-signup",

--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -100,22 +100,33 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
   ])
   const aggregate = aggregates[product.id]
 
+  const productUrl = `${env.APP_URL}/s/${locale}/${site}/producto/${product.slug}`
+  // All product images, not just the cover — Google Rich Results card can
+  // pull up to 3 and prefers multiple images when present.
+  const imageList = product.images
+    .map((i) => i.url)
+    .filter((u): u is string => typeof u === 'string' && u.length > 0)
   const structuredData = {
     '@context': 'https://schema.org',
     '@type': 'Product',
     name: product.name,
     description: product.description ?? undefined,
-    image: cover?.url,
+    image: imageList.length > 0 ? imageList : cover?.url,
     sku: product.sku ?? undefined,
+    mpn: product.sku ?? undefined,
+    url: productUrl,
     brand: product.brand ? { '@type': 'Brand', name: product.brand } : undefined,
     offers: {
       '@type': 'Offer',
+      url: productUrl,
       price: (product.priceCents / 100).toFixed(2),
       priceCurrency: product.currency,
+      itemCondition: 'https://schema.org/NewCondition',
       availability:
         product.inventoryPolicy === 'deny' && product.inventoryQty === 0
           ? 'https://schema.org/OutOfStock'
           : 'https://schema.org/InStock',
+      seller: { '@type': 'Organization', name: business.name },
     },
     aggregateRating: aggregate && aggregate.count > 0
       ? {

--- a/web/app/s/[locale]/[site]/sitemap.xml/route.ts
+++ b/web/app/s/[locale]/[site]/sitemap.xml/route.ts
@@ -3,8 +3,17 @@ import { loadSite, listPageSlugs, loadPage } from '@/lib/engine/site-loader'
 import { listBlogSlugs } from '@/lib/engine/blog-loader'
 import { buildLocaleUrl, type Locale } from '@/lib/i18n/routing'
 import { isLocale } from '@/lib/i18n/config'
+import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
+import { isCommerceEnabled } from '@/lib/commerce/capability'
+import { listActiveProducts, listDistinctCategories } from '@/lib/commerce/products'
+import { logger } from '@/lib/logger'
 
 export const runtime = 'nodejs'
+
+// Include at most this many PDPs per tenant to keep the sitemap under
+// Google's 50k-URL / 50MB limits on very large catalogs. We'll paginate
+// with sitemap-index files if any tenant ever crosses this.
+const MAX_PDP_URLS = 5000
 
 export async function GET(
   _req: Request,
@@ -64,6 +73,49 @@ export async function GET(
     urls.push({
       loc: `${base}${buildLocaleUrl(locale as Locale, slug, pathPart)}`,
       alternates,
+    })
+  }
+
+  // Commerce URLs — product detail pages + category index pages, included
+  // only for tenants with commerce enabled. A catalog of real products is
+  // the single highest-impact sitemap addition for a commerce tenant.
+  try {
+    const business = await resolveBusinessBySlug(slug)
+    if (business && (await isCommerceEnabled(business.type))) {
+      const [products, categories] = await Promise.all([
+        listActiveProducts(business.id, { limit: MAX_PDP_URLS, sort: 'newest' }),
+        listDistinctCategories(business.id),
+      ])
+      for (const category of categories) {
+        const pathPart = `tienda/categoria/${encodeURIComponent(category)}`
+        const alternates = site.locales.map((l) => ({
+          hreflang: l,
+          href: `${base}${buildLocaleUrl(l, slug, pathPart)}`,
+        }))
+        urls.push({
+          loc: `${base}${buildLocaleUrl(locale as Locale, slug, pathPart)}`,
+          alternates,
+        })
+      }
+      for (const product of products) {
+        const pathPart = `producto/${product.slug}`
+        const alternates = site.locales.map((l) => ({
+          hreflang: l,
+          href: `${base}${buildLocaleUrl(l, slug, pathPart)}`,
+        }))
+        urls.push({
+          loc: `${base}${buildLocaleUrl(locale as Locale, slug, pathPart)}`,
+          alternates,
+        })
+      }
+    }
+  } catch (err) {
+    // A commerce query failure shouldn't 500 the whole sitemap — core
+    // tenant pages still render; Google will retry later. Log so we see it.
+    logger.warn('[sitemap] commerce URLs skipped', {
+      action: 'sitemap.commerce_skip',
+      slug,
+      error: err instanceof Error ? err.message : String(err),
     })
   }
 


### PR DESCRIPTION
## Summary

Three high-ROI shipments bundled — all unblocked by prior platform work:

1. **fun4me enhanced-faq** — home FAQ swapped from legacy accordion to searchable/categorized. 16 Q/A pairs (was 9) across 6 categories: Privacidad, Pagos, Envío, Garantía, Productos, Tienda física. Legacy \`home.faq\` ref kept for pages that still use it (subscriptions, gift-cards).
2. **PDP Schema.org hardening** — added \`url\`, \`offers.url\`, \`itemCondition\`, \`seller\`, \`mpn\`, and full image list to the Product JSON-LD on \`/producto/[slug]\`. Aligns with Google Shopping / Product rich-results requirements.
3. **Dynamic per-tenant sitemap** — \`/s/[locale]/[site]/sitemap.xml\` now includes \`/producto/<slug>\` (up to 5k) and \`/tienda/categoria/<slug>\` for any commerce-enabled tenant. Soft-fails — a commerce query error logs a warning but core tenant URLs still render.

## Test plan
- [ ] Typecheck green (\`npx tsc --noEmit -p web/tsconfig.json\`)
- [ ] SEO + compose unit tests pass
- [ ] \`/fun4me\` home renders the new FAQ with search + category pills
- [ ] \`/fun4me/producto/<slug>\` — Google Rich Results Test passes for Product structured data
- [ ] \`/s/es/fun4me/sitemap.xml\` — inspect response, confirm product PDPs and categories listed
- [ ] Non-commerce tenants (nexa, granja) still render sitemap unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)