### PR TITLE
fix(renderer): wire FeaturesSection into COMPONENTS map — /recursos empty bug

### DIFF
--- a/web/lib/engine/site-renderer.tsx
+++ b/web/lib/engine/site-renderer.tsx
@@ -48,6 +48,7 @@ import { B2BWholesaleSection } from '@/components/sections/b2b-wholesale-section
 import { RecipeSection } from '@/components/sections/recipe-section'
 import { TaxSavingsCalculatorSection } from '@/components/sections/tax-savings-calculator-section'
 import { IntakeWizardSection } from '@/components/sections/intake-wizard-section'
+import { FeaturesSection } from '@/components/sections/features-section'
 import { ComplianceDisclaimerFooterSection } from '@/components/sections/compliance-disclaimer-footer-section'
 import { PromoBannerSection } from '@/components/sections/promo-banner-section'
 import { NewsletterSignupSection } from '@/components/sections/newsletter-signup-section'
@@ -97,6 +98,7 @@ const COMPONENTS: Record<string, React.ComponentType<any>> = {
   'newsletter-signup': NewsletterSignupSection,
   'tax-savings-calculator': TaxSavingsCalculatorSection,
   'intake-wizard': IntakeWizardSection,
+  features: FeaturesSection,
 }
 
 export function renderPage(page: ResolvedPage): React.ReactNode {


### PR DESCRIPTION
Same bug class as #245. FeaturesSection exists, registry knows it, nexa /recursos references it with `features` id → COMPONENTS map had no entry → section silently skipped. /recursos rendered hero + newsletter only; the 3 guide cards defined in content never showed.

Fix: import + register `features: FeaturesSection`.

Audit sidebar: 14 other registered section IDs still unwired in COMPONENTS — most are alias targets or unused, but worth a platform-level sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)