### PR TITLE
feat(nexa): expose /benelux in footer nav

### DIFF
--- a/sites/nexa-paraguay/content/de.json
+++ b/sites/nexa-paraguay/content/de.json
@@ -1047,6 +1047,10 @@
         "href": "/s/de/nexa-paraguay/por-que-paraguay"
       },
       {
+        "label": "Benelux Desk",
+        "href": "/s/de/nexa-paraguay/benelux"
+      },
+      {
         "label": "Lebensqualität",
         "href": "/s/de/nexa-paraguay/calidad-de-vida"
       },

--- a/sites/nexa-paraguay/content/en.json
+++ b/sites/nexa-paraguay/content/en.json
@@ -1028,6 +1028,10 @@
         "href": "/s/en/nexa-paraguay/por-que-paraguay"
       },
       {
+        "label": "Benelux desk",
+        "href": "/s/en/nexa-paraguay/benelux"
+      },
+      {
         "label": "Quality of life",
         "href": "/s/en/nexa-paraguay/calidad-de-vida"
       },

--- a/sites/nexa-paraguay/content/es.json
+++ b/sites/nexa-paraguay/content/es.json
@@ -1044,6 +1044,10 @@
         "href": "/s/es/nexa-paraguay/por-que-paraguay"
       },
       {
+        "label": "Benelux desk",
+        "href": "/s/es/nexa-paraguay/benelux"
+      },
+      {
         "label": "Calidad de vida",
         "href": "/s/es/nexa-paraguay/calidad-de-vida"
       },

--- a/sites/nexa-paraguay/content/nl.json
+++ b/sites/nexa-paraguay/content/nl.json
@@ -1044,6 +1044,10 @@
         "href": "/s/nl/nexa-paraguay/por-que-paraguay"
       },
       {
+        "label": "Benelux desk",
+        "href": "/s/nl/nexa-paraguay/benelux"
+      },
+      {
         "label": "Levenskwaliteit",
         "href": "/s/nl/nexa-paraguay/calidad-de-vida"
       },

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -20788,6 +20788,10 @@ export const CONTENT: Record<string, JsonRecord> = {
           "label": "Warum Paraguay"
         },
         {
+          "href": "/s/de/nexa-paraguay/benelux",
+          "label": "Benelux Desk"
+        },
+        {
           "href": "/s/de/nexa-paraguay/calidad-de-vida",
           "label": "Lebensqualität"
         },
@@ -22867,6 +22871,10 @@ export const CONTENT: Record<string, JsonRecord> = {
           "label": "Why Paraguay"
         },
         {
+          "href": "/s/en/nexa-paraguay/benelux",
+          "label": "Benelux desk"
+        },
+        {
           "href": "/s/en/nexa-paraguay/calidad-de-vida",
           "label": "Quality of life"
         },
@@ -24929,6 +24937,10 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/es/nexa-paraguay/por-que-paraguay",
           "label": "Por qué Paraguay"
+        },
+        {
+          "href": "/s/es/nexa-paraguay/benelux",
+          "label": "Benelux desk"
         },
         {
           "href": "/s/es/nexa-paraguay/calidad-de-vida",
@@ -27007,6 +27019,10 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/nl/nexa-paraguay/por-que-paraguay",
           "label": "Waarom Paraguay"
+        },
+        {
+          "href": "/s/nl/nexa-paraguay/benelux",
+          "label": "Benelux desk"
         },
         {
           "href": "/s/nl/nexa-paraguay/calidad-de-vida",


### PR DESCRIPTION
Follow-up to #246. Benelux page shipped but was undiscoverable — no nav link. Added to footer.navLinks after 'Why Paraguay' in all 4 locales. Kept out of main nav (already 9 items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)