### PR TITLE
fix(nexa-paraguay): restore /prensa nav links — page actually exists

### DIFF
--- a/sites/nexa-paraguay/content/de.json
+++ b/sites/nexa-paraguay/content/de.json
@@ -48,6 +48,10 @@
         "href": "/s/de/nexa-paraguay/recursos"
       },
       {
+        "label": "Presse",
+        "href": "/s/de/nexa-paraguay/prensa"
+      },
+      {
         "label": "Kontakt",
         "href": "/s/de/nexa-paraguay/contacto"
       }
@@ -1061,6 +1065,10 @@
       {
         "label": "Ressourcen",
         "href": "/s/de/nexa-paraguay/recursos"
+      },
+      {
+        "label": "Presse",
+        "href": "/s/de/nexa-paraguay/prensa"
       }
     ]
   },

--- a/sites/nexa-paraguay/content/en.json
+++ b/sites/nexa-paraguay/content/en.json
@@ -45,6 +45,10 @@
         "href": "/s/en/nexa-paraguay/recursos"
       },
       {
+        "label": "Press",
+        "href": "/s/en/nexa-paraguay/prensa"
+      },
+      {
         "label": "Contact",
         "href": "/s/en/nexa-paraguay/contacto"
       }
@@ -1042,6 +1046,10 @@
       {
         "label": "Resources",
         "href": "/s/en/nexa-paraguay/recursos"
+      },
+      {
+        "label": "Press",
+        "href": "/s/en/nexa-paraguay/prensa"
       }
     ]
   },

--- a/sites/nexa-paraguay/content/es.json
+++ b/sites/nexa-paraguay/content/es.json
@@ -45,6 +45,10 @@
         "href": "/s/es/nexa-paraguay/recursos"
       },
       {
+        "label": "Prensa",
+        "href": "/s/es/nexa-paraguay/prensa"
+      },
+      {
         "label": "Contacto",
         "href": "/s/es/nexa-paraguay/contacto"
       }
@@ -1058,6 +1062,10 @@
       {
         "label": "Recursos",
         "href": "/s/es/nexa-paraguay/recursos"
+      },
+      {
+        "label": "Prensa",
+        "href": "/s/es/nexa-paraguay/prensa"
       }
     ]
   },

--- a/sites/nexa-paraguay/content/nl.json
+++ b/sites/nexa-paraguay/content/nl.json
@@ -45,6 +45,10 @@
         "href": "/s/nl/nexa-paraguay/recursos"
       },
       {
+        "label": "Pers",
+        "href": "/s/nl/nexa-paraguay/prensa"
+      },
+      {
         "label": "Contact",
         "href": "/s/nl/nexa-paraguay/contacto"
       }
@@ -1058,6 +1062,10 @@
       {
         "label": "Bronnen",
         "href": "/s/nl/nexa-paraguay/recursos"
+      },
+      {
+        "label": "Pers",
+        "href": "/s/nl/nexa-paraguay/prensa"
       }
     ]
   },

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -20802,6 +20802,10 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/de/nexa-paraguay/recursos",
           "label": "Ressourcen"
+        },
+        {
+          "href": "/s/de/nexa-paraguay/prensa",
+          "label": "Presse"
         }
       ],
       "whatsapp": "595982515138"
@@ -21713,6 +21717,10 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/de/nexa-paraguay/recursos",
           "label": "Ressourcen"
+        },
+        {
+          "href": "/s/de/nexa-paraguay/prensa",
+          "label": "Presse"
         },
         {
           "href": "/s/de/nexa-paraguay/contacto",
@@ -22885,6 +22893,10 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/en/nexa-paraguay/recursos",
           "label": "Resources"
+        },
+        {
+          "href": "/s/en/nexa-paraguay/prensa",
+          "label": "Press"
         }
       ],
       "whatsapp": "595982515138"
@@ -23796,6 +23808,10 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/en/nexa-paraguay/recursos",
           "label": "Resources"
+        },
+        {
+          "href": "/s/en/nexa-paraguay/prensa",
+          "label": "Press"
         },
         {
           "href": "/s/en/nexa-paraguay/contacto",
@@ -24953,6 +24969,10 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/es/nexa-paraguay/recursos",
           "label": "Recursos"
+        },
+        {
+          "href": "/s/es/nexa-paraguay/prensa",
+          "label": "Prensa"
         }
       ],
       "whatsapp": "595982515138"
@@ -25864,6 +25884,10 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/es/nexa-paraguay/recursos",
           "label": "Recursos"
+        },
+        {
+          "href": "/s/es/nexa-paraguay/prensa",
+          "label": "Prensa"
         },
         {
           "href": "/s/es/nexa-paraguay/contacto",
@@ -27035,6 +27059,10 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/nl/nexa-paraguay/recursos",
           "label": "Bronnen"
+        },
+        {
+          "href": "/s/nl/nexa-paraguay/prensa",
+          "label": "Pers"
         }
       ],
       "whatsapp": "595982515138"
@@ -27946,6 +27974,10 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/nl/nexa-paraguay/recursos",
           "label": "Bronnen"
+        },
+        {
+          "href": "/s/nl/nexa-paraguay/prensa",
+          "label": "Pers"
         },
         {
           "href": "/s/nl/nexa-paraguay/contacto",


### PR DESCRIPTION
## Summary
Reverts the nav removals from #233. I was wrong: `/prensa` IS a real page, I just looked in the wrong place.

- #233 checked `sites/nexa-paraguay/pages/prensa.json` (missing → concluded "page doesn't exist")
- But `/prensa` is a **hardcoded Next.js app-router route** at `web/app/s/[locale]/[site]/prensa/page.tsx` that serves a press-kit with brand + press assets from the tenant images manifest
- So the nav links weren't dead — they went to a real page with real content (all the `brand.*` image entries in `sites/nexa-paraguay/images.json`)

## Scope
- Content JSONs (4 locales): Prensa/Press/Pers/Presse added back to header nav (before Contacto) and footer navLinks
- Regenerated tenant-data.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)