### PR TITLE
perf(hero): fetchpriority=high on hero background image

### DIFF
--- a/web/components/sections/hero-section.tsx
+++ b/web/components/sections/hero-section.tsx
@@ -171,6 +171,7 @@ export function HeroSection({
             alt=""
             className="h-full w-full object-cover"
             loading="eager"
+            fetchPriority="high"
             decoding="async"
           />
         </picture>


### PR DESCRIPTION
## Summary
Lighthouse LCP was failing the 2500ms budget on all 3 test URLs now that the CI check actually runs (#241/#242).

The hero `<picture>/<img>` was already `loading="eager"` but missing `fetchpriority="high"`. Without it, modern browsers don't prioritize the hero over later-discovered resources (Playfair Display, Inter, section JS) in the waterfall.

## Change
One-line: add `fetchPriority="high"` to the eager `<img>` in hero-section.

## Expected impact
- LCP improvement of **300–700ms** on typical 4G profiles
- Should get all 3 URLs back under the 2500ms budget
- Measurable in the Lighthouse run on this PR

## Followups (not this PR)
- SEO < 0.9 on 2 URLs is a separate issue — likely missing `<meta name="description">` on some pages or `<title>` uniqueness
- Fonts still render-block via `<link rel="stylesheet" href={googleFontsUrl}>` — moving to `next/font/google` is a bigger refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)