### PR TITLE
test(engine): guard renderer wiring to prevent silent-skip bug class

### DIFF
--- a/web/lib/engine/site-renderer.tsx
+++ b/web/lib/engine/site-renderer.tsx
@@ -56,8 +56,15 @@ import { ComplianceDisclaimerFooterSection } from '@/components/sections/complia
 import { PromoBannerSection } from '@/components/sections/promo-banner-section'
 import { NewsletterSignupSection } from '@/components/sections/newsletter-signup-section'
 
+// Exported so tests (and any future tooling) can assert that every
+// registered section in section-registry has a matching render binding.
+// See tests/unit/engine/renderer-wiring.test.ts — silent-skip bugs of
+// the class "component exists, registry knows it, page config references
+// it, but the COMPONENTS map has no entry → renderPage warns and moves
+// on" hit us four separate times before this guard landed (PRs #245,
+// #247, #248). The test makes the whole class impossible.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const COMPONENTS: Record<string, React.ComponentType<any>> = {
+export const COMPONENTS: Record<string, React.ComponentType<any>> = {
   header: HeaderSection,
   hero: HeroSection,
   services: ServicesSection,

--- a/web/tests/unit/engine/renderer-wiring.test.ts
+++ b/web/tests/unit/engine/renderer-wiring.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { SECTION_CATALOG } from '@/lib/engine/section-registry'
+import { COMPONENTS } from '@/lib/engine/site-renderer'
+
+// Guard against the silent-skip bug class that recurred four times:
+// - #245 tax-savings-calculator wasn't in COMPONENTS → home rendered empty band
+// - #247 FeaturesSection wasn't in COMPONENTS   → /recursos empty
+// - #248 intake-questionnaire, process, menu-categorized-priced missing
+//
+// Every section-registry entry that live content references MUST have a
+// COMPONENTS map binding. Without that, renderPage() silently drops the
+// section and only logs a warning — visually broken pages ship.
+
+// Sections the platform exposes but that no live tenant uses yet. When
+// they get wired up (or a tenant starts using one), remove from this set
+// and the wiring must exist. Keep this list short and reviewed — it's
+// the opt-out escape hatch for genuinely un-shipped features.
+const INTENTIONALLY_UNWIRED = new Set<string>([
+  'conveyor-belt',
+  'delivery-slot-picker',
+  'mortgage-calculator',
+  'omakase',
+  'pricing',
+  'property-listings',
+  'regulatory-status-badge',
+  'sake-menu',
+  'sample-week-preview',
+  'savings-calculator',
+  'tiered-service-ladder',
+  'weekly-cadence-calendar',
+])
+
+describe('renderer wiring', () => {
+  it('every registered section (minus intentionally unwired) has a COMPONENTS binding', () => {
+    const registered = new Set(Object.keys(SECTION_CATALOG))
+    const wired = new Set(Object.keys(COMPONENTS))
+
+    const missing: string[] = []
+    for (const id of registered) {
+      if (INTENTIONALLY_UNWIRED.has(id)) continue
+      if (!wired.has(id)) missing.push(id)
+    }
+
+    expect(
+      missing,
+      `Section(s) registered in section-registry.ts but missing from COMPONENTS in site-renderer.tsx:\n` +
+        missing.map((m) => `  - ${m}`).join('\n') +
+        `\n\nEither add to the COMPONENTS map, or add to INTENTIONALLY_UNWIRED in this test ` +
+        `if the section is a platform-level placeholder no tenant uses yet.`,
+    ).toEqual([])
+  })
+
+  it('every COMPONENTS key exists in SECTION_CATALOG', () => {
+    const registered = new Set(Object.keys(SECTION_CATALOG))
+    const orphans = Object.keys(COMPONENTS).filter((k) => !registered.has(k))
+    expect(
+      orphans,
+      `COMPONENTS key(s) not registered in section-registry:\n` +
+        orphans.map((o) => `  - ${o}`).join('\n'),
+    ).toEqual([])
+  })
+
+  it('INTENTIONALLY_UNWIRED ids all actually exist in SECTION_CATALOG', () => {
+    // Stops this list from silently aging out of sync with the registry.
+    const registered = new Set(Object.keys(SECTION_CATALOG))
+    const stale = [...INTENTIONALLY_UNWIRED].filter((id) => !registered.has(id))
+    expect(
+      stale,
+      `INTENTIONALLY_UNWIRED contains id(s) no longer in SECTION_CATALOG:\n` +
+        stale.map((s) => `  - ${s}`).join('\n') +
+        `\nRemove these from INTENTIONALLY_UNWIRED.`,
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## Why
This exact bug class hit us four times this week:
- **#245** tax-savings-calculator missing from COMPONENTS → home had an unexplained empty white band for an unknown amount of time
- **#247** FeaturesSection missing → /recursos rendered hero + newsletter only, silently swallowing 3 guide cards
- **#248** intake-questionnaire / process / menu-categorized-priced all missing, breaking nexa /privacidad and 4 starter-kit verticals

Same pattern every time: component file exists, registry knows it, page config references it, but the `COMPONENTS` map in `site-renderer.tsx` has no binding. `renderPage()` logs a warning and ships a visually-broken page.

## What
Three tests in `tests/unit/engine/renderer-wiring.test.ts`:

1. Every `SECTION_CATALOG` entry (minus an explicit `INTENTIONALLY_UNWIRED` set) MUST have a `COMPONENTS` binding.
2. Every `COMPONENTS` key MUST exist in `SECTION_CATALOG` — catches typos + accidentally-added orphan keys.
3. `INTENTIONALLY_UNWIRED` itself must only contain real registry IDs — stops the opt-out list from aging out of sync.

`COMPONENTS` is now exported from `site-renderer` for test access.

## Opt-out escape hatch
The 12-entry `INTENTIONALLY_UNWIRED` set in the test covers platform-level placeholder sections (conveyor-belt, mortgage-calculator, sake-menu, tiered-service-ladder, etc.) that no live tenant uses yet. To ship one: either wire it, or remove from the set and wire it. Either way the test enforces symmetry.

## Test plan
- [x] 3 new tests pass
- [x] Existing 24 engine tests still pass
- [x] typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)