### PR TITLE
fix(checkout): empty cart on /checkout even when drawer has items

### DIFF
--- a/web/app/s/[locale]/[site]/carrito/page.tsx
+++ b/web/app/s/[locale]/[site]/carrito/page.tsx
@@ -5,17 +5,29 @@ import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { CartPageClient } from '@/components/commerce/cart-page-client'
+import { getSessionToken } from '@/lib/commerce/session'
+import { getCartBySessionToken } from '@/lib/commerce/cart'
 
 export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic' // depends on the session cookie
 
 export default async function CartPage({ params }: { params: Promise<{ site: string; locale: string }> }) {
   const { site, locale } = await params
   const business = await resolveBusinessBySlug(site)
   if (!business || !(await isCommerceEnabled(business.type))) notFound()
 
+  // Server-load the current shopper's cart so SSR renders the items
+  // directly. The relaxed hydrator (see PR #256 cart-store.ts change)
+  // also protects against the null-wipe case, but loading here means
+  // no flash of empty, and no dependence on client-side persist.
+  const sessionToken = await getSessionToken()
+  const initialCart = sessionToken
+    ? await getCartBySessionToken(business.id, sessionToken).catch(() => null)
+    : null
+
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
-      <CartStoreHydrator siteSlug={site} initialCart={null} />
+      <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
       <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
       <main className="mx-auto max-w-4xl px-4 py-8">
         <h1 className="mb-6 text-2xl font-bold">Tu carrito</h1>

--- a/web/app/s/[locale]/[site]/checkout/page.tsx
+++ b/web/app/s/[locale]/[site]/checkout/page.tsx
@@ -5,17 +5,31 @@ import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { CheckoutForm } from '@/components/commerce/checkout-form'
 import { CheckoutTracker } from '@/components/commerce/checkout-tracker'
+import { getSessionToken } from '@/lib/commerce/session'
+import { getCartBySessionToken } from '@/lib/commerce/cart'
 
 export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic' // depends on the session cookie
 
 export default async function CheckoutPage({ params }: { params: Promise<{ site: string; locale: string }> }) {
   const { site, locale } = await params
   const business = await resolveBusinessBySlug(site)
   if (!business || !(await isCommerceEnabled(business.type))) notFound()
 
+  // Server-load the shopper's cart so the rendered form + hydrator agree
+  // with the drawer. Passing `initialCart={null}` wipes the persisted
+  // zustand cart on mount — which is how the "cart has items but
+  // checkout says empty" regression happened. getSessionToken does not
+  // create a new cookie; if there is no session yet, the cart is null
+  // (which is correct — there's nothing to check out).
+  const sessionToken = await getSessionToken()
+  const initialCart = sessionToken
+    ? await getCartBySessionToken(business.id, sessionToken).catch(() => null)
+    : null
+
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
-      <CartStoreHydrator siteSlug={site} initialCart={null} />
+      <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
       <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
       <main className="mx-auto max-w-5xl px-4 py-8">
         <h1 className="mb-6 text-2xl font-bold">Finalizar compra</h1>

--- a/web/lib/commerce/cart.ts
+++ b/web/lib/commerce/cart.ts
@@ -207,3 +207,29 @@ export async function getCartById(businessId: string, cartId: string): Promise<C
   if (error || !row) throw new Error('cart_not_found')
   return rowToCart(row, await fetchItems(businessId, cartId))
 }
+
+/**
+ * Load the current shopper's cart from a session token, without creating
+ * a new one. Returns null when no cart exists for this session — suitable
+ * for server components that want to hydrate the client-side store with
+ * real data instead of forcing it to fetch after mount.
+ *
+ * Why this exists: the zustand cart store is persisted to localStorage
+ * via zustand/persist. When a page renders with `initialCart={null}`,
+ * the hydrator blows the persisted cart away before the user sees it —
+ * surfaces as an empty /checkout even though the drawer has items.
+ * Loading server-side and passing the real cart fixes that.
+ */
+export async function getCartBySessionToken(
+  businessId: string,
+  sessionToken: string,
+): Promise<Cart | null> {
+  const supabase = await createAdminClient()
+  const scoped = scopedQueries(supabase, businessId)
+  const { data } = await scoped.select<CartRow>('carts', '*', {
+    filter: (q) => q.eq('session_token', sessionToken).eq('status', 'open').limit(1),
+  })
+  const row = Array.isArray(data) ? data[0] : data
+  if (!row) return null
+  return rowToCart(row, await fetchItems(businessId, row.id))
+}

--- a/web/lib/stores/cart-store.ts
+++ b/web/lib/stores/cart-store.ts
@@ -43,7 +43,20 @@ export const useCartStore = create<CartStore>()(
       status: 'idle',
       error: null,
 
-      hydrate: (siteSlug, cart) => set({ siteSlug, cart, status: 'idle', error: null }),
+      // Passing cart=null means "I don't have fresh server data", NOT "the
+      // cart is empty" — we keep whatever the persist layer already
+      // rehydrated from localStorage. That matters when a page (e.g. the
+      // checkout /pagar page) renders without pre-fetching the cart: the
+      // old behavior wiped the drawer's items on mount and surfaced as a
+      // confusing "cart has items / checkout empty" regression. Callers
+      // that genuinely want to clear should call `reset()`.
+      hydrate: (siteSlug, cart) =>
+        set((prev) => ({
+          siteSlug,
+          cart: cart ?? prev.cart,
+          status: 'idle',
+          error: null,
+        })),
 
       refresh: async (siteSlug) => {
         set({ status: 'syncing', error: null })


### PR DESCRIPTION
## User-reported

> Cart drawer shows 3 items, Gs 603.000 subtotal. Click "Pagar ahora" →
> \`/s/es/fun4me/checkout\` says "Tu carrito está vacío".

## Root cause

\`<CartStoreHydrator initialCart={null}>\` calls \`hydrate(siteSlug, null)\` inside a useEffect. Zustand's persist middleware has already rehydrated the cart from \`localStorage\` by the time that effect fires — so the \`null\` passed from the server component **wipes the drawer's items** before the checkout form ever reads them.

The tienda page masks this because its \`addItem\` flow immediately re-fetches + re-hydrates. The checkout page has no such trigger, so the post-hydrate cart stays empty forever.

## Fix (two-sided)

1. **Server-load the cart on \`/checkout\`.** New helper \`getCartBySessionToken(businessId, token)\` in \`lib/commerce/cart.ts\` returns the open cart for the current session cookie or \`null\` if none exists — without creating a new row. Paired with \`getSessionToken()\` so we never mint a cookie just to read.
2. **Relax \`hydrate\` semantics.** Passing \`cart=null\` now means "no fresh server data, keep persisted" instead of "wipe". Callers that genuinely want to clear still have \`reset()\`. Defense-in-depth for other pages that forget to pre-fetch.

\`/checkout\` gets \`dynamic = 'force-dynamic'\` (result depends on session cookie).

## Test plan
- [ ] Typecheck green
- [ ] Add items on \`/tienda\`, click Pagar ahora → checkout form shows all items
- [ ] Load \`/checkout\` fresh with no session → empty cart as expected
- [ ] Adding/removing items on tienda then going back to drawer still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)