### PR TITLE
perf(fonts): preconnect hints for Google Fonts

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -82,6 +82,17 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang={htmlLang}>
       <head>
+        {/*
+          Preconnect hints for Google Fonts. Tenant pages load per-site
+          Playfair/Inter/etc. via a `<link rel="stylesheet"
+          href="https://fonts.googleapis.com/...">` — that's render-blocking
+          and discovered late. Pre-warming the DNS + TLS + HTTP handshake
+          shaves 100–250ms off FCP/LCP for first-time visitors.
+          `fonts.gstatic.com` serves the actual font files and MUST be
+          crossorigin (browsers treat font requests as CORS).
+        */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Summary
Tenant pages still load Playfair Display / Inter / etc. via a render-blocking `<link rel="stylesheet" href="https://fonts.googleapis.com/...">` per request. Without preconnects, the browser does DNS + TLS + HTTP handshake sequentially after discovering the link — 100–250ms added to FCP/LCP for first-time visitors.

## Change
Two preconnect `<link>` tags in the root layout's `<head>`:
- `https://fonts.googleapis.com` — CSS host
- `https://fonts.gstatic.com` — WOFF2 host (requires `crossorigin` because font fetches are CORS)

## Expected impact
- 100–250ms FCP/LCP improvement for first-time visitors on all tenant pages
- Complements #252 (hero fetchpriority) — together they attack the two biggest LCP waterfall positions

## Followups
If this + the hero fetchpriority still doesn't clear the 2500ms LCP budget:
- Move to `next/font/google` (auto-preload, self-host, no external request)
- Non-blocking CSS: `rel="preload" as="style" onload="this.rel='stylesheet'"` pattern
- Reduce the hero image payload (current webp may be oversized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)