### PR TITLE
perf(fonts): migrate top-6 Google Fonts to next/font/google

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -5,6 +5,7 @@ import { HOME_FAQS, HOME_PLANS_SCHEMA, HOME_REVIEWS } from '@/lib/landing/home-d
 import { WebVitalsReporter } from '@/components/analytics/web-vitals-reporter'
 import { SkipToContent } from '@/components/ui/skip-to-content'
 import { isLocale, LOCALE_HTML_LANG } from '@/lib/i18n/config'
+import { rootFontVariables } from '@/lib/fonts'
 
 // Extract the tenant locale from `/s/<locale>/<site>/...` paths so the
 // `<html lang>` attribute is correct per-request. Without this, every
@@ -80,7 +81,7 @@ export const metadata: Metadata = {
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const htmlLang = await resolveHtmlLang()
   return (
-    <html lang={htmlLang}>
+    <html lang={htmlLang} className={rootFontVariables}>
       <head>
         {/*
           Preconnect hints for Google Fonts. Tenant pages load per-site

--- a/web/lib/engine/resolve-site-tokens.ts
+++ b/web/lib/engine/resolve-site-tokens.ts
@@ -8,6 +8,35 @@
  */
 import { BASE_TOKENS } from './generated/tenant-data'
 import { loadSiteTokens, loadVerticalTokens } from './site-loader'
+import { PRELOADED_FONT_FAMILIES } from '@/lib/fonts'
+
+/**
+ * Rewrite a typography font-family CSS value so any preloaded font is
+ * served via its `next/font/google` CSS variable, with the original
+ * Google Fonts name kept as a fallback.
+ */
+function prependPreloadedVar(value: string | undefined): string | undefined {
+  if (!value) return value
+  const match = value.match(/^\s*['"]?([^,'"]+)['"]?/)
+  const primary = match?.[1]?.trim()
+  if (!primary) return value
+  const cssVar = PRELOADED_FONT_FAMILIES[primary]
+  if (!cssVar) return value
+  return `${cssVar}, ${value}`
+}
+
+/**
+ * Drop preloaded families from the tenant's googleFonts list — they're
+ * self-hosted via root-layout next/font declarations, no CDN fetch needed.
+ */
+function stripPreloadedGoogleFonts(fonts: string[] | undefined): string[] {
+  if (!fonts || fonts.length === 0) return []
+  const preloaded = new Set(Object.keys(PRELOADED_FONT_FAMILIES))
+  return fonts.filter((entry) => {
+    const family = entry.split(':')[0].replace(/\+/g, ' ')
+    return !preloaded.has(family)
+  })
+}
 
 interface PaletteColors {
   primary: string
@@ -138,9 +167,9 @@ export function resolveSiteTokens(
     '--success': colors.success || '#4a7c59',
     '--error': colors.error || '#c0392b',
     '--warning': colors.warning || '#f39c12',
-    '--font-heading': typo.heading || "'Playfair Display', serif",
-    '--font-body': typo.body || "'Inter', sans-serif",
-    '--font-accent': typo.accent || typo.body || "'Inter', sans-serif",
+    '--font-heading': prependPreloadedVar(typo.heading) || prependPreloadedVar("'Playfair Display', serif")!,
+    '--font-body': prependPreloadedVar(typo.body) || prependPreloadedVar("'Inter', sans-serif")!,
+    '--font-accent': prependPreloadedVar(typo.accent) || prependPreloadedVar(typo.body) || prependPreloadedVar("'Inter', sans-serif")!,
     '--heading-weight': typo.headingWeight || '700',
     '--body-weight': typo.bodyWeight || '400',
     '--heading-transform': typo.textTransform || 'none',
@@ -172,8 +201,9 @@ export function resolveSiteTokens(
   if (colors.error && !vars['--color-error']) vars['--color-error'] = colors.error
   if (colors.warning && !vars['--color-warning']) vars['--color-warning'] = colors.warning
 
-  const googleFontsUrl = merged.googleFonts && merged.googleFonts.length > 0
-    ? `https://fonts.googleapis.com/css2?${merged.googleFonts.map((f) => `family=${f}`).join('&')}&display=swap`
+  const remainingFonts = stripPreloadedGoogleFonts(merged.googleFonts)
+  const googleFontsUrl = remainingFonts.length > 0
+    ? `https://fonts.googleapis.com/css2?${remainingFonts.map((f) => `family=${f}`).join('&')}&display=swap`
     : ''
   const cssBody = Object.entries(vars).map(([k, v]) => `  ${k}: ${v};`).join('\n')
   return {

--- a/web/lib/fonts.ts
+++ b/web/lib/fonts.ts
@@ -1,0 +1,105 @@
+/**
+ * Pre-declared Google Fonts, served via `next/font/google`.
+ *
+ * The top 6 font families by tenant usage (Inter, Playfair Display,
+ * Cormorant Garamond, Montserrat, Oswald, Lora) cover ~85% of all
+ * tenants. Declaring them statically here lets Next.js self-host the
+ * WOFF2 files, auto-preload the critical subset, and eliminate the
+ * external `fonts.googleapis.com` stylesheet request — the single
+ * biggest remaining render-blocking resource on tenant pages.
+ *
+ * Tenants whose `typography.heading` / `typography.body` resolves to
+ * one of these families get the self-hosted version automatically via
+ * `resolve-site-tokens.ts` + `PRELOADED_FONT_FAMILIES` below. Tenants
+ * using rarer fonts (long tail in `src/tokens/*.tokens.json`) still
+ * flow through the CDN pipeline as before — no regression.
+ *
+ * Bundle cost: each declaration emits a `<link rel="stylesheet">` for
+ * its @font-face rules in the root layout. Actual WOFF2 files only
+ * download when CSS references the matching CSS variable, so unused
+ * fonts cost a few hundred bytes of CSS, not the full font payload.
+ */
+import {
+  Inter,
+  Playfair_Display,
+  Cormorant_Garamond,
+  Montserrat,
+  Oswald,
+  Lora,
+} from 'next/font/google'
+
+const fontConfig = {
+  subsets: ['latin'] as ['latin'],
+  display: 'swap' as const,
+}
+
+export const fontInter = Inter({
+  ...fontConfig,
+  weight: ['400', '500', '600', '700', '800'],
+  variable: '--font-inter',
+})
+
+export const fontPlayfair = Playfair_Display({
+  ...fontConfig,
+  weight: ['400', '500', '600', '700'],
+  style: ['normal', 'italic'],
+  variable: '--font-playfair',
+})
+
+export const fontCormorant = Cormorant_Garamond({
+  ...fontConfig,
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-cormorant',
+})
+
+export const fontMontserrat = Montserrat({
+  ...fontConfig,
+  weight: ['400', '500', '600', '700', '800'],
+  variable: '--font-montserrat',
+})
+
+export const fontOswald = Oswald({
+  ...fontConfig,
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-oswald',
+})
+
+export const fontLora = Lora({
+  ...fontConfig,
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-lora',
+})
+
+export const preloadedFonts = [
+  fontInter,
+  fontPlayfair,
+  fontCormorant,
+  fontMontserrat,
+  fontOswald,
+  fontLora,
+]
+
+/**
+ * Map human font-family name → CSS variable reference.
+ *
+ * `resolveSiteTokens` uses this to:
+ *   1. Detect when a tenant's declared font matches a preloaded one
+ *   2. Substitute the CSS variable for the font-family in emitted CSS
+ *   3. Strip the matching entry from `googleFonts` so the CDN stylesheet
+ *      doesn't double-load the font
+ */
+export const PRELOADED_FONT_FAMILIES: Record<string, string> = {
+  Inter: 'var(--font-inter)',
+  'Playfair Display': 'var(--font-playfair)',
+  'Cormorant Garamond': 'var(--font-cormorant)',
+  Montserrat: 'var(--font-montserrat)',
+  Oswald: 'var(--font-oswald)',
+  Lora: 'var(--font-lora)',
+}
+
+/**
+ * Whitespace-separated CSS class names from all preloaded fonts. Apply to
+ * the root `<html>` (or any wrapping element) so every preloaded font's
+ * CSS variable is in scope for descendant rules.
+ */
+export const rootFontVariables = preloadedFonts.map((f) => f.variable).join(' ')

--- a/web/lib/fonts.ts
+++ b/web/lib/fonts.ts
@@ -2,11 +2,12 @@
  * Pre-declared Google Fonts, served via `next/font/google`.
  *
  * The top 6 font families by tenant usage (Inter, Playfair Display,
- * Cormorant Garamond, Montserrat, Oswald, Lora) cover ~85% of all
- * tenants. Declaring them statically here lets Next.js self-host the
- * WOFF2 files, auto-preload the critical subset, and eliminate the
- * external `fonts.googleapis.com` stylesheet request — the single
- * biggest remaining render-blocking resource on tenant pages.
+ * Cormorant Garamond, Montserrat, Oswald, Lora) cover ~79 of ~100
+ * tenant-level font uses. Declaring them statically here lets Next.js
+ * self-host the WOFF2 files, auto-preload the critical subset, and
+ * eliminate the external `fonts.googleapis.com` stylesheet request —
+ * the single biggest remaining render-blocking resource on tenant
+ * pages.
  *
  * Tenants whose `typography.heading` / `typography.body` resolves to
  * one of these families get the self-hosted version automatically via
@@ -14,10 +15,10 @@
  * using rarer fonts (long tail in `src/tokens/*.tokens.json`) still
  * flow through the CDN pipeline as before — no regression.
  *
- * Bundle cost: each declaration emits a `<link rel="stylesheet">` for
- * its @font-face rules in the root layout. Actual WOFF2 files only
- * download when CSS references the matching CSS variable, so unused
- * fonts cost a few hundred bytes of CSS, not the full font payload.
+ * NOTE: `next/font/google` arguments must be statically analyzable by
+ * Turbopack — no spreads, no dynamic values, no shared config objects.
+ * Each call below inlines its full options literal on purpose; do not
+ * refactor into a helper that builds options dynamically.
  */
 import {
   Inter,
@@ -28,44 +29,45 @@ import {
   Lora,
 } from 'next/font/google'
 
-const fontConfig = {
-  subsets: ['latin'] as ['latin'],
-  display: 'swap' as const,
-}
-
 export const fontInter = Inter({
-  ...fontConfig,
+  subsets: ['latin'],
+  display: 'swap',
   weight: ['400', '500', '600', '700', '800'],
   variable: '--font-inter',
 })
 
 export const fontPlayfair = Playfair_Display({
-  ...fontConfig,
+  subsets: ['latin'],
+  display: 'swap',
   weight: ['400', '500', '600', '700'],
   style: ['normal', 'italic'],
   variable: '--font-playfair',
 })
 
 export const fontCormorant = Cormorant_Garamond({
-  ...fontConfig,
+  subsets: ['latin'],
+  display: 'swap',
   weight: ['400', '500', '600', '700'],
   variable: '--font-cormorant',
 })
 
 export const fontMontserrat = Montserrat({
-  ...fontConfig,
+  subsets: ['latin'],
+  display: 'swap',
   weight: ['400', '500', '600', '700', '800'],
   variable: '--font-montserrat',
 })
 
 export const fontOswald = Oswald({
-  ...fontConfig,
+  subsets: ['latin'],
+  display: 'swap',
   weight: ['400', '500', '600', '700'],
   variable: '--font-oswald',
 })
 
 export const fontLora = Lora({
-  ...fontConfig,
+  subsets: ['latin'],
+  display: 'swap',
   weight: ['400', '500', '600', '700'],
   variable: '--font-lora',
 })

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,1 +1,25 @@
 import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+
+// next/font/google relies on Next.js's build-time transform to replace
+// the font-family helpers with objects containing className/variable.
+// In a plain Vitest run the imports resolve to the raw loader functions
+// and calling them throws "X is not a function". Mock the module so
+// `@/lib/fonts` (which uses Inter(), Playfair_Display(), etc.) works in
+// tests as well as in the Next build.
+function mockFont(cssVar: string) {
+  return () => ({
+    className: `mock-${cssVar}`,
+    variable: `--${cssVar}`,
+    style: { fontFamily: `mock-${cssVar}` },
+  })
+}
+
+vi.mock('next/font/google', () => ({
+  Inter: mockFont('font-inter'),
+  Playfair_Display: mockFont('font-playfair'),
+  Cormorant_Garamond: mockFont('font-cormorant'),
+  Montserrat: mockFont('font-montserrat'),
+  Oswald: mockFont('font-oswald'),
+  Lora: mockFont('font-lora'),
+}))


### PR DESCRIPTION
## Summary
Biggest outstanding LCP lever. Eliminates the render-blocking external `fonts.googleapis.com` stylesheet for ~79 of ~100 tenant font uses by self-hosting the top 6 families through `next/font/google`.

## Scope
- New `web/lib/fonts.ts`: static declarations for Inter, Playfair Display, Cormorant Garamond, Montserrat, Oswald, Lora
- Root layout adds `rootFontVariables` to `<html className>` so all 6 CSS variables are in scope globally
- `resolveSiteTokens` prepends `var(--font-<family>)` when a tenant's `typography.heading`/`body` matches a preloaded family
- `stripPreloadedGoogleFonts()` removes those families from `googleFontsUrl` so the CDN doesn't double-serve

## Backward compatibility
Tenants using rarer fonts (Fraunces, Bebas Neue, Noto Serif JP, etc.) keep using the CDN stylesheet. Only the top 6 families are short-circuited — no regression for the long tail.

## Expected impact
400-700ms LCP improvement on first-time tenant-page visits. The external `<link rel="stylesheet">` request was discovered late in the waterfall and blocked paint until it resolved; self-hosted fonts come inline + auto-preload.

## Font coverage (tenant count per family)
- Inter: 36
- Playfair Display: 12
- Cormorant Garamond: 12
- Montserrat: 10
- Oswald: 6
- Lora: 3
- **Total: 79 usages covered**
- Remaining long tail: 21 usages across 18 rarer fonts

🤖 Generated with [Claude Code](https://claude.com/claude-code)