### PR TITLE
feat(commerce): Batch A — order-confirmation + admin-new-order + polish

### DIFF
--- a/supabase/migrations/20260422020000_outbox_admin_templates.sql
+++ b/supabase/migrations/20260422020000_outbox_admin_templates.sql
@@ -1,0 +1,22 @@
+-- Extend commerce_email_outbox.template CHECK constraint to include the
+-- new admin-notification templates. Without this, any attempt to insert
+-- an admin notification into the outbox fails with a 23514 CHECK violation
+-- and the merchant never learns about new orders.
+
+ALTER TABLE commerce_email_outbox DROP CONSTRAINT commerce_email_outbox_template_check;
+
+ALTER TABLE commerce_email_outbox ADD CONSTRAINT commerce_email_outbox_template_check
+  CHECK (template = ANY (ARRAY[
+    'order_confirmation',
+    'order_paid',
+    'order_shipped',
+    'order_refunded',
+    'low_stock_digest',
+    'cart_recovery_24h',
+    'cart_recovery_72h',
+    'cart_recovery_7d',
+    'back_in_stock',
+    'review_request',
+    'admin_new_order',
+    'admin_daily_digest'
+  ]));

--- a/web/app/admin/commerce/[businessId]/orders/[id]/page.tsx
+++ b/web/app/admin/commerce/[businessId]/orders/[id]/page.tsx
@@ -40,6 +40,34 @@ export default async function AdminOrderDetail({ params }: { params: Promise<{ b
           <p>{order.customerName}</p>
           <p className="text-sm text-[color:var(--text-muted,#6b7280)]">{order.customerEmail}</p>
           {order.customerPhone ? <p className="text-sm text-[color:var(--text-muted,#6b7280)]">{order.customerPhone}</p> : null}
+          <div className="mt-3 flex flex-wrap gap-2">
+            {order.customerPhone ? (
+              <a
+                href={`https://wa.me/${order.customerPhone.replace(/\D/g, '')}?text=${encodeURIComponent(`Hola ${order.customerName}, sobre tu pedido ${order.orderNumber}:`)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-md bg-[#25D366] px-3 py-1.5 text-xs font-semibold text-white hover:opacity-90"
+              >
+                <span aria-hidden="true">💬</span> WhatsApp
+              </a>
+            ) : null}
+            {order.customerEmail ? (
+              <a
+                href={`mailto:${order.customerEmail}?subject=${encodeURIComponent(`Tu pedido ${order.orderNumber}`)}&body=${encodeURIComponent(`Hola ${order.customerName},\n\nSobre tu pedido ${order.orderNumber}:\n\n`)}`}
+                className="inline-flex items-center gap-1.5 rounded-md border border-[color:var(--border,#e5e7eb)] px-3 py-1.5 text-xs font-medium hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+              >
+                <span aria-hidden="true">✉</span> Email
+              </a>
+            ) : null}
+            {order.customerPhone ? (
+              <a
+                href={`tel:${order.customerPhone}`}
+                className="inline-flex items-center gap-1.5 rounded-md border border-[color:var(--border,#e5e7eb)] px-3 py-1.5 text-xs font-medium hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+              >
+                <span aria-hidden="true">📞</span> Llamar
+              </a>
+            ) : null}
+          </div>
         </section>
 
         {order.shippingAddress ? (

--- a/web/app/api/admin/commerce/[businessId]/orders/[id]/transition/route.ts
+++ b/web/app/api/admin/commerce/[businessId]/orders/[id]/transition/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { withRequestLog } from '@/lib/api/with-request-log'
-import { transitionStatus, CheckoutError } from '@/lib/commerce/orders'
+import { transitionStatus, CheckoutError, getOrder } from '@/lib/commerce/orders'
 import { OrderStatusSchema } from '@/lib/schemas/commerce/order'
 import { requireAdminUser } from '@/lib/commerce/admin-auth'
+import { enqueueOrderEmail } from '@/lib/commerce/notifications'
+import { createAdminClient } from '@/lib/supabase/admin'
 
 export const runtime = 'nodejs'
 
@@ -17,6 +19,14 @@ const BodySchema = z.object({
     })
     .optional(),
 })
+
+// Which status transitions should fire a customer email. Intentionally
+// small — refunded / fulfilled / delivered don't email today; the admin
+// can still transition them, just no customer notification.
+const STATUS_TO_TEMPLATE: Partial<Record<z.infer<typeof OrderStatusSchema>, 'order_paid' | 'order_shipped'>> = {
+  paid: 'order_paid',
+  shipped: 'order_shipped',
+}
 
 export const POST = withRequestLog<{ businessId: string; id: string }>(async (req, { log }, { businessId, id }) => {
   const admin = await requireAdminUser()
@@ -36,7 +46,6 @@ export const POST = withRequestLog<{ businessId: string; id: string }>(async (re
   try {
     await transitionStatus(businessId, id, parsed.data.status, { tracking: parsed.data.tracking })
     log.info('admin.commerce.order.transitioned', { businessId, orderId: id, status: parsed.data.status })
-    return NextResponse.json({ ok: true })
   } catch (err) {
     if (err instanceof CheckoutError) {
       const status = err.code === 'order_not_found' ? 404 : 409
@@ -47,4 +56,39 @@ export const POST = withRequestLog<{ businessId: string; id: string }>(async (re
     }
     throw err
   }
+
+  // Fire the matching customer notification for transitions the shopper
+  // cares about. Fire-and-forget — an outbox insert failure must not
+  // block the admin action. commerce-email-flush cron sends on next tick.
+  const template = STATUS_TO_TEMPLATE[parsed.data.status]
+  if (template) {
+    try {
+      const order = await getOrder(businessId, id)
+      const supabase = await createAdminClient()
+      const { data: biz } = await supabase
+        .from('businesses')
+        .select('name, slug')
+        .eq('id', businessId)
+        .maybeSingle()
+      const appUrl =
+        process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXT_PUBLIC_BASE_URL ?? 'https://paragu-ai.com'
+      const storeUrl = biz ? `${appUrl}/s/es/${biz.slug}/orden/${order.id}` : appUrl
+      await enqueueOrderEmail({
+        businessId,
+        businessName: biz?.name ?? 'Tienda',
+        orderId: order.id,
+        template,
+        order,
+        storeUrl,
+      })
+    } catch (err) {
+      log.warn('admin.commerce.order.customer_email_enqueue_failed', {
+        orderId: id,
+        status: parsed.data.status,
+        err: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  return NextResponse.json({ ok: true })
 })

--- a/web/app/api/storefront/[site]/checkout/route.ts
+++ b/web/app/api/storefront/[site]/checkout/route.ts
@@ -14,6 +14,11 @@ import { computeCartTotals } from '@/lib/commerce/compute-totals'
 import { quoteShippingForAddress } from '@/lib/commerce/shipping-zones'
 import { CheckoutInputSchema } from '@/lib/schemas/commerce/order'
 import type { PaymentProvider } from '@/lib/schemas/commerce/transaction'
+import {
+  enqueueOrderEmail,
+  enqueueAdminNewOrderEmail,
+  resolveAdminEmail,
+} from '@/lib/commerce/notifications'
 
 // Extend the base CheckoutInputSchema to optionally accept a discountCode.
 // The code is validated server-side against discounts table — never trust
@@ -111,6 +116,39 @@ export const POST = withRequestLog<{ site: string }>(async (req, { log }, { site
   const order = await getOrder(business.id, orderId)
 
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000'
+
+  // Fire-and-forget order-confirmation + admin-notification emails via
+  // the outbox. The commerce-email-flush cron picks them up on the next
+  // tick and sends via Resend. We do NOT let failures block the payment
+  // flow — outbox insert errors log + swallow.
+  const storeOrderUrl = `${appUrl}/s/es/${site}/orden/${order.id}`
+  const adminDashboardUrl = `${appUrl}/admin/commerce/${business.id}/orders/${order.id}`
+  const adminEmail = resolveAdminEmail(business.dataJson)
+  await Promise.all([
+    enqueueOrderEmail({
+      businessId: business.id,
+      businessName: business.name,
+      orderId: order.id,
+      template: 'order_confirmation',
+      order,
+      storeUrl: storeOrderUrl,
+    }).catch((err) =>
+      log.warn('commerce.checkout.customer_email_enqueue_failed', {
+        err: err instanceof Error ? err.message : String(err),
+      }),
+    ),
+    enqueueAdminNewOrderEmail({
+      businessId: business.id,
+      businessName: business.name,
+      order,
+      adminEmail: adminEmail ?? '',
+      adminDashboardUrl,
+    }).catch((err) =>
+      log.warn('commerce.checkout.admin_email_enqueue_failed', {
+        err: err instanceof Error ? err.message : String(err),
+      }),
+    ),
+  ])
 
   // Pick provider via capability matrix; failover on gateway 5xx/timeout.
   //

--- a/web/components/commerce/checkout-form.tsx
+++ b/web/components/commerce/checkout-form.tsx
@@ -159,12 +159,22 @@ export function CheckoutForm({ siteSlug, locale = 'es' }: Props) {
       <aside className="h-fit rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-6 lg:sticky lg:top-4">
         <h2 className="mb-4 text-lg font-semibold">Resumen</h2>
         <ul className="mb-4 space-y-2 text-sm">
-          {cart.items.map((it) => (
-            <li key={it.id} className="flex justify-between">
-              <span className="text-[color:var(--text-muted,#6b7280)]">{it.quantity} × producto</span>
-              <span>{formatCents(it.unitPriceCents * it.quantity, cart.currency)}</span>
-            </li>
-          ))}
+          {cart.items.map((it) => {
+            // Fall back to "Producto" only when the join row didn't resolve
+            // a name — real products always have one. The pre-fix copy
+            // literally read "producto" for every line.
+            const name = it.productName ?? 'Producto'
+            return (
+              <li key={it.id} className="flex justify-between gap-2">
+                <span className="flex-1 truncate text-[color:var(--text-muted,#6b7280)]">
+                  {it.quantity} × {name}
+                </span>
+                <span className="whitespace-nowrap">
+                  {formatCents(it.unitPriceCents * it.quantity, cart.currency)}
+                </span>
+              </li>
+            )
+          })}
         </ul>
 
         {/* Discount code */}

--- a/web/lib/commerce/email-templates.ts
+++ b/web/lib/commerce/email-templates.ts
@@ -156,6 +156,61 @@ export function reviewRequestEmail(ctx: ReviewRequestContext) {
   }
 }
 
+export interface AdminNewOrderContext {
+  order: Order
+  businessName: string
+  adminDashboardUrl: string
+}
+
+/**
+ * Notifies the merchant that a new order was placed. Fast scannable
+ * format with all decision-relevant info so the merchant can act
+ * without logging in (reply to WhatsApp, prep the package, etc.).
+ */
+export function adminNewOrderEmail({ order, businessName, adminDashboardUrl }: AdminNewOrderContext) {
+  const itemsHtml = (order.items ?? [])
+    .map(
+      (it) =>
+        `<tr><td style="padding:6px 0;">${escape(it.productSnapshot.name)} × ${it.quantity}</td><td style="padding:6px 0;text-align:right;">${formatCents(it.lineTotalCents, order.currency)}</td></tr>`,
+    )
+    .join('')
+
+  const addr = order.shippingAddress
+  const addrLine = addr
+    ? `${escape(addr.line1)}${addr.line2 ? ', ' + escape(addr.line2) : ''}, ${escape(addr.city)}${addr.department ? ' (' + escape(addr.department) + ')' : ''}`
+    : '—'
+
+  const phoneDigits = order.customerPhone ? order.customerPhone.replace(/\D/g, '') : ''
+  const whatsappUrl = phoneDigits
+    ? `https://wa.me/${phoneDigits}?text=${encodeURIComponent(`Hola ${order.customerName}, recibimos tu pedido ${order.orderNumber}.`)}`
+    : null
+
+  return {
+    subject: `🛒 Nueva orden ${order.orderNumber} — ${formatCents(order.totalCents, order.currency)} (${businessName})`,
+    html: `
+<!doctype html><html><body style="font-family:system-ui,-apple-system,sans-serif;color:#111;max-width:600px;margin:0 auto;padding:24px;">
+  <h1 style="font-size:20px;margin:0 0 8px 0;">Nuevo pedido</h1>
+  <p style="color:#6b7280;margin:0 0 16px 0;font-size:13px;">Orden <strong style="color:#111;">${order.orderNumber}</strong> · ${new Date(order.createdAt).toLocaleString('es-PY')}</p>
+  <div style="display:inline-block;background:#fef3c7;color:#92400e;padding:4px 10px;border-radius:4px;font-size:12px;font-weight:600;margin-bottom:16px;">Esperando pago</div>
+  <table style="width:100%;border-collapse:collapse;margin:0 0 16px 0;font-size:14px;">
+    ${itemsHtml}
+    <tr><td style="padding:8px 0;border-top:1px solid #e5e7eb;font-weight:600;">Total</td><td style="padding:8px 0;border-top:1px solid #e5e7eb;text-align:right;font-weight:600;">${formatCents(order.totalCents, order.currency)}</td></tr>
+  </table>
+  <div style="background:#f9fafb;border-radius:8px;padding:12px;margin:0 0 16px 0;font-size:14px;">
+    <p style="margin:0 0 4px 0;font-weight:600;">${escape(order.customerName)}</p>
+    <p style="margin:0 0 4px 0;color:#6b7280;">${escape(order.customerEmail)}</p>
+    ${order.customerPhone ? `<p style="margin:0 0 4px 0;color:#6b7280;">${escape(order.customerPhone)}</p>` : ''}
+    <p style="margin:8px 0 0 0;color:#6b7280;font-size:12px;">Envío: ${addrLine}</p>
+  </div>
+  <div style="margin:0 0 8px 0;">
+    <a href="${adminDashboardUrl}" style="display:inline-block;background:#111;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;">Ver en el admin →</a>
+    ${whatsappUrl ? `<a href="${whatsappUrl}" style="display:inline-block;background:#25D366;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;margin-left:8px;">WhatsApp cliente</a>` : ''}
+  </div>
+  <p style="color:#9ca3af;font-size:11px;margin-top:24px;">${escape(businessName)} · notificación automática de Paragu-AI</p>
+</body></html>`.trim(),
+  }
+}
+
 function escape(s: string): string {
   return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!))
 }

--- a/web/lib/commerce/notifications.ts
+++ b/web/lib/commerce/notifications.ts
@@ -1,9 +1,21 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { logger } from '@/lib/logger'
-import { orderConfirmationEmail, orderPaidEmail, orderShippedEmail } from './email-templates'
+import {
+  orderConfirmationEmail,
+  orderPaidEmail,
+  orderShippedEmail,
+  adminNewOrderEmail,
+} from './email-templates'
 import type { Order } from '@/lib/schemas/commerce/order'
 
-type Template = 'order_confirmation' | 'order_paid' | 'order_shipped' | 'order_refunded' | 'low_stock_digest'
+type Template =
+  | 'order_confirmation'
+  | 'order_paid'
+  | 'order_shipped'
+  | 'order_refunded'
+  | 'low_stock_digest'
+  | 'admin_new_order'
+  | 'admin_daily_digest'
 
 interface EnqueueOpts {
   businessId: string
@@ -17,7 +29,7 @@ interface EnqueueOpts {
 /**
  * Writes an email row to commerce_email_outbox. A separate cron job
  * (see /api/cron/commerce-email-flush) actually sends via Resend.
- * This keeps webhook responses fast and gives us a retry surface.
+ * This keeps checkout/admin flows fast and gives us a retry surface.
  */
 export async function enqueueOrderEmail(opts: EnqueueOpts): Promise<void> {
   const supabase = await createAdminClient()
@@ -34,7 +46,7 @@ export async function enqueueOrderEmail(opts: EnqueueOpts): Promise<void> {
       rendered = orderShippedEmail({ order: opts.order, businessName: opts.businessName, storeUrl: opts.storeUrl })
       break
     default:
-      logger.warn('[commerce] template not implemented', { template: opts.template })
+      logger.warn('[commerce] template not implemented for customer email', { template: opts.template })
       return
   }
 
@@ -54,4 +66,73 @@ export async function enqueueOrderEmail(opts: EnqueueOpts): Promise<void> {
       error: error.message,
     })
   }
+}
+
+interface AdminEnqueueOpts {
+  businessId: string
+  businessName: string
+  order: Order
+  adminEmail: string
+  adminDashboardUrl: string
+}
+
+/**
+ * Enqueue a new-order notification for the merchant. Separate from
+ * `enqueueOrderEmail` because the recipient + template are not tied to
+ * the customer's email on the order. Silently no-ops when no admin
+ * email is configured — we log a warning so the gap is visible in
+ * prod logs without breaking the checkout flow.
+ */
+export async function enqueueAdminNewOrderEmail(opts: AdminEnqueueOpts): Promise<void> {
+  if (!opts.adminEmail) {
+    logger.warn('[commerce] admin new-order notification skipped: no admin_email configured', {
+      action: 'commerce.admin_email.missing',
+      businessId: opts.businessId,
+      orderId: opts.order.id,
+    })
+    return
+  }
+
+  const rendered = adminNewOrderEmail({
+    order: opts.order,
+    businessName: opts.businessName,
+    adminDashboardUrl: opts.adminDashboardUrl,
+  })
+
+  const supabase = await createAdminClient()
+  const { error } = await supabase.from('commerce_email_outbox').insert({
+    business_id: opts.businessId,
+    order_id: opts.order.id,
+    template: 'admin_new_order',
+    recipient_email: opts.adminEmail,
+    subject: rendered.subject,
+    html_body: rendered.html,
+  })
+
+  if (error) {
+    logger.error('[commerce] admin outbox insert failed', {
+      action: 'commerce.admin_email.enqueue_failed',
+      orderId: opts.order.id,
+      error: error.message,
+    })
+  }
+}
+
+/**
+ * Resolve the admin email for notifications. Priority:
+ *   1. data_json.admin_email (explicit — set via ops)
+ *   2. data_json.content.contact.email (tenant support email — in
+ *      practice the same inbox for SMB tenants like fun4me)
+ *
+ * Returns null if neither is set. Callers should log + skip when null
+ * rather than fail — missing admin email isn't a customer-visible failure.
+ */
+export function resolveAdminEmail(dataJson: unknown): string | null {
+  if (!dataJson || typeof dataJson !== 'object') return null
+  const j = dataJson as Record<string, unknown>
+  const explicit = typeof j.admin_email === 'string' ? j.admin_email.trim() : ''
+  if (explicit) return explicit
+  const content = j.content as { contact?: { email?: string } } | undefined
+  const fromContact = content?.contact?.email?.trim() ?? ''
+  return fromContact || null
 }

--- a/web/lib/commerce/resolve-business.ts
+++ b/web/lib/commerce/resolve-business.ts
@@ -12,6 +12,10 @@ export interface ResolvedBusiness {
   /** WhatsApp number from the tenant's content blob, if set. Digits only,
    * no `+`, ready to drop into a `wa.me/<digits>` URL. */
   whatsappNumber?: string
+  /** Raw data_json passed through for callers that need fields this
+   * interface doesn't explicitly model (admin_email, legal info, etc.).
+   * Treat as opaque. */
+  dataJson?: unknown
 }
 
 /**
@@ -60,5 +64,6 @@ export async function resolveBusinessBySlug(slug: string): Promise<ResolvedBusin
     currency,
     preferredProvider: commerceCfg?.provider,
     whatsappNumber,
+    dataJson: data.data_json,
   }
 }


### PR DESCRIPTION
## Batch A of the commerce-improvements plan

Shipping **1 of 10 batches** from the [detailed improvement plan](# ). This batch closes the single biggest operational gap: today, a new order silently lands in the DB and nobody hears about it.

### What's in this PR
1. **Customer order-confirmation email** — wired `enqueueOrderEmail('order_confirmation')` in the checkout route.
2. **Admin new-order notification email** — new template + enqueue function. Subject: `🛒 Nueva orden PRG-... — Gs X (Tenant)`. Body includes items, customer block, shipping address, "Ver en admin" + "WhatsApp cliente" CTAs.
3. **Customer paid/shipped transition emails** — wired in admin status-transition route.
4. **Outbox CHECK constraint widened** to include `admin_new_order` + `admin_daily_digest` templates.
5. **`ResolvedBusiness` exposes `dataJson`** — needed to read `admin_email`.
6. **Fix `"2 × producto"`** → `{quantity} × {productName}` in checkout summary.
7. **WhatsApp / Email / Tel quick-actions** on admin order detail.

### Test plan
- [x] Typecheck green
- [x] Unit tests green (133/133)
- [ ] Manual: place order as anonymous shopper → customer email arrives with order# + items
- [ ] Manual: same order → admin email arrives at `hola@fun4me.com.py` with "Ver en admin" button working
- [ ] Manual: admin clicks "Confirmar pago recibido" → customer email "Tu pago fue aprobado"

### Ops already applied
- Migration applied to prod via `supabase apply_migration`
- `fun4me.data_json.admin_email = hola@fun4me.com.py` set via SQL
- Admin notification flow is end-to-end from day 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)