### PR TITLE
feat(admin): /admin/inbox — inbound consultation CRM on public.leads

### DIFF
--- a/supabase/migrations/20260422020000_leads_status_and_admin_notes.sql
+++ b/supabase/migrations/20260422020000_leads_status_and_admin_notes.sql
@@ -1,0 +1,48 @@
+-- /admin/inbox workflow fields on public.leads.
+--
+-- Adds:
+-- - status          — pipeline state: new → contacted → qualified → closed
+-- - admin_notes     — free-form internal notes (markdown-friendly, no HTML)
+-- - contacted_at    — timestamp of first outreach (derived from status transitions)
+-- - qualified_at    — timestamp of qualification (derived)
+-- - closed_at       — timestamp of close (won or lost)
+-- - close_reason    — text: 'won' | 'lost_not_fit' | 'lost_no_response' | 'lost_other' | null
+--
+-- Indexes: (site_slug, status, created_at desc) to accelerate the inbox list.
+--
+-- RLS: service-role-only matches the existing pattern on public.leads. Admin
+-- UI accesses via service-role key. No public/anon access.
+
+alter table public.leads
+  add column if not exists status text not null default 'new',
+  add column if not exists admin_notes text,
+  add column if not exists contacted_at timestamptz,
+  add column if not exists qualified_at timestamptz,
+  add column if not exists closed_at timestamptz,
+  add column if not exists close_reason text;
+
+-- Enforce valid status transitions at the DB level. Dropping first in case an
+-- earlier variant exists from a prior partial migration.
+alter table public.leads drop constraint if exists leads_status_check;
+alter table public.leads
+  add constraint leads_status_check
+  check (status in ('new', 'contacted', 'qualified', 'closed'));
+
+alter table public.leads drop constraint if exists leads_close_reason_check;
+alter table public.leads
+  add constraint leads_close_reason_check
+  check (close_reason is null or close_reason in ('won', 'lost_not_fit', 'lost_no_response', 'lost_other'));
+
+-- Inbox query pattern: filter by site_slug (optional) + status, sort by
+-- most recent first. This composite covers both the scoped and global views.
+create index if not exists leads_site_status_created_idx
+  on public.leads (site_slug, status, created_at desc);
+
+create index if not exists leads_status_created_idx
+  on public.leads (status, created_at desc);
+
+comment on column public.leads.status is
+  'Pipeline state. Transitions: new → contacted → qualified → closed. See close_reason for terminal state.';
+
+comment on column public.leads.admin_notes is
+  'Internal notes — not exposed to the lead or CRM adapters. Text only.';

--- a/supabase/migrations/20260422030000_orders_comprobante_sent.sql
+++ b/supabase/migrations/20260422030000_orders_comprobante_sent.sql
@@ -1,0 +1,9 @@
+-- Add comprobante-sent timestamp + optional note to orders. Set by the
+-- customer via a new POST endpoint on the transfer-instructions page
+-- after they send the transfer proof via WhatsApp. The admin sees a
+-- badge on the order-detail page so both sides know the current state
+-- without pinging each other on WhatsApp.
+
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS comprobante_sent_at TIMESTAMPTZ NULL,
+  ADD COLUMN IF NOT EXISTS comprobante_note TEXT NULL;

--- a/web/app/admin/commerce/[businessId]/orders/[id]/page.tsx
+++ b/web/app/admin/commerce/[businessId]/orders/[id]/page.tsx
@@ -35,6 +35,21 @@ export default async function AdminOrderDetail({ params }: { params: Promise<{ b
           <span className="rounded bg-[color:var(--primary,#111)]/10 px-3 py-1 text-sm font-medium">{order.status}</span>
         </header>
 
+        {order.comprobanteSentAt && order.status === 'awaiting_payment' ? (
+          <div className="mb-6 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-900">
+            <p className="font-semibold">✓ Cliente avisó que envió el comprobante</p>
+            <p className="mt-0.5 text-xs">
+              {new Date(order.comprobanteSentAt).toLocaleString('es-PY')} · Verificá la transferencia y
+              marcá el pago como recibido abajo.
+            </p>
+            {order.comprobanteNote ? (
+              <p className="mt-2 whitespace-pre-line rounded bg-white/60 p-2 text-xs">
+                Nota del cliente: {order.comprobanteNote}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
         <section className="mb-6">
           <h2 className="mb-2 text-sm font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Cliente</h2>
           <p>{order.customerName}</p>

--- a/web/app/admin/inbox/inbox-dashboard.tsx
+++ b/web/app/admin/inbox/inbox-dashboard.tsx
@@ -1,0 +1,499 @@
+'use client'
+
+import { useState, useMemo, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import type { InboxLead, InboxStats } from './page'
+
+type Filters = { site?: string; status?: string; q?: string }
+
+const STATUS_ORDER: InboxLead['status'][] = ['new', 'contacted', 'qualified', 'closed']
+const STATUS_LABELS: Record<InboxLead['status'], string> = {
+  new: 'New',
+  contacted: 'Contacted',
+  qualified: 'Qualified',
+  closed: 'Closed',
+}
+const STATUS_COLORS: Record<InboxLead['status'], string> = {
+  new: 'bg-blue-50 text-blue-700 border-blue-200',
+  contacted: 'bg-amber-50 text-amber-700 border-amber-200',
+  qualified: 'bg-purple-50 text-purple-700 border-purple-200',
+  closed: 'bg-slate-100 text-slate-600 border-slate-200',
+}
+
+const CLOSE_REASON_LABELS: Record<string, string> = {
+  won: 'Won (paid)',
+  lost_not_fit: 'Lost — not a fit',
+  lost_no_response: 'Lost — no response',
+  lost_other: 'Lost — other',
+}
+
+export function InboxDashboard({
+  leads,
+  stats,
+  siteOptions,
+  activeFilters,
+}: {
+  leads: InboxLead[]
+  stats: InboxStats
+  siteOptions: string[]
+  activeFilters: Filters
+}) {
+  const router = useRouter()
+  const [selected, setSelected] = useState<InboxLead | null>(null)
+  const [pending, startTransition] = useTransition()
+
+  const applyFilters = (next: Filters) => {
+    const qs = new URLSearchParams()
+    if (next.site) qs.set('site', next.site)
+    if (next.status) qs.set('status', next.status)
+    if (next.q) qs.set('q', next.q)
+    const query = qs.toString()
+    startTransition(() => {
+      router.push(query ? `/admin/inbox?${query}` : '/admin/inbox')
+    })
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-50">
+      <header className="border-b bg-white">
+        <div className="mx-auto max-w-7xl px-6 py-5">
+          <div className="flex items-baseline justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-slate-900">Inbox</h1>
+              <p className="text-sm text-slate-500">
+                Inbound consultation leads across tenants.
+              </p>
+            </div>
+            <a
+              href="/admin"
+              className="text-sm text-slate-600 hover:text-slate-900 hover:underline"
+            >
+              ← Back to admin
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <section className="mx-auto max-w-7xl px-6 py-6">
+        <StatsRow stats={stats} />
+        <Filters
+          active={activeFilters}
+          siteOptions={siteOptions}
+          onApply={applyFilters}
+          pending={pending}
+        />
+        <LeadsTable
+          leads={leads}
+          onSelect={setSelected}
+          pending={pending}
+        />
+      </section>
+
+      {selected && (
+        <LeadDrawer
+          lead={selected}
+          onClose={() => setSelected(null)}
+          onUpdated={(next) => {
+            // Refresh the page data so the table reflects the update.
+            setSelected(next)
+            startTransition(() => router.refresh())
+          }}
+        />
+      )}
+    </main>
+  )
+}
+
+function StatsRow({ stats }: { stats: InboxStats }) {
+  const cards = [
+    { label: 'Total', value: stats.total, tone: 'slate' },
+    { label: 'New', value: stats.new, tone: 'blue' },
+    { label: 'Contacted', value: stats.contacted, tone: 'amber' },
+    { label: 'Qualified', value: stats.qualified, tone: 'purple' },
+    { label: 'Won (30d)', value: stats.wonLast30Days, tone: 'emerald' },
+  ]
+  const tone: Record<string, string> = {
+    slate: 'text-slate-700',
+    blue: 'text-blue-700',
+    amber: 'text-amber-700',
+    purple: 'text-purple-700',
+    emerald: 'text-emerald-700',
+  }
+  return (
+    <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+      {cards.map((c) => (
+        <div
+          key={c.label}
+          className="rounded-lg border border-slate-200 bg-white p-4"
+        >
+          <p className="text-xs font-medium uppercase tracking-wider text-slate-500">
+            {c.label}
+          </p>
+          <p className={`mt-1 text-2xl font-semibold ${tone[c.tone]}`}>
+            {c.value}
+          </p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Filters({
+  active,
+  siteOptions,
+  onApply,
+  pending,
+}: {
+  active: Filters
+  siteOptions: string[]
+  onApply: (next: Filters) => void
+  pending: boolean
+}) {
+  const [local, setLocal] = useState<Filters>(active)
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        onApply(local)
+      }}
+      className="mb-4 flex flex-wrap items-end gap-3 rounded-lg border border-slate-200 bg-white p-4"
+    >
+      <label className="flex-1 min-w-[180px]">
+        <span className="mb-1 block text-xs font-medium text-slate-600">Search</span>
+        <input
+          type="search"
+          value={local.q ?? ''}
+          onChange={(e) => setLocal({ ...local, q: e.target.value })}
+          placeholder="name, email, objective…"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none"
+        />
+      </label>
+      <label>
+        <span className="mb-1 block text-xs font-medium text-slate-600">Site</span>
+        <select
+          value={local.site ?? ''}
+          onChange={(e) => setLocal({ ...local, site: e.target.value || undefined })}
+          className="rounded-md border border-slate-300 px-3 py-2 text-sm"
+        >
+          <option value="">All sites</option>
+          {siteOptions.map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+      </label>
+      <label>
+        <span className="mb-1 block text-xs font-medium text-slate-600">Status</span>
+        <select
+          value={local.status ?? ''}
+          onChange={(e) => setLocal({ ...local, status: e.target.value || undefined })}
+          className="rounded-md border border-slate-300 px-3 py-2 text-sm"
+        >
+          <option value="">All</option>
+          {STATUS_ORDER.map((s) => (
+            <option key={s} value={s}>{STATUS_LABELS[s]}</option>
+          ))}
+        </select>
+      </label>
+      <button
+        type="submit"
+        disabled={pending}
+        className="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800 disabled:opacity-50"
+      >
+        {pending ? 'Applying…' : 'Apply'}
+      </button>
+      {(active.site || active.status || active.q) && (
+        <button
+          type="button"
+          onClick={() => { setLocal({}); onApply({}) }}
+          className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+        >
+          Clear
+        </button>
+      )}
+    </form>
+  )
+}
+
+function LeadsTable({
+  leads,
+  onSelect,
+  pending,
+}: {
+  leads: InboxLead[]
+  onSelect: (l: InboxLead) => void
+  pending: boolean
+}) {
+  if (leads.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-slate-300 bg-white p-12 text-center">
+        <p className="text-sm text-slate-500">No leads match the current filters.</p>
+      </div>
+    )
+  }
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
+      <table className="w-full divide-y divide-slate-200 text-sm">
+        <thead className="bg-slate-50 text-left text-xs font-medium uppercase tracking-wider text-slate-500">
+          <tr>
+            <th className="px-4 py-3">Received</th>
+            <th className="px-4 py-3">Name + contact</th>
+            <th className="px-4 py-3">Site · locale</th>
+            <th className="px-4 py-3">Program</th>
+            <th className="px-4 py-3">Status</th>
+          </tr>
+        </thead>
+        <tbody className={`divide-y divide-slate-100 ${pending ? 'opacity-60' : ''}`}>
+          {leads.map((l) => (
+            <tr
+              key={l.id}
+              className="cursor-pointer hover:bg-slate-50"
+              onClick={() => onSelect(l)}
+            >
+              <td className="whitespace-nowrap px-4 py-3 text-slate-600">
+                {formatDate(l.created_at)}
+              </td>
+              <td className="px-4 py-3">
+                <div className="font-medium text-slate-900">{l.name}</div>
+                <div className="text-xs text-slate-500">{l.email}</div>
+                {l.country && (
+                  <div className="text-xs text-slate-400">{l.country}</div>
+                )}
+              </td>
+              <td className="whitespace-nowrap px-4 py-3 text-slate-600">
+                <span className="font-mono text-xs">{l.site_slug}</span>
+                <span className="text-slate-400"> · {l.locale}</span>
+              </td>
+              <td className="whitespace-nowrap px-4 py-3 text-slate-600">
+                {l.program_interest || <span className="text-slate-300">—</span>}
+              </td>
+              <td className="px-4 py-3">
+                <StatusBadge status={l.status} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: InboxLead['status'] }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[status]}`}
+    >
+      {STATUS_LABELS[status]}
+    </span>
+  )
+}
+
+function LeadDrawer({
+  lead,
+  onClose,
+  onUpdated,
+}: {
+  lead: InboxLead
+  onClose: () => void
+  onUpdated: (next: InboxLead) => void
+}) {
+  const [saving, setSaving] = useState(false)
+  const [notes, setNotes] = useState(lead.admin_notes ?? '')
+  const [error, setError] = useState<string | null>(null)
+
+  const patch = async (body: Partial<{ status: InboxLead['status']; admin_notes: string; close_reason: string | null }>) => {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/admin/leads/${lead.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'update failed')
+      if (json.lead) onUpdated({ ...lead, ...json.lead })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'update failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const whatsappHref = lead.phone
+    ? `https://wa.me/${lead.phone.replace(/\D/g, '')}`
+    : null
+  const mailHref = `mailto:${lead.email}?subject=${encodeURIComponent('Re: your Nexa Paraguay consultation')}&body=${encodeURIComponent(`Hi ${lead.name},\n\nThanks for reaching out. `)}`
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex justify-end bg-slate-900/40"
+      onClick={onClose}
+    >
+      <aside
+        className="h-full w-full max-w-xl overflow-y-auto bg-white shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="sticky top-0 flex items-center justify-between border-b bg-white px-6 py-4">
+          <div>
+            <p className="text-xs uppercase tracking-wider text-slate-500">
+              {lead.site_slug} · {lead.locale}
+            </p>
+            <h2 className="text-lg font-semibold text-slate-900">{lead.name}</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="space-y-6 px-6 py-6">
+          <section>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+              Contact
+            </h3>
+            <dl className="space-y-1 text-sm">
+              <Row label="Email"><a href={mailHref} className="text-blue-600 hover:underline">{lead.email}</a></Row>
+              {lead.phone && <Row label="Phone">{lead.phone}</Row>}
+              {lead.country && <Row label="Country">{lead.country}</Row>}
+              {lead.program_interest && <Row label="Program">{lead.program_interest}</Row>}
+            </dl>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {whatsappHref && (
+                <a
+                  href={whatsappHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-md bg-[#25D366] px-3 py-1.5 text-xs font-medium text-white"
+                >
+                  WhatsApp
+                </a>
+              )}
+              <a
+                href={mailHref}
+                className="inline-flex items-center gap-1.5 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+              >
+                Email
+              </a>
+            </div>
+          </section>
+
+          {lead.objective && (
+            <section>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+                Objective
+              </h3>
+              <p className="whitespace-pre-wrap rounded-md bg-slate-50 p-3 text-sm text-slate-700">
+                {lead.objective}
+              </p>
+            </section>
+          )}
+
+          <section>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+              Pipeline
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {STATUS_ORDER.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => patch({ status: s })}
+                  disabled={saving || lead.status === s}
+                  className={`rounded-md border px-3 py-1.5 text-xs font-medium transition ${
+                    lead.status === s
+                      ? `${STATUS_COLORS[s]} ring-2 ring-offset-1 ring-slate-400`
+                      : 'border-slate-300 bg-white text-slate-700 hover:bg-slate-50'
+                  } ${saving ? 'opacity-50' : ''}`}
+                >
+                  {STATUS_LABELS[s]}
+                </button>
+              ))}
+            </div>
+            <div className="mt-3 space-y-1 text-xs text-slate-500">
+              <div>Received: {formatDate(lead.created_at)}</div>
+              {lead.contacted_at && <div>Contacted: {formatDate(lead.contacted_at)}</div>}
+              {lead.qualified_at && <div>Qualified: {formatDate(lead.qualified_at)}</div>}
+              {lead.closed_at && <div>Closed: {formatDate(lead.closed_at)}{lead.close_reason && ` — ${CLOSE_REASON_LABELS[lead.close_reason]}`}</div>}
+            </div>
+            {lead.status === 'closed' && (
+              <div className="mt-3">
+                <label className="text-xs font-medium text-slate-600">Close reason</label>
+                <select
+                  value={lead.close_reason ?? ''}
+                  onChange={(e) => patch({ close_reason: e.target.value || null })}
+                  disabled={saving}
+                  className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+                >
+                  <option value="">— pick one —</option>
+                  {Object.entries(CLOSE_REASON_LABELS).map(([v, l]) => (
+                    <option key={v} value={v}>{l}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </section>
+
+          <section>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+              Internal notes
+            </h3>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={6}
+              placeholder="Context, follow-ups, decisions. Not shared with the lead."
+              className="w-full rounded-md border border-slate-300 p-3 text-sm focus:border-slate-500 focus:outline-none"
+            />
+            <button
+              type="button"
+              onClick={() => patch({ admin_notes: notes })}
+              disabled={saving || notes === (lead.admin_notes ?? '')}
+              className="mt-2 rounded-md bg-slate-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-slate-800 disabled:opacity-50"
+            >
+              {saving ? 'Saving…' : 'Save notes'}
+            </button>
+          </section>
+
+          {(lead.source || lead.referer || (lead.utm && Object.keys(lead.utm).length > 0)) && (
+            <section className="border-t pt-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+                Attribution
+              </h3>
+              <dl className="space-y-1 font-mono text-xs text-slate-600">
+                {lead.source && <Row label="source" mono>{lead.source}</Row>}
+                {lead.referer && <Row label="referer" mono><span className="break-all">{lead.referer}</span></Row>}
+                {lead.utm &&
+                  Object.entries(lead.utm).map(([k, v]) => (
+                    <Row key={k} label={k} mono>{v}</Row>
+                  ))}
+              </dl>
+            </section>
+          )}
+
+          {error && (
+            <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>
+          )}
+        </div>
+      </aside>
+    </div>
+  )
+}
+
+function Row({ label, children, mono }: { label: string; children: React.ReactNode; mono?: boolean }) {
+  return (
+    <div className="flex gap-3">
+      <dt className={`w-24 flex-shrink-0 ${mono ? 'font-mono' : ''} text-slate-500`}>{label}</dt>
+      <dd className="flex-1 text-slate-800">{children}</dd>
+    </div>
+  )
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  })
+}

--- a/web/app/admin/inbox/page.tsx
+++ b/web/app/admin/inbox/page.tsx
@@ -1,0 +1,136 @@
+/**
+ * /admin/inbox — inbound consultation leads dashboard.
+ *
+ * Reads from public.leads (the inbound contact-form schema, not the older
+ * outbound-prospecting table that /admin/leads references). Status pipeline:
+ * new → contacted → qualified → closed.
+ *
+ * Service-role access via createClient(). RLS remains service-role-only;
+ * admin gate is at the route level via requireAdmin().
+ */
+import { requireAdmin } from '@/lib/auth/admin'
+import { createClient } from '@/lib/supabase/server'
+import { logger } from '@/lib/logger'
+import { InboxDashboard } from './inbox-dashboard'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export const metadata = {
+  title: 'Inbox — Admin',
+  description: 'Inbound consultation leads across tenants.',
+}
+
+export interface InboxLead {
+  id: string
+  site_slug: string
+  locale: string
+  name: string
+  email: string
+  phone: string | null
+  country: string | null
+  program_interest: string | null
+  objective: string | null
+  source: string | null
+  referer: string | null
+  utm: Record<string, string> | null
+  status: 'new' | 'contacted' | 'qualified' | 'closed'
+  admin_notes: string | null
+  contacted_at: string | null
+  qualified_at: string | null
+  closed_at: string | null
+  close_reason: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface InboxStats {
+  total: number
+  new: number
+  contacted: number
+  qualified: number
+  closed: number
+  wonLast30Days: number
+}
+
+export default async function InboxPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ site?: string; status?: string; q?: string }>
+}) {
+  await requireAdmin()
+  const { site, status, q } = await searchParams
+
+  const supabase = await createClient()
+
+  let query = supabase
+    .from('leads')
+    .select(
+      'id, site_slug, locale, name, email, phone, country, program_interest, objective, source, referer, utm, status, admin_notes, contacted_at, qualified_at, closed_at, close_reason, created_at, updated_at',
+    )
+    .order('created_at', { ascending: false })
+    .limit(250)
+
+  if (site) query = query.eq('site_slug', site)
+  if (status && ['new', 'contacted', 'qualified', 'closed'].includes(status)) {
+    query = query.eq('status', status)
+  }
+  if (q && q.trim()) {
+    // PostgREST `or` filter: name/email ilike. Safe from injection; supabase-js
+    // escapes values. Kept narrow — no full-text search.
+    const esc = q.trim().replace(/[%,]/g, '')
+    query = query.or(`name.ilike.%${esc}%,email.ilike.%${esc}%,objective.ilike.%${esc}%`)
+  }
+
+  const { data, error } = await query
+  if (error) {
+    logger.error('inbox leads load failed', { error: error.message })
+  }
+  const leads = (data ?? []) as InboxLead[]
+
+  // Stats across ALL leads (unfiltered) for the top cards. Kept separate so
+  // filters don't skew the pipeline count.
+  const { data: statRows } = await supabase
+    .from('leads')
+    .select('status, closed_at, close_reason')
+    .limit(10_000)
+
+  const stats = buildStats((statRows ?? []) as Array<{ status: string; closed_at: string | null; close_reason: string | null }>)
+
+  const siteOptions = Array.from(new Set(leads.map((l) => l.site_slug))).sort()
+
+  return (
+    <InboxDashboard
+      leads={leads}
+      stats={stats}
+      siteOptions={siteOptions}
+      activeFilters={{ site, status, q }}
+    />
+  )
+}
+
+function buildStats(
+  rows: Array<{ status: string; closed_at: string | null; close_reason: string | null }>,
+): InboxStats {
+  const base: InboxStats = {
+    total: rows.length,
+    new: 0,
+    contacted: 0,
+    qualified: 0,
+    closed: 0,
+    wonLast30Days: 0,
+  }
+  const cutoff = Date.now() - 30 * 24 * 60 * 60 * 1000
+  for (const r of rows) {
+    if (r.status in base) (base as unknown as Record<string, number>)[r.status]++
+    if (
+      r.status === 'closed' &&
+      r.close_reason === 'won' &&
+      r.closed_at &&
+      new Date(r.closed_at).getTime() >= cutoff
+    ) {
+      base.wonLast30Days++
+    }
+  }
+  return base
+}

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -76,6 +76,18 @@ export default async function AdminDashboard() {
             </p>
           </Link>
           <Link
+            href="/admin/inbox"
+            className="group rounded-lg border bg-white p-5 transition-all hover:-translate-y-0.5 hover:border-blue-300 hover:shadow-sm"
+          >
+            <p className="text-xs uppercase tracking-wider text-gray-500">Inbound</p>
+            <p className="mt-1 text-base font-semibold text-gray-900 group-hover:text-blue-700">
+              Inbox
+            </p>
+            <p className="mt-1 text-sm text-gray-500">
+              Consultas entrantes (contact forms) — pipeline new → closed.
+            </p>
+          </Link>
+          <Link
             href="/admin/demo-requests"
             className="group rounded-lg border bg-white p-5 transition-all hover:-translate-y-0.5 hover:border-blue-300 hover:shadow-sm"
           >

--- a/web/app/api/admin/leads/[id]/route.ts
+++ b/web/app/api/admin/leads/[id]/route.ts
@@ -1,0 +1,101 @@
+/**
+ * PATCH /api/admin/leads/[id]
+ *
+ * Updates status + admin_notes on a lead row. Admin-only via requireAdmin().
+ * Derives the status-transition timestamps automatically: contacted_at on
+ * first move to 'contacted', qualified_at on first move to 'qualified',
+ * closed_at on first move to 'closed'. Never clears those once set.
+ */
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { checkAdmin } from '@/lib/auth/admin'
+import { createClient } from '@/lib/supabase/server'
+import { logger } from '@/lib/logger'
+
+export const runtime = 'nodejs'
+
+const PatchSchema = z.object({
+  status: z.enum(['new', 'contacted', 'qualified', 'closed']).optional(),
+  admin_notes: z.string().max(10_000).optional(),
+  close_reason: z.enum(['won', 'lost_not_fit', 'lost_no_response', 'lost_other']).nullable().optional(),
+})
+
+export async function PATCH(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params
+  const admin = await checkAdmin()
+  if (!admin.ok) {
+    return NextResponse.json({ error: admin.reason }, { status: admin.status })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid json' }, { status: 400 })
+  }
+
+  const parsed = PatchSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'validation', detail: parsed.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const supabase = await createClient()
+
+  // Load current row so we can compute transition timestamps.
+  const { data: current, error: loadErr } = await supabase
+    .from('leads')
+    .select('id, status, contacted_at, qualified_at, closed_at')
+    .eq('id', id)
+    .maybeSingle()
+
+  if (loadErr) {
+    logger.warn('Failed to load lead for PATCH', { id, error: loadErr.message })
+    return NextResponse.json({ error: 'lookup_failed' }, { status: 500 })
+  }
+  if (!current) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 })
+  }
+
+  const patch: Record<string, unknown> = {}
+  if (parsed.data.admin_notes !== undefined) patch.admin_notes = parsed.data.admin_notes
+  if (parsed.data.close_reason !== undefined) patch.close_reason = parsed.data.close_reason
+
+  if (parsed.data.status) {
+    patch.status = parsed.data.status
+    const now = new Date().toISOString()
+    // Set transition timestamps on first entry into each terminal-ish state.
+    if (parsed.data.status === 'contacted' && !current.contacted_at) patch.contacted_at = now
+    if (parsed.data.status === 'qualified' && !current.qualified_at) patch.qualified_at = now
+    if (parsed.data.status === 'closed' && !current.closed_at) patch.closed_at = now
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ ok: true, changed: false })
+  }
+
+  const { data: updated, error: updateErr } = await supabase
+    .from('leads')
+    .update(patch)
+    .eq('id', id)
+    .select('id, status, admin_notes, contacted_at, qualified_at, closed_at, close_reason, updated_at')
+    .single()
+
+  if (updateErr) {
+    logger.warn('Failed to update lead', { id, error: updateErr.message })
+    return NextResponse.json({ error: 'update_failed', detail: updateErr.message }, { status: 500 })
+  }
+
+  logger.info('Lead updated via admin inbox', {
+    leadId: id,
+    by: admin.user.email,
+    fields: Object.keys(patch),
+  })
+
+  return NextResponse.json({ ok: true, lead: updated })
+}

--- a/web/app/api/storefront/[site]/orders/[id]/comprobante-sent/route.ts
+++ b/web/app/api/storefront/[site]/orders/[id]/comprobante-sent/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+export const runtime = 'nodejs'
+
+// Customer-facing — no auth. An abuser could only mark their own
+// orders as "comprobante sent"; the admin still has to verify and
+// hit "Confirmar pago recibido" manually. This endpoint is a UX
+// signal, not a money-moving action.
+const BodySchema = z.object({
+  note: z.string().trim().max(500).optional(),
+})
+
+export const POST = withRequestLog<{ site: string; id: string }>(
+  async (req, { log }, { site, id }) => {
+    const business = await resolveBusinessBySlug(site)
+    if (!business) return NextResponse.json({ error: 'not_found' }, { status: 404 })
+
+    let json: unknown = {}
+    try {
+      json = await req.json()
+    } catch {
+      // Body is optional — empty body is the expected flow for the
+      // "Ya envié el comprobante" button.
+    }
+    const parsed = BodySchema.safeParse(json)
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const supabase = await createAdminClient()
+    // Stamp only if not already set — treat re-submissions as idempotent.
+    const { data: updated, error } = await supabase
+      .from('orders')
+      .update({
+        comprobante_sent_at: new Date().toISOString(),
+        comprobante_note: parsed.data.note ?? null,
+      })
+      .eq('id', id)
+      .eq('business_id', business.id)
+      .is('comprobante_sent_at', null)
+      .select('id, order_number')
+      .maybeSingle()
+
+    if (error) {
+      log.error('commerce.comprobante_sent.update_failed', { orderId: id, error: error.message })
+      return NextResponse.json({ error: 'update_failed' }, { status: 500 })
+    }
+
+    // If no row was updated, either the order doesn't exist or the
+    // comprobante was already stamped. Both map to a 200 OK — the
+    // customer clicked the button, their intent is recorded either
+    // way, no reason to surface "already did that" as an error.
+    log.info('commerce.comprobante_sent.recorded', {
+      orderId: id,
+      orderNumber: updated?.order_number,
+      alreadyStamped: !updated,
+    })
+
+    return NextResponse.json({ ok: true })
+  },
+)

--- a/web/app/s/[locale]/[site]/checkout/transfer/[orderId]/page.tsx
+++ b/web/app/s/[locale]/[site]/checkout/transfer/[orderId]/page.tsx
@@ -4,6 +4,7 @@ import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { getOrder, CheckoutError } from '@/lib/commerce/orders'
 import { formatCents } from '@/lib/commerce/compute-totals'
 import { listCredentialsForBusiness } from '@/lib/commerce/payment-credentials'
+import { ComprobanteSentButton } from '@/components/commerce/comprobante-sent-button'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -90,24 +91,37 @@ export default async function TransferInstructionsPage({
 
           <section className="mt-6 space-y-3">
             <h2 className="text-xs font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Enviar comprobante</h2>
-            {whatsappUrl ? (
-              <a
-                href={whatsappUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-lg bg-[#25D366] px-5 py-3 text-sm font-semibold text-white hover:opacity-90"
-              >
-                Enviar comprobante por WhatsApp
-              </a>
+            {order.comprobanteSentAt ? (
+              <div className="rounded-lg border border-green-200 bg-green-50 p-4 text-sm text-green-900">
+                <p className="font-semibold">✓ Marcaste el comprobante como enviado</p>
+                <p className="mt-1 text-xs">
+                  {new Date(order.comprobanteSentAt).toLocaleString('es-PY')} · {business.name} revisa
+                  los comprobantes y confirma tu pago por email en las próximas horas.
+                </p>
+              </div>
             ) : (
-              <p className="text-sm text-[color:var(--text-muted,#6b7280)]">
-                El comercio no configuró WhatsApp. Contactalo por otro canal.
-              </p>
+              <>
+                {whatsappUrl ? (
+                  <a
+                    href={whatsappUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 rounded-lg bg-[#25D366] px-5 py-3 text-sm font-semibold text-white hover:opacity-90"
+                  >
+                    Enviar comprobante por WhatsApp
+                  </a>
+                ) : (
+                  <p className="text-sm text-[color:var(--text-muted,#6b7280)]">
+                    El comercio no configuró WhatsApp. Contactalo por otro canal.
+                  </p>
+                )}
+                <ComprobanteSentButton siteSlug={site} orderId={order.id} />
+                <p className="text-xs text-[color:var(--text-muted,#6b7280)]">
+                  Referenciá el pedido <strong>{order.orderNumber}</strong> al enviarlo. Tu pedido se
+                  confirma cuando el comercio valida la transferencia.
+                </p>
+              </>
             )}
-            <p className="text-xs text-[color:var(--text-muted,#6b7280)]">
-              Referenciá el pedido <strong>{order.orderNumber}</strong> al enviarlo. Tu pedido se confirma
-              cuando el comercio valida la transferencia.
-            </p>
           </section>
 
           <section className="mt-8 border-t border-[color:var(--border,#e5e7eb)] pt-4 text-sm">

--- a/web/components/commerce/comprobante-sent-button.tsx
+++ b/web/components/commerce/comprobante-sent-button.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface Props {
+  siteSlug: string
+  orderId: string
+}
+
+/**
+ * "Ya envié el comprobante" button on the /checkout/transfer/[id]
+ * page. POSTs to the comprobante-sent endpoint which stamps
+ * orders.comprobante_sent_at — purely a UX signal so the merchant
+ * sees a "Comprobante enviado" badge on the order detail. The admin
+ * still has to confirm the payment manually.
+ */
+export function ComprobanteSentButton({ siteSlug, orderId }: Props) {
+  const router = useRouter()
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleClick() {
+    if (submitting) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/storefront/${siteSlug}/orders/${orderId}/comprobante-sent`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error ?? 'update_failed')
+      }
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'update_failed')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={submitting}
+        className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-4 py-2 text-sm font-medium hover:bg-[color:var(--surface-muted,#f3f4f6)] disabled:opacity-60"
+      >
+        {submitting ? 'Registrando…' : 'Ya envié el comprobante'}
+      </button>
+      {error ? (
+        <p role="alert" className="mt-2 text-xs text-red-700">
+          No pudimos registrar tu aviso. Intentá de nuevo o mandá el comprobante por WhatsApp.
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/web/lib/commerce/orders.ts
+++ b/web/lib/commerce/orders.ts
@@ -161,6 +161,8 @@ function rowToOrder(row: Record<string, unknown>, items: Record<string, unknown>
     trackingCarrier: (row.tracking_carrier as string | null) ?? null,
     trackingNumber: (row.tracking_number as string | null) ?? null,
     trackingUrl: (row.tracking_url as string | null) ?? null,
+    comprobanteSentAt: (row.comprobante_sent_at as string | null) ?? null,
+    comprobanteNote: (row.comprobante_note as string | null) ?? null,
     createdAt: row.created_at as string,
     updatedAt: row.updated_at as string,
     items: items.map(

--- a/web/lib/schemas/commerce/order.ts
+++ b/web/lib/schemas/commerce/order.ts
@@ -70,6 +70,12 @@ export const OrderSchema = z.object({
   trackingCarrier: z.string().nullable(),
   trackingNumber: z.string().nullable(),
   trackingUrl: z.string().nullable(),
+  /** When the customer confirmed they sent the transfer proof via
+   * WhatsApp. Set by POST /api/storefront/[site]/orders/[id]/comprobante-sent.
+   * Null means the customer hasn't told us yet. Admin UI renders a
+   * "Comprobante enviado" badge when this is populated. */
+  comprobanteSentAt: z.string().nullable(),
+  comprobanteNote: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
   items: z.array(OrderItemSchema).optional(),


### PR DESCRIPTION
First real admin dashboard for the inbound lead pipeline, built on the 2026-04-17 public.leads schema (site_slug/locale/name/email/phone/country/program_interest/objective/utm).

Separate from the existing /admin/leads (outbound prospecting schema — data-model collision avoided).

## What shipped
- **Migration**: adds `status`, `admin_notes`, 3 transition timestamps, `close_reason` + CHECK constraints + indexes.
- **PATCH /api/admin/leads/[id]**: status + notes updates, auto-derives transition timestamps.
- **/admin/inbox**: filterable table (site, status, search) + stats row (total/new/contacted/qualified/won30d) + detail drawer with WhatsApp/email quick actions, pipeline buttons, close-reason selector, internal notes.
- Admin nav tile added.

Uses existing `requireAdmin()` env-allowlist auth pattern. Service-role Supabase access; RLS stays service-role-only.

## Out of scope
Pagination (250-row cap for now), bulk actions, CSV export, lead assignment to specific admins, Supabase Realtime. All clean add-ons without schema changes.

Note: this branch also contains background-agent work on admin orders comprobante-sent flow — separate concern, same admin area.

## Test plan
- [x] tsc clean
- [x] 27 engine tests pass
- [ ] Post-deploy: visit /admin/inbox as admin email → renders table, detail drawer works, status transitions persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)