### PR TITLE
feat(commerce): Batch D (partial) — comprobante image upload infrastructure

### DIFF
--- a/supabase/migrations/20260422050000_orders_comprobante_upload.sql
+++ b/supabase/migrations/20260422050000_orders_comprobante_upload.sql
@@ -1,0 +1,16 @@
+-- Comprobante image upload (Batch D). Adds two columns on orders for
+-- the Supabase-storage-backed file the customer optionally uploads
+-- on /checkout/transfer/[id]. Path shape: <business_id>/<order_id>/<ts>.<ext>.
+
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS comprobante_image_url TEXT NULL,
+  ADD COLUMN IF NOT EXISTS comprobante_uploaded_at TIMESTAMPTZ NULL;
+
+-- Storage bucket `comprobantes` is created via Supabase admin with:
+--   id='comprobantes', public=false, file_size_limit=5MB,
+--   allowed_mime_types=[image/jpeg, image/png, image/webp, application/pdf]
+--
+-- Our upload API uses the service-role client and writes directly to
+-- the bucket; the image_url we persist is a signed URL valid for the
+-- bucket's default TTL. Admin UI generates fresh signed URLs on demand
+-- so we don't have to worry about expiry on stored column values.

--- a/web/app/api/admin/commerce/[businessId]/orders/[id]/comprobante-url/route.ts
+++ b/web/app/api/admin/commerce/[businessId]/orders/[id]/comprobante-url/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { requireAdminUser } from '@/lib/commerce/admin-auth'
+
+export const runtime = 'nodejs'
+
+// 15-minute signed URL — long enough to render in the admin UI and
+// click through to full-size, short enough that a leaked URL decays
+// fast. The bucket is private; we create a new signed URL each time
+// the admin page renders.
+const SIGNED_URL_TTL_SECONDS = 15 * 60
+
+export const GET = withRequestLog<{ businessId: string; id: string }>(
+  async (_req, { log }, { businessId, id }) => {
+    const admin = await requireAdminUser()
+    if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+    const supabase = await createAdminClient()
+    const { data: order } = await supabase
+      .from('orders')
+      .select('comprobante_image_url')
+      .eq('id', id)
+      .eq('business_id', businessId)
+      .maybeSingle()
+
+    if (!order?.comprobante_image_url) {
+      return NextResponse.json({ error: 'no_comprobante' }, { status: 404 })
+    }
+
+    const { data, error } = await supabase.storage
+      .from('comprobantes')
+      .createSignedUrl(order.comprobante_image_url, SIGNED_URL_TTL_SECONDS)
+
+    if (error || !data?.signedUrl) {
+      log.error('admin.commerce.comprobante_signed_url.failed', {
+        orderId: id,
+        error: error?.message,
+      })
+      return NextResponse.json({ error: 'sign_failed' }, { status: 500 })
+    }
+
+    return NextResponse.json({ url: data.signedUrl })
+  },
+)

--- a/web/app/api/storefront/[site]/orders/[id]/comprobante-upload/route.ts
+++ b/web/app/api/storefront/[site]/orders/[id]/comprobante-upload/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+export const runtime = 'nodejs'
+
+// Max body size handled via the multipart/form-data parse; the bucket
+// itself enforces 5MB at the storage layer.
+const ALLOWED_MIME = new Set(['image/jpeg', 'image/png', 'image/webp', 'application/pdf'])
+const MAX_BYTES = 5 * 1024 * 1024
+
+function extForMime(mime: string): string {
+  if (mime === 'image/jpeg') return 'jpg'
+  if (mime === 'image/png') return 'png'
+  if (mime === 'image/webp') return 'webp'
+  if (mime === 'application/pdf') return 'pdf'
+  return 'bin'
+}
+
+export const POST = withRequestLog<{ site: string; id: string }>(
+  async (req, { log }, { site, id }) => {
+    const business = await resolveBusinessBySlug(site)
+    if (!business) return NextResponse.json({ error: 'not_found' }, { status: 404 })
+
+    const form = await req.formData().catch(() => null)
+    if (!form) return NextResponse.json({ error: 'invalid_body' }, { status: 400 })
+    const file = form.get('file')
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'missing_file' }, { status: 400 })
+    }
+    if (!ALLOWED_MIME.has(file.type)) {
+      return NextResponse.json({ error: 'unsupported_mime' }, { status: 415 })
+    }
+    if (file.size > MAX_BYTES) {
+      return NextResponse.json({ error: 'file_too_large', maxBytes: MAX_BYTES }, { status: 413 })
+    }
+
+    const supabase = await createAdminClient()
+
+    // Confirm the order exists + belongs to this business before writing.
+    // Avoids a random shopper dumping files into other tenants' paths.
+    const { data: order } = await supabase
+      .from('orders')
+      .select('id, business_id, order_number, comprobante_image_url')
+      .eq('id', id)
+      .eq('business_id', business.id)
+      .maybeSingle()
+    if (!order) return NextResponse.json({ error: 'order_not_found' }, { status: 404 })
+
+    const ext = extForMime(file.type)
+    const ts = Date.now()
+    const path = `${business.id}/${order.id}/${ts}.${ext}`
+
+    const buf = Buffer.from(await file.arrayBuffer())
+    const { error: uploadError } = await supabase.storage.from('comprobantes').upload(path, buf, {
+      contentType: file.type,
+      upsert: false,
+    })
+    if (uploadError) {
+      log.error('commerce.comprobante_upload.failed', {
+        orderId: id,
+        error: uploadError.message,
+      })
+      return NextResponse.json({ error: 'upload_failed' }, { status: 500 })
+    }
+
+    // Mark order as comprobante-sent and persist the storage path.
+    const { error: updateError } = await supabase
+      .from('orders')
+      .update({
+        comprobante_image_url: path,
+        comprobante_uploaded_at: new Date().toISOString(),
+        comprobante_sent_at: order.comprobante_image_url
+          ? undefined // preserve earlier sent-at if reuploading
+          : new Date().toISOString(),
+      })
+      .eq('id', id)
+      .eq('business_id', business.id)
+    if (updateError) {
+      log.error('commerce.comprobante_upload.db_update_failed', {
+        orderId: id,
+        error: updateError.message,
+      })
+      // File uploaded but DB didn't update — still return ok, the admin
+      // can recover via the storage path if needed. Logging is enough.
+    }
+
+    log.info('commerce.comprobante_upload.ok', {
+      orderId: id,
+      orderNumber: order.order_number,
+      path,
+      size: file.size,
+    })
+
+    return NextResponse.json({ ok: true })
+  },
+)

--- a/web/components/admin/commerce/comprobante-viewer.tsx
+++ b/web/components/admin/commerce/comprobante-viewer.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Props {
+  businessId: string
+  orderId: string
+  uploadedAt: string
+}
+
+/**
+ * Renders a preview + "Ver comprobante" button on the admin order
+ * detail page. Fetches a fresh 15-minute signed URL on mount; never
+ * persists the URL in the DOM beyond the current session.
+ */
+export function ComprobanteViewer({ businessId, orderId, uploadedAt }: Props) {
+  const [state, setState] = useState<
+    | { kind: 'loading' }
+    | { kind: 'ready'; url: string }
+    | { kind: 'error'; message: string }
+  >({ kind: 'loading' })
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch(`/api/admin/commerce/${businessId}/orders/${orderId}/comprobante-url`)
+        if (!res.ok) throw new Error('sign_failed')
+        const j = (await res.json()) as { url: string }
+        if (!cancelled) setState({ kind: 'ready', url: j.url })
+      } catch {
+        if (!cancelled) setState({ kind: 'error', message: 'No se pudo cargar el comprobante.' })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [businessId, orderId])
+
+  const isImage = state.kind === 'ready' && !state.url.includes('.pdf?')
+
+  return (
+    <div className="mt-3 rounded-lg border border-green-200 bg-green-50 p-3">
+      <p className="text-xs font-semibold uppercase text-green-900">
+        Comprobante subido — {new Date(uploadedAt).toLocaleString('es-PY')}
+      </p>
+      {state.kind === 'loading' ? (
+        <p className="mt-2 text-xs text-green-800">Cargando vista previa…</p>
+      ) : state.kind === 'error' ? (
+        <p className="mt-2 text-xs text-red-700">{state.message}</p>
+      ) : isImage ? (
+        <div className="mt-2 flex items-center gap-3">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={state.url}
+            alt="Comprobante de transferencia"
+            className="h-24 w-24 rounded border border-[color:var(--border,#e5e7eb)] object-cover"
+          />
+          <a
+            href={state.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium text-[color:var(--primary,#111)] underline"
+          >
+            Ver tamaño completo →
+          </a>
+        </div>
+      ) : (
+        <a
+          href={state.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-block text-sm font-medium text-[color:var(--primary,#111)] underline"
+        >
+          Abrir comprobante (PDF) →
+        </a>
+      )}
+    </div>
+  )
+}

--- a/web/components/commerce/comprobante-upload-button.tsx
+++ b/web/components/commerce/comprobante-upload-button.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface Props {
+  siteSlug: string
+  orderId: string
+  alreadyUploaded: boolean
+}
+
+/**
+ * Upload-a-comprobante-image widget on /checkout/transfer/[id].
+ * Completely optional — the WhatsApp deep link remains the primary path.
+ * Benefits: admin gets an audit trail, customer doesn't have to swap
+ * to another app if they'd rather drop a screenshot here.
+ *
+ * Accepts: JPG / PNG / WebP / PDF, up to 5MB. The backing Supabase
+ * bucket enforces the same limits.
+ */
+export function ComprobanteUploadButton({ siteSlug, orderId, alreadyUploaded }: Props) {
+  const router = useRouter()
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const [state, setState] = useState<
+    | { kind: 'idle' }
+    | { kind: 'uploading'; name: string }
+    | { kind: 'error'; message: string }
+    | { kind: 'done'; name: string }
+  >({ kind: 'idle' })
+
+  async function handleFile(file: File) {
+    setState({ kind: 'uploading', name: file.name })
+    const body = new FormData()
+    body.append('file', file)
+    try {
+      const res = await fetch(`/api/storefront/${siteSlug}/orders/${orderId}/comprobante-upload`, {
+        method: 'POST',
+        body,
+      })
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string }
+        throw new Error(j.error ?? 'upload_failed')
+      }
+      setState({ kind: 'done', name: file.name })
+      router.refresh()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'upload_failed'
+      setState({
+        kind: 'error',
+        message:
+          msg === 'file_too_large'
+            ? 'Archivo muy grande (máx 5 MB).'
+            : msg === 'unsupported_mime'
+              ? 'Solo JPG, PNG, WebP o PDF.'
+              : 'No pudimos subir el archivo. Intentá de nuevo.',
+      })
+    }
+  }
+
+  return (
+    <div className="mt-2">
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,application/pdf"
+        className="sr-only"
+        onChange={(e) => {
+          const f = e.target.files?.[0]
+          if (f) void handleFile(f)
+          e.target.value = '' // allow re-selecting same file after error
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        disabled={state.kind === 'uploading'}
+        className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-4 py-2 text-sm font-medium hover:bg-[color:var(--surface-muted,#f3f4f6)] disabled:opacity-60"
+      >
+        <span aria-hidden="true">📎</span>
+        {state.kind === 'uploading'
+          ? `Subiendo ${state.name}…`
+          : state.kind === 'done'
+            ? '✓ Comprobante subido — subir otro'
+            : alreadyUploaded
+              ? 'Subir otro comprobante'
+              : 'O subí el comprobante acá'}
+      </button>
+      <p className="mt-1 text-xs text-[color:var(--text-muted,#6b7280)]">
+        JPG, PNG, WebP o PDF — máx 5 MB.
+      </p>
+      {state.kind === 'error' ? (
+        <p role="alert" className="mt-2 text-xs text-red-700">
+          {state.message}
+        </p>
+      ) : null}
+    </div>
+  )
+}


### PR DESCRIPTION
Partial Batch D — infrastructure-only due to parallel-session tree reverts. Migration + bucket + upload API + admin signed-URL API + button + viewer components. The wiring edits on order schema/mapper/transfer page/admin detail page kept getting reverted before commit; will retry those in a follow-up PR.