### PR TITLE
feat(analytics): GA4 marketing-funnel event helpers

### DIFF
--- a/web/lib/analytics/marketing-events.ts
+++ b/web/lib/analytics/marketing-events.ts
@@ -1,0 +1,118 @@
+/**
+ * GA4 marketing-funnel event helpers for Nexa Paraguay.
+ *
+ * Mirrors the shape of commerce-events.ts but targets the service/lead
+ * funnel rather than ecommerce: hero CTA, intake wizard steps, tier
+ * selection, lead submission. All events fire on `window.gtag` so they
+ * show up in GA4 DebugView + the standard event reports.
+ *
+ * All functions are no-ops when gtag isn't on window (no consent, GA4
+ * not configured) — safe to call unconditionally from client components.
+ */
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
+function gtag(...args: unknown[]) {
+  if (typeof window === 'undefined' || !window.gtag) return
+  try {
+    window.gtag(...args)
+  } catch {
+    // Analytics failures must never break the prospect experience.
+  }
+}
+
+/**
+ * Hero primary/secondary CTA click. `location` lets us split same-action
+ * CTAs across multiple pages in GA4 (e.g. hero CTA on /home vs /programas).
+ */
+export function trackHeroCta(opts: {
+  label: string
+  href: string
+  location: string
+  tenant?: string
+}) {
+  gtag('event', 'cta_click', {
+    cta_location: opts.location,
+    cta_type: 'hero',
+    cta_label: opts.label,
+    cta_href: opts.href,
+    tenant: opts.tenant,
+  })
+}
+
+/** Intake wizard — user advanced to the next step with a selected answer. */
+export function trackWizardStep(opts: {
+  step: number
+  stepKey: string
+  answerKey: string
+  answerLabel: string
+  tenant?: string
+}) {
+  gtag('event', 'wizard_step', {
+    wizard_step: opts.step,
+    wizard_step_key: opts.stepKey,
+    wizard_answer_key: opts.answerKey,
+    wizard_answer_label: opts.answerLabel,
+    tenant: opts.tenant,
+  })
+}
+
+/**
+ * Intake wizard — final "Programa recomendado" screen rendered. This is the
+ * primary conversion signal before the user actually hits contact.
+ */
+export function trackWizardComplete(opts: {
+  recommendedTier: string
+  tenant?: string
+}) {
+  gtag('event', 'wizard_complete', {
+    recommended_tier: opts.recommendedTier,
+    tenant: opts.tenant,
+  })
+}
+
+/**
+ * Programs-comparison tier CTA click. `location` = which page the tier
+ * card was rendered on (home, /programas, /comparacion, /benelux, ...).
+ */
+export function trackTierCta(opts: {
+  tierId: string
+  tierName: string
+  location: string
+  tenant?: string
+}) {
+  gtag('event', 'tier_cta_click', {
+    tier_id: opts.tierId,
+    tier_name: opts.tierName,
+    cta_location: opts.location,
+    tenant: opts.tenant,
+  })
+}
+
+/**
+ * Lead submission — contact form, exit-intent modal, newsletter signup.
+ * `success` distinguishes forms that completed from those that fell back
+ * to mailto. `source` is the component name for funnel attribution.
+ */
+export function trackLeadSubmit(opts: {
+  source: string
+  success: boolean
+  tenant?: string
+}) {
+  gtag('event', opts.success ? 'lead_submit' : 'lead_fallback', {
+    lead_source: opts.source,
+    tenant: opts.tenant,
+  })
+  if (opts.success) {
+    // Also fire GA4's standard `generate_lead` event so GA4's built-in
+    // conversion reports pick it up without custom setup.
+    gtag('event', 'generate_lead', {
+      lead_source: opts.source,
+      tenant: opts.tenant,
+    })
+  }
+}


### PR DESCRIPTION
## Summary
New `web/lib/analytics/marketing-events.ts` module for the Nexa service/lead funnel, mirroring the shape of the existing `commerce-events.ts`.

Functions:
- `trackHeroCta({ label, href, location, tenant })` — hero primary/secondary CTA click
- `trackWizardStep({ step, stepKey, answerKey, answerLabel, tenant })` — intake wizard step advance
- `trackWizardComplete({ recommendedTier, tenant })` — final "Programa recomendado" render
- `trackTierCta({ tierId, tierName, location, tenant })` — programs-comparison tier CTA click
- `trackLeadSubmit({ source, success, tenant })` — contact / exit-intent / newsletter submission

All functions are no-ops when `window.gtag` isn't available (no analytics consent, GA4 not configured). `trackLeadSubmit` additionally fires GA4's standard `generate_lead` event so Conversion reports work without custom event configuration.

## Why a separate module from commerce-events.ts
- Different funnel: service-lead vs product-purchase
- Different event names: GA4 groups these into different conversion reports
- Different call sites: hero/wizard/programs-comparison don't touch the commerce path

## Scope
**This PR ships the lib only.** Wiring into hero, intake wizard, and programs-comparison happens in focused follow-up PRs — keeps each diff small and reviewable. All call sites are pure tracking calls with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)