### PR TITLE
feat(admin/inbox): pagination + bulk + export + assignment polish

### DIFF
--- a/supabase/migrations/20260422040000_leads_assigned_to.sql
+++ b/supabase/migrations/20260422040000_leads_assigned_to.sql
@@ -1,0 +1,14 @@
+-- /admin/inbox — lead assignment column.
+alter table public.leads
+  add column if not exists assigned_to text;
+
+create index if not exists leads_assigned_to_idx
+  on public.leads (assigned_to)
+  where assigned_to is not null;
+
+create index if not exists leads_unassigned_created_idx
+  on public.leads (created_at desc)
+  where assigned_to is null;
+
+comment on column public.leads.assigned_to is
+  'Email of the admin responsible for this lead. Null = unassigned. Validated against ADMIN_EMAILS at write time.';

--- a/web/app/api/admin/leads/bulk/route.ts
+++ b/web/app/api/admin/leads/bulk/route.ts
@@ -1,0 +1,85 @@
+/**
+ * POST /api/admin/leads/bulk
+ * Apply one patch across multiple lead ids. Admin-gated. Max 200 ids.
+ * Supported ops: status, close_reason, assigned_to.
+ */
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { checkAdmin, isAdminEmail } from '@/lib/auth/admin'
+import { createClient } from '@/lib/supabase/server'
+import { logger } from '@/lib/logger'
+
+export const runtime = 'nodejs'
+
+const BulkSchema = z.object({
+  ids: z.array(z.string().uuid()).min(1).max(200),
+  status: z.enum(['new', 'contacted', 'qualified', 'closed']).optional(),
+  close_reason: z.enum(['won', 'lost_not_fit', 'lost_no_response', 'lost_other']).nullable().optional(),
+  assigned_to: z.string().email().nullable().optional(),
+})
+
+export async function POST(req: Request) {
+  const admin = await checkAdmin()
+  if (!admin.ok) return NextResponse.json({ error: admin.reason }, { status: admin.status })
+
+  let body: unknown
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'invalid json' }, { status: 400 }) }
+
+  const parsed = BulkSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: 'validation', detail: parsed.error.flatten() }, { status: 400 })
+
+  const { ids, status, close_reason, assigned_to } = parsed.data
+  if (assigned_to !== undefined && assigned_to !== null && !isAdminEmail(assigned_to)) {
+    return NextResponse.json({ error: 'invalid_assignee' }, { status: 400 })
+  }
+  if (status === undefined && close_reason === undefined && assigned_to === undefined) {
+    return NextResponse.json({ error: 'no_op_specified' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const { data: current, error: loadErr } = await supabase
+    .from('leads')
+    .select('id, status, contacted_at, qualified_at, closed_at')
+    .in('id', ids)
+  if (loadErr) return NextResponse.json({ error: 'lookup_failed' }, { status: 500 })
+
+  const currentById = new Map(
+    ((current ?? []) as Array<{ id: string; status: string; contacted_at: string | null; qualified_at: string | null; closed_at: string | null }>).map((r) => [r.id, r]),
+  )
+
+  const now = new Date().toISOString()
+  const basePatch: Record<string, unknown> = {}
+  if (close_reason !== undefined) basePatch.close_reason = close_reason
+  if (assigned_to !== undefined) basePatch.assigned_to = assigned_to
+  if (status !== undefined) basePatch.status = status
+
+  const needContacted: string[] = []
+  const needQualified: string[] = []
+  const needClosed: string[] = []
+  if (status) {
+    for (const id of ids) {
+      const row = currentById.get(id)
+      if (!row) continue
+      if (status === 'contacted' && !row.contacted_at) needContacted.push(id)
+      if (status === 'qualified' && !row.qualified_at) needQualified.push(id)
+      if (status === 'closed' && !row.closed_at) needClosed.push(id)
+    }
+  }
+
+  const baseIds = ids.filter((id) => !needContacted.includes(id) && !needQualified.includes(id) && !needClosed.includes(id))
+  const updates: Array<PromiseLike<{ error: { message: string } | null }>> = []
+  if (baseIds.length > 0) updates.push(supabase.from('leads').update(basePatch).in('id', baseIds) as unknown as PromiseLike<{ error: { message: string } | null }>)
+  if (needContacted.length > 0) updates.push(supabase.from('leads').update({ ...basePatch, contacted_at: now }).in('id', needContacted) as unknown as PromiseLike<{ error: { message: string } | null }>)
+  if (needQualified.length > 0) updates.push(supabase.from('leads').update({ ...basePatch, qualified_at: now }).in('id', needQualified) as unknown as PromiseLike<{ error: { message: string } | null }>)
+  if (needClosed.length > 0) updates.push(supabase.from('leads').update({ ...basePatch, closed_at: now }).in('id', needClosed) as unknown as PromiseLike<{ error: { message: string } | null }>)
+
+  const results = await Promise.all(updates)
+  const errors = results.map((r) => r.error).filter((e): e is { message: string } => !!e)
+  if (errors.length > 0) {
+    logger.error('Bulk update partial failure', { by: admin.user.email, errors: errors.map((e) => e.message) })
+    return NextResponse.json({ error: 'bulk_update_partial' }, { status: 500 })
+  }
+
+  logger.info('Bulk lead update', { by: admin.user.email, count: ids.length, ops: Object.keys(basePatch) })
+  return NextResponse.json({ ok: true, count: ids.length })
+}

--- a/web/app/api/admin/leads/export/route.ts
+++ b/web/app/api/admin/leads/export/route.ts
@@ -1,0 +1,80 @@
+/**
+ * GET /api/admin/leads/export?site=&status=&assignee=&q=
+ * CSV export of inbox leads matching the filter set. Admin-gated.
+ */
+import { NextResponse } from 'next/server'
+import { checkAdmin } from '@/lib/auth/admin'
+import { createClient } from '@/lib/supabase/server'
+import { logger } from '@/lib/logger'
+
+export const runtime = 'nodejs'
+
+export async function GET(req: Request) {
+  const admin = await checkAdmin()
+  if (!admin.ok) return NextResponse.json({ error: admin.reason }, { status: admin.status })
+
+  const url = new URL(req.url)
+  const site = url.searchParams.get('site') || undefined
+  const status = url.searchParams.get('status') || undefined
+  const assignee = url.searchParams.get('assignee') || undefined
+  const q = url.searchParams.get('q') || undefined
+
+  const supabase = await createClient()
+  let query = supabase
+    .from('leads')
+    .select('id, created_at, site_slug, locale, name, email, phone, country, program_interest, objective, status, assigned_to, close_reason, contacted_at, qualified_at, closed_at, source, referer, utm')
+    .order('created_at', { ascending: false })
+    .limit(10_000)
+
+  if (site) query = query.eq('site_slug', site)
+  if (status && ['new', 'contacted', 'qualified', 'closed'].includes(status)) query = query.eq('status', status)
+  if (assignee === 'unassigned') query = query.is('assigned_to', null)
+  else if (assignee) query = query.eq('assigned_to', assignee)
+  if (q && q.trim()) {
+    const esc = q.trim().replace(/[%,]/g, '')
+    query = query.or(`name.ilike.%${esc}%,email.ilike.%${esc}%,objective.ilike.%${esc}%`)
+  }
+
+  const { data, error } = await query
+  if (error) {
+    logger.error('inbox CSV export query failed', { error: error.message })
+    return NextResponse.json({ error: 'query_failed' }, { status: 500 })
+  }
+
+  const rows = (data ?? []) as Array<Record<string, unknown>>
+  const csv = toCsv(rows)
+  const filename = `inbox-leads-${new Date().toISOString().slice(0, 10)}.csv`
+  logger.info('Inbox CSV export', { by: admin.user.email, rows: rows.length })
+
+  return new Response(csv, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+function toCsv(rows: Array<Record<string, unknown>>): string {
+  const cols = ['created_at', 'site_slug', 'locale', 'name', 'email', 'phone', 'country', 'program_interest', 'status', 'assigned_to', 'close_reason', 'contacted_at', 'qualified_at', 'closed_at', 'source', 'referer', 'utm_source', 'utm_medium', 'utm_campaign', 'objective']
+  const lines = [cols.join(',')]
+  for (const row of rows) {
+    const utm = (row.utm && typeof row.utm === 'object' ? row.utm : {}) as Record<string, string>
+    const flat: Record<string, unknown> = {
+      ...row,
+      utm_source: utm.utm_source ?? utm.source ?? '',
+      utm_medium: utm.utm_medium ?? utm.medium ?? '',
+      utm_campaign: utm.utm_campaign ?? utm.campaign ?? '',
+    }
+    lines.push(cols.map((c) => csvCell(flat[c])).join(','))
+  }
+  return lines.join('\n') + '\n'
+}
+
+function csvCell(v: unknown): string {
+  if (v === null || v === undefined) return ''
+  const s = typeof v === 'string' ? v : String(v)
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`
+  return s
+}


### PR DESCRIPTION
Re-applies the inbox polish work that got lost to branch chaos:

- Migration 20260422040000 — add `assigned_to text` + indexes
- PATCH /api/admin/leads/[id] — accepts assigned_to (validated vs ADMIN_EMAILS)
- POST /api/admin/leads/bulk — status/close_reason/assigned_to in one call, max 200 ids
- GET /api/admin/leads/export — CSV export respecting filters, 10k row cap
- /admin/inbox — 25/page pagination, assignee filter, bulk action bar, drawer assignment dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)