### PR TITLE
fix(lint): use next/link for internal /admin navigation

### DIFF
--- a/web/app/admin/inbox/inbox-dashboard.tsx
+++ b/web/app/admin/inbox/inbox-dashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import type { InboxLead, InboxStats } from './page'
 
 type Filters = { site?: string; status?: string; q?: string; assignee?: string }
@@ -132,9 +133,9 @@ export function InboxDashboard({
               <a href={exportHref} className="text-slate-600 hover:text-slate-900 hover:underline">
                 Export CSV
               </a>
-              <a href="/admin" className="text-slate-600 hover:text-slate-900 hover:underline">
+              <Link href="/admin" className="text-slate-600 hover:text-slate-900 hover:underline">
                 ← Back to admin
-              </a>
+              </Link>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Unblocks every other PR's Lint & Typecheck.

`@next/next/no-html-link-for-pages` treats `<a href="/internal">` as an **error** (not a warning) when the href points at an internal app-router route. After #264 landed, `inbox-dashboard.tsx:135` had a raw `<a href="/admin">`, which ESLint rejects. Every PR opened after #264 has failed Lint on this single file even when the PR doesn't touch it.

## Change
Swap the one anchor for `<Link>` + add the `next/link` import.

## Expected impact
All of PR #265, #266, #268, #271, #272 (and any others blocked on Lint for the same reason) can now pass Lint once their branches rebase on Main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)