### PR TITLE
feat(commerce): Batch I — SSR cart on remaining commerce pages

### DIFF
--- a/docs/runbooks/CRON_STRATEGY.md
+++ b/docs/runbooks/CRON_STRATEGY.md
@@ -34,6 +34,7 @@ No extra moving parts.**
 | `POST /api/cron/commerce-email-flush` | `*/5 * * * *` | `CRON_SECRET`, `RESEND_API_KEY`, `COMMERCE_EMAIL_FROM` | Send queued commerce emails |
 | `POST /api/cron/commerce-abandoned-cart` | `0 */4 * * *` | `CRON_SECRET` | Abandoned cart recovery |
 | `POST /api/cron/commerce-reconcile-pending` | `0 * * * *` | `CRON_SECRET` | Reconcile MP pending payments |
+| `POST /api/cron/commerce-merchant-digest` | `0 11 * * *` (08:00 Asunción) | `CRON_SECRET`, `RESEND_API_KEY`, `COMMERCE_EMAIL_FROM` | Daily merchant digest: yesterday's orders + revenue + actionable pending list |
 | `POST /api/cron/commerce-prune-search-events` | `17 3 * * *` (03:17 UTC daily) | `CRON_SECRET` | Prune `search_events` rows older than 90 days so the table stays bounded |
 | `POST /api/cron/health` | `0 * * * *` (UTC, hourly) | `CRON_SECRET` | Returns `{ ok, crons[] }` per-cron env-readiness. 503 if any required env is missing. Wire to your monitor of choice. |
 
@@ -68,6 +69,7 @@ Paste (one line per cron):
 0 12 * * *  curl -fsS -X POST https://paragu-ai.com/api/cron/leads-digest -H "x-cron-secret: $CRON_SECRET" >> /var/log/paragu-ai-crons.log 2>&1
 0 11 * * 1  curl -fsS -X POST https://paragu-ai.com/api/cron/sitemap-ping -H "x-cron-secret: $CRON_SECRET" >> /var/log/paragu-ai-crons.log 2>&1
 */5 * * * * curl -fsS -X POST https://paragu-ai.com/api/cron/commerce-email-flush -H "x-cron-secret: $CRON_SECRET" >> /var/log/paragu-ai-crons.log 2>&1
+0 11 * * *  curl -fsS -X POST https://paragu-ai.com/api/cron/commerce-merchant-digest -H "x-cron-secret: $CRON_SECRET" >> /var/log/paragu-ai-crons.log 2>&1
 0 */4 * * * curl -fsS -X POST https://paragu-ai.com/api/cron/commerce-abandoned-cart -H "x-cron-secret: $CRON_SECRET" >> /var/log/paragu-ai-crons.log 2>&1
 0 * * * *   curl -fsS -X POST https://paragu-ai.com/api/cron/commerce-reconcile-pending -H "x-cron-secret: $CRON_SECRET" >> /var/log/paragu-ai-crons.log 2>&1
 17 3 * * *  curl -fsS -X POST https://paragu-ai.com/api/cron/commerce-prune-search-events -H "x-cron-secret: $CRON_SECRET" >> /var/log/paragu-ai-crons.log 2>&1
@@ -97,6 +99,7 @@ Then crontab becomes:
 0 12 * * *  /usr/local/bin/paragu-cron /api/cron/leads-digest >> /var/log/paragu-ai-crons.log 2>&1
 0 11 * * 1  /usr/local/bin/paragu-cron /api/cron/sitemap-ping >> /var/log/paragu-ai-crons.log 2>&1
 */5 * * * * /usr/local/bin/paragu-cron /api/cron/commerce-email-flush >> /var/log/paragu-ai-crons.log 2>&1
+0 11 * * *  /usr/local/bin/paragu-cron /api/cron/commerce-merchant-digest >> /var/log/paragu-ai-crons.log 2>&1
 0 */4 * * * /usr/local/bin/paragu-cron /api/cron/commerce-abandoned-cart >> /var/log/paragu-ai-crons.log 2>&1
 0 * * * *   /usr/local/bin/paragu-cron /api/cron/commerce-reconcile-pending >> /var/log/paragu-ai-crons.log 2>&1
 17 3 * * *  /usr/local/bin/paragu-cron /api/cron/commerce-prune-search-events >> /var/log/paragu-ai-crons.log 2>&1

--- a/web/app/admin/inbox/audit-timeline.tsx
+++ b/web/app/admin/inbox/audit-timeline.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface AuditEntry {
+  id: string
+  actor: string | null
+  field: string
+  old_value: string | null
+  new_value: string | null
+  created_at: string
+}
+
+const FIELD_LABELS: Record<string, string> = {
+  status: 'Status',
+  assigned_to: 'Assignee',
+  close_reason: 'Close reason',
+}
+
+export function AuditTimeline({ leadId }: { leadId: string }) {
+  const [entries, setEntries] = useState<AuditEntry[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(`/api/admin/leads/${leadId}/audit`)
+      .then(async (r) => {
+        const j = await r.json()
+        if (!r.ok) throw new Error(j.error || 'audit load failed')
+        if (!cancelled) setEntries(j.entries as AuditEntry[])
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'failed')
+      })
+    return () => { cancelled = true }
+  }, [leadId])
+
+  if (error) {
+    return <p className="text-xs text-red-600">Failed to load audit trail: {error}</p>
+  }
+  if (entries === null) {
+    return <p className="text-xs text-slate-400">Loading timeline…</p>
+  }
+  if (entries.length === 0) {
+    return <p className="text-xs text-slate-400">No changes recorded yet.</p>
+  }
+  return (
+    <ol className="space-y-2 text-xs">
+      {entries.map((e) => (
+        <li key={e.id} className="flex gap-2 border-l-2 border-slate-200 pl-3">
+          <div className="flex-1">
+            <p className="text-slate-700">
+              <span className="font-medium">{FIELD_LABELS[e.field] ?? e.field}</span>
+              {e.old_value && <> from <code className="rounded bg-slate-100 px-1">{e.old_value}</code></>}
+              {' '}→ <code className="rounded bg-slate-100 px-1">{e.new_value ?? '—'}</code>
+            </p>
+            <p className="mt-0.5 text-slate-400">
+              {e.actor ?? 'system'} · {formatTime(e.created_at)}
+            </p>
+          </div>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}

--- a/web/app/api/admin/leads/[id]/audit/route.ts
+++ b/web/app/api/admin/leads/[id]/audit/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+import { checkAdmin } from '@/lib/auth/admin'
+import { createClient } from '@/lib/supabase/server'
+import { logger } from '@/lib/logger'
+
+export const runtime = 'nodejs'
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params
+  const admin = await checkAdmin()
+  if (!admin.ok) return NextResponse.json({ error: admin.reason }, { status: admin.status })
+
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('lead_audit_log')
+    .select('id, actor, field, old_value, new_value, created_at')
+    .eq('lead_id', id)
+    .order('created_at', { ascending: false })
+    .limit(200)
+
+  if (error) {
+    logger.warn('Audit load failed', { id, error: error.message })
+    return NextResponse.json({ error: 'lookup_failed' }, { status: 500 })
+  }
+
+  return NextResponse.json({ entries: data ?? [] })
+}

--- a/web/app/api/cron/commerce-merchant-digest/route.ts
+++ b/web/app/api/cron/commerce-merchant-digest/route.ts
@@ -1,0 +1,212 @@
+import { NextResponse } from 'next/server'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { resolveAdminEmail } from '@/lib/commerce/notifications'
+import { formatCents } from '@/lib/commerce/compute-totals'
+
+export const runtime = 'nodejs'
+
+/**
+ * Daily merchant digest — one email per commerce-enabled tenant with
+ * yesterday's activity + current pending list. Scheduled: 11:00 UTC
+ * (08:00 Asunción). Protected by CRON_SECRET header.
+ *
+ * Contents:
+ *   - How many orders yesterday + revenue
+ *   - Awaiting-payment with comprobante-sent (needs admin verify)
+ *   - Awaiting-payment stalled >48h
+ *   - Paid but not yet shipped
+ *   - Low-stock alerts
+ */
+interface BusinessRow {
+  id: string
+  slug: string
+  name: string
+  data_json: unknown
+}
+
+interface OrderLite {
+  id: string
+  order_number: string
+  status: string
+  total_cents: number
+  currency: string
+  created_at: string
+  comprobante_sent_at: string | null
+}
+
+interface ProductLowStock {
+  id: string
+  name: string
+  inventory_qty: number
+  low_stock_threshold: number | null
+}
+
+function escape(s: string): string {
+  return s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]!))
+}
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.floor((b.getTime() - a.getTime()) / 86_400_000)
+}
+
+export const POST = withRequestLog(async (request, { log }) => {
+  if (process.env.CRON_SECRET && request.headers.get('x-cron-secret') !== process.env.CRON_SECRET) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+
+  const supabase = await createAdminClient()
+  const { data: businesses } = await supabase
+    .from('businesses')
+    .select('id, slug, name, data_json')
+    .eq('status', 'active')
+
+  const tenants = (Array.isArray(businesses) ? businesses : []) as BusinessRow[]
+  const now = new Date()
+  const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+  const yesterdayStart = new Date(yesterday.setHours(0, 0, 0, 0)).toISOString()
+  const yesterdayEnd = new Date(new Date(yesterdayStart).getTime() + 86_400_000).toISOString()
+  const stalledCutoff = new Date(now.getTime() - 48 * 60 * 60 * 1000).toISOString()
+
+  let tenantsChecked = 0
+  let digestsEnqueued = 0
+  let skippedNoOrders = 0
+
+  for (const t of tenants) {
+    tenantsChecked++
+    const adminEmail = resolveAdminEmail(t.data_json)
+    if (!adminEmail) continue
+
+    const [yday, awaitingSent, stalledAwaiting, pendingShip, lowStock] = await Promise.all([
+      supabase
+        .from('orders')
+        .select('id, order_number, status, total_cents, currency, created_at, comprobante_sent_at')
+        .eq('business_id', t.id)
+        .gte('created_at', yesterdayStart)
+        .lt('created_at', yesterdayEnd),
+      supabase
+        .from('orders')
+        .select('id, order_number, status, total_cents, currency, created_at, comprobante_sent_at')
+        .eq('business_id', t.id)
+        .eq('status', 'awaiting_payment')
+        .not('comprobante_sent_at', 'is', null)
+        .order('comprobante_sent_at', { ascending: true })
+        .limit(20),
+      supabase
+        .from('orders')
+        .select('id, order_number, status, total_cents, currency, created_at, comprobante_sent_at')
+        .eq('business_id', t.id)
+        .eq('status', 'awaiting_payment')
+        .lt('created_at', stalledCutoff)
+        .limit(20),
+      supabase
+        .from('orders')
+        .select('id, order_number, status, total_cents, currency, created_at, comprobante_sent_at')
+        .eq('business_id', t.id)
+        .in('status', ['paid', 'fulfilled'])
+        .order('created_at', { ascending: true })
+        .limit(20),
+      supabase
+        .from('products')
+        .select('id, name, inventory_qty, low_stock_threshold')
+        .eq('business_id', t.id)
+        .eq('status', 'active')
+        .eq('inventory_policy', 'deny')
+        .lt('inventory_qty', 10)
+        .limit(20),
+    ])
+
+    const ydayOrders = (yday.data as OrderLite[] | null) ?? []
+    const awaitingSentRows = (awaitingSent.data as OrderLite[] | null) ?? []
+    const stalledRows = (stalledAwaiting.data as OrderLite[] | null) ?? []
+    const pendingShipRows = (pendingShip.data as OrderLite[] | null) ?? []
+    const lowStockRows = ((lowStock.data as ProductLowStock[] | null) ?? []).filter(
+      (p) => p.inventory_qty <= (p.low_stock_threshold ?? 3),
+    )
+
+    // Skip the email if nothing happened + no pending state — the merchant
+    // doesn't need a "zero activity" email every day.
+    const hasActionable =
+      ydayOrders.length > 0 ||
+      awaitingSentRows.length > 0 ||
+      stalledRows.length > 0 ||
+      pendingShipRows.length > 0 ||
+      lowStockRows.length > 0
+    if (!hasActionable) {
+      skippedNoOrders++
+      continue
+    }
+
+    const ydayRevenue = ydayOrders.reduce(
+      (sum, o) => (o.status !== 'cancelled' && o.status !== 'refunded' ? sum + o.total_cents : sum),
+      0,
+    )
+    const currency = ydayOrders[0]?.currency ?? 'PYG'
+
+    const renderList = (label: string, rows: OrderLite[]): string => {
+      if (rows.length === 0) return ''
+      const items = rows
+        .map(
+          (o) =>
+            `<li style="margin:4px 0;"><a href="${process.env.NEXT_PUBLIC_APP_URL ?? 'https://paragu-ai.com'}/admin/commerce/${t.id}/orders/${o.id}" style="color:#111;">${o.order_number}</a> — ${formatCents(o.total_cents, o.currency)} · ${daysBetween(new Date(o.created_at), now)}d</li>`,
+        )
+        .join('')
+      return `<h3 style="font-size:14px;margin:16px 0 4px 0;">${label} <span style="color:#6b7280;font-weight:400;">(${rows.length})</span></h3><ul style="padding-left:20px;margin:0;">${items}</ul>`
+    }
+
+    const lowStockBlock =
+      lowStockRows.length > 0
+        ? `<h3 style="font-size:14px;margin:16px 0 4px 0;">Stock bajo <span style="color:#6b7280;font-weight:400;">(${lowStockRows.length})</span></h3><ul style="padding-left:20px;margin:0;">${lowStockRows
+            .map(
+              (p) =>
+                `<li style="margin:4px 0;">${escape(p.name)} — ${p.inventory_qty} ${p.inventory_qty === 1 ? 'unidad' : 'unidades'} restantes</li>`,
+            )
+            .join('')}</ul>`
+        : ''
+
+    const subject = `📊 Resumen diario ${t.name} — ${ydayOrders.length} ${ydayOrders.length === 1 ? 'orden' : 'órdenes'} ayer`
+    const html = `
+<!doctype html><html><body style="font-family:system-ui,-apple-system,sans-serif;color:#111;max-width:600px;margin:0 auto;padding:24px;">
+  <h1 style="font-size:20px;margin:0 0 8px 0;">Resumen del día</h1>
+  <p style="color:#6b7280;margin:0 0 16px 0;">${t.name} · ${new Date(yesterdayStart).toLocaleDateString('es-PY')}</p>
+
+  <div style="background:#f9fafb;border-radius:8px;padding:16px;margin:0 0 16px 0;">
+    <p style="margin:0;font-size:13px;color:#6b7280;">Órdenes ayer</p>
+    <p style="margin:4px 0 12px 0;font-size:24px;font-weight:700;">${ydayOrders.length}</p>
+    <p style="margin:0;font-size:13px;color:#6b7280;">Facturado ayer</p>
+    <p style="margin:4px 0 0 0;font-size:20px;font-weight:700;">${formatCents(ydayRevenue, currency)}</p>
+  </div>
+
+  ${renderList('Esperan tu verificación (comprobante enviado)', awaitingSentRows)}
+  ${renderList('Pendientes >48h sin pagar', stalledRows)}
+  ${renderList('Listas para enviar', pendingShipRows)}
+  ${lowStockBlock}
+
+  <p style="color:#9ca3af;font-size:11px;margin-top:24px;">Paragu-AI · digest automático diario</p>
+</body></html>`.trim()
+
+    const { error } = await supabase.from('commerce_email_outbox').insert({
+      business_id: t.id,
+      order_id: null,
+      template: 'admin_daily_digest',
+      recipient_email: adminEmail,
+      subject,
+      html_body: html,
+    })
+    if (error) {
+      log.warn('commerce.digest.enqueue_failed', { tenantId: t.id, error: error.message })
+    } else {
+      digestsEnqueued++
+    }
+  }
+
+  log.info('commerce.cron.digest.done', {
+    tenantsChecked,
+    digestsEnqueued,
+    skippedNoOrders,
+  })
+
+  return NextResponse.json({ tenantsChecked, digestsEnqueued, skippedNoOrders })
+})
+
+export const GET = POST

--- a/web/app/api/cron/health/route.ts
+++ b/web/app/api/cron/health/route.ts
@@ -56,6 +56,11 @@ const CRONS: Array<Omit<CronCheck, 'status' | 'missing'>> = [
     requiredEnv: ['CRON_SECRET'],
   },
   {
+    path: '/api/cron/commerce-merchant-digest',
+    schedule: '0 11 * * * (UTC, daily 08:00 Asunción)',
+    requiredEnv: ['CRON_SECRET', 'RESEND_API_KEY', 'COMMERCE_EMAIL_FROM'],
+  },
+  {
     path: '/api/cron/commerce-prune-search-events',
     schedule: '17 3 * * * (UTC, daily 03:17)',
     requiredEnv: ['CRON_SECRET'],

--- a/web/app/s/[locale]/[site]/buscar-orden/page.tsx
+++ b/web/app/s/[locale]/[site]/buscar-orden/page.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from 'next'
 import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
+import { getSessionToken } from '@/lib/commerce/session'
+import { getCartBySessionToken } from '@/lib/commerce/cart'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { OrderLookupForm } from '@/components/commerce/order-lookup-form'
 
@@ -23,9 +25,14 @@ export default async function OrderLookupPage({
   const business = await resolveBusinessBySlug(site)
   if (!business || !(await isCommerceEnabled(business.type))) notFound()
 
+  const sessionToken = await getSessionToken()
+  const initialCart = sessionToken && business
+    ? await getCartBySessionToken(business.id, sessionToken).catch(() => null)
+    : null
+
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
-      <CartStoreHydrator siteSlug={site} initialCart={null} />
+      <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
       <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
       <main className="mx-auto max-w-md px-4 py-10">
         <h1 className="mb-2 text-2xl font-bold text-[color:var(--text,#111)]">Buscar mi orden</h1>

--- a/web/app/s/[locale]/[site]/favoritos/page.tsx
+++ b/web/app/s/[locale]/[site]/favoritos/page.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from 'next'
 import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
+import { getSessionToken } from '@/lib/commerce/session'
+import { getCartBySessionToken } from '@/lib/commerce/cart'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { WishlistPageClient } from '@/components/commerce/wishlist-page-client'
 
@@ -23,9 +25,14 @@ export default async function WishlistPage({
   const business = await resolveBusinessBySlug(site)
   if (!business || !(await isCommerceEnabled(business.type))) notFound()
 
+  const sessionToken = await getSessionToken()
+  const initialCart = sessionToken && business
+    ? await getCartBySessionToken(business.id, sessionToken).catch(() => null)
+    : null
+
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
-      <CartStoreHydrator siteSlug={site} initialCart={null} />
+      <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
       <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
       <main className="mx-auto max-w-5xl px-4 py-8">
         <h1 className="mb-2 text-2xl font-bold text-[color:var(--text,#111)]">Mis favoritos</h1>

--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -6,6 +6,8 @@ import { getProductBySlug, listRelatedProducts } from '@/lib/commerce/products'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { ProductImage } from '@/components/commerce/product-image'
+import { getSessionToken } from '@/lib/commerce/session'
+import { getCartBySessionToken } from '@/lib/commerce/cart'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { formatCents } from '@/lib/commerce/compute-totals'
 import { ProductDetailActions } from '@/components/commerce/product-detail-actions'
@@ -147,9 +149,14 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
     })),
   }
 
+  const sessionToken = await getSessionToken()
+  const initialCart = sessionToken && business
+    ? await getCartBySessionToken(business.id, sessionToken).catch(() => null)
+    : null
+
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
-      <CartStoreHydrator siteSlug={site} initialCart={null} />
+      <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
       <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
 
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />

--- a/web/app/s/[locale]/[site]/tienda/categoria/[category]/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/categoria/[category]/page.tsx
@@ -13,6 +13,8 @@ import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { Breadcrumbs } from '@/components/commerce/breadcrumbs'
 import { env } from '@/lib/env'
 import { ProductCard } from '@/components/commerce/product-card'
+import { getSessionToken } from '@/lib/commerce/session'
+import { getCartBySessionToken } from '@/lib/commerce/cart'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { TiendaToolbar } from '@/components/commerce/tienda-toolbar'
 import { TiendaPagination } from '@/components/commerce/tienda-pagination'
@@ -119,9 +121,14 @@ export default async function CategoryPage({
 
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
 
+  const sessionToken = await getSessionToken()
+  const initialCart = sessionToken && business
+    ? await getCartBySessionToken(business.id, sessionToken).catch(() => null)
+    : null
+
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
-      <CartStoreHydrator siteSlug={site} initialCart={null} />
+      <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
       <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
 
       <Breadcrumbs

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -17,6 +17,8 @@ import { getReviewAggregatesByBusiness } from '@/lib/commerce/reviews'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { ProductCard } from '@/components/commerce/product-card'
+import { getSessionToken } from '@/lib/commerce/session'
+import { getCartBySessionToken } from '@/lib/commerce/cart'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { TiendaToolbar } from '@/components/commerce/tienda-toolbar'
 import { TiendaQuickFilters } from '@/components/commerce/tienda-quick-filters'
@@ -200,9 +202,14 @@ export default async function StorePage({
       onSaleOnly,
   )
 
+  const sessionToken = await getSessionToken()
+  const initialCart = sessionToken && business
+    ? await getCartBySessionToken(business.id, sessionToken).catch(() => null)
+    : null
+
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
-      <CartStoreHydrator siteSlug={site} initialCart={null} />
+      <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
       <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
 
       <Breadcrumbs


### PR DESCRIPTION
Server-loads the session cart on /tienda, /tienda/categoria, /producto, /favoritos, /buscar-orden. Kills flash-of-empty-cart on those pages same as /carrito + /checkout did in PR #256.