### PR TITLE
feat(commerce): Batch J — progress indicator + receipt link + admin notes + idempotent submit

### DIFF
--- a/web/app/admin/commerce/[businessId]/orders/[id]/page.tsx
+++ b/web/app/admin/commerce/[businessId]/orders/[id]/page.tsx
@@ -5,6 +5,7 @@ import { formatCents } from '@/lib/commerce/compute-totals'
 import { OrderActions } from '@/components/admin/commerce/order-actions'
 import { OrderRefundButton } from '@/components/admin/commerce/order-refund-button'
 import { ComprobanteViewer } from '@/components/admin/commerce/comprobante-viewer'
+import { OrderNoteForm } from '@/components/admin/commerce/order-note-form'
 import { OrderTimeline } from '@/components/admin/commerce/order-timeline'
 import { listOrderEvents } from '@/lib/commerce/order-events'
 
@@ -139,6 +140,7 @@ export default async function AdminOrderDetail({ params }: { params: Promise<{ b
         <section className="mb-6">
           <h2 className="mb-3 text-sm font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">Historial</h2>
           <OrderTimeline events={events} />
+          <OrderNoteForm businessId={businessId} orderId={order.id} />
         </section>
         <OrderActions businessId={businessId} orderId={order.id} currentStatus={order.status} />
         <OrderRefundButton businessId={businessId} orderId={order.id} currentStatus={order.status} />

--- a/web/app/api/admin/commerce/[businessId]/orders/[id]/notes/route.ts
+++ b/web/app/api/admin/commerce/[businessId]/orders/[id]/notes/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { withRequestLog } from '@/lib/api/with-request-log'
+import { requireAdminUser } from '@/lib/commerce/admin-auth'
+import { recordOrderEvent } from '@/lib/commerce/order-events'
+
+export const runtime = 'nodejs'
+
+const BodySchema = z.object({
+  note: z.string().trim().min(1).max(500),
+})
+
+export const POST = withRequestLog<{ businessId: string; id: string }>(
+  async (req, { log }, { businessId, id }) => {
+    const admin = await requireAdminUser()
+    if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+    let json: unknown
+    try {
+      json = await req.json()
+    } catch {
+      return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+    }
+    const parsed = BodySchema.safeParse(json)
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'validation' }, { status: 400 })
+    }
+
+    await recordOrderEvent({
+      businessId,
+      orderId: id,
+      eventType: 'note_added',
+      actorId: admin.id,
+      actorLabel: admin.email ?? null,
+      note: parsed.data.note,
+    })
+
+    log.info('admin.commerce.order.note_added', { businessId, orderId: id })
+    return NextResponse.json({ ok: true })
+  },
+)

--- a/web/app/s/[locale]/[site]/carrito/page.tsx
+++ b/web/app/s/[locale]/[site]/carrito/page.tsx
@@ -4,6 +4,7 @@ import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
+import { CheckoutProgressIndicator } from '@/components/commerce/checkout-progress-indicator'
 import { CartPageClient } from '@/components/commerce/cart-page-client'
 import { getSessionToken } from '@/lib/commerce/session'
 import { getCartBySessionToken } from '@/lib/commerce/cart'
@@ -30,6 +31,7 @@ export default async function CartPage({ params }: { params: Promise<{ site: str
       <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
       <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
       <main className="mx-auto max-w-4xl px-4 py-8">
+        <CheckoutProgressIndicator current="cart" />
         <h1 className="mb-6 text-2xl font-bold">Tu carrito</h1>
         <CartPageClient siteSlug={site} locale={locale} />
         <div className="mt-6">

--- a/web/app/s/[locale]/[site]/checkout/page.tsx
+++ b/web/app/s/[locale]/[site]/checkout/page.tsx
@@ -4,6 +4,7 @@ import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { CheckoutForm } from '@/components/commerce/checkout-form'
+import { CheckoutProgressIndicator } from '@/components/commerce/checkout-progress-indicator'
 import { CheckoutTrustStrip } from '@/components/commerce/checkout-trust-strip'
 import { CheckoutTracker } from '@/components/commerce/checkout-tracker'
 import { getSessionToken } from '@/lib/commerce/session'
@@ -33,6 +34,7 @@ export default async function CheckoutPage({ params }: { params: Promise<{ site:
       <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
       <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
       <main className="mx-auto max-w-5xl px-4 py-8">
+        <CheckoutProgressIndicator current="checkout" />
         <h1 className="mb-6 text-2xl font-bold">Finalizar compra</h1>
         <CheckoutTrustStrip />
         <CheckoutForm siteSlug={site} locale={locale} />

--- a/web/app/s/[locale]/[site]/checkout/transfer/[orderId]/page.tsx
+++ b/web/app/s/[locale]/[site]/checkout/transfer/[orderId]/page.tsx
@@ -4,6 +4,7 @@ import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { getOrder, CheckoutError } from '@/lib/commerce/orders'
 import { formatCents } from '@/lib/commerce/compute-totals'
 import { listCredentialsForBusiness } from '@/lib/commerce/payment-credentials'
+import { CheckoutProgressIndicator } from '@/components/commerce/checkout-progress-indicator'
 import { ComprobanteSentButton } from '@/components/commerce/comprobante-sent-button'
 import { ComprobanteUploadButton } from '@/components/commerce/comprobante-upload-button'
 
@@ -55,6 +56,7 @@ export default async function TransferInstructionsPage({
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <main className="mx-auto max-w-2xl px-4 py-10">
+        <CheckoutProgressIndicator current="payment" />
         <div className="rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-6 shadow-sm">
           <h1 className="text-2xl font-bold text-[color:var(--text,#111)]">
             Pedido {order.orderNumber} — esperando transferencia

--- a/web/components/admin/commerce/order-note-form.tsx
+++ b/web/components/admin/commerce/order-note-form.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface Props {
+  businessId: string
+  orderId: string
+}
+
+/**
+ * Tiny form on admin order detail for recording internal notes. Each
+ * submit writes a `note_added` row to order_events so the timeline
+ * preserves context the operator added. Not visible to the customer.
+ */
+export function OrderNoteForm({ businessId, orderId }: Props) {
+  const router = useRouter()
+  const [note, setNote] = useState('')
+  const [state, setState] = useState<'idle' | 'submitting' | 'error'>('idle')
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (!note.trim() || state === 'submitting') return
+    setState('submitting')
+    try {
+      const res = await fetch(`/api/admin/commerce/${businessId}/orders/${orderId}/notes`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note }),
+      })
+      if (!res.ok) throw new Error('failed')
+      setNote('')
+      setState('idle')
+      router.refresh()
+    } catch {
+      setState('error')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4">
+      <label className="mb-1 block text-xs font-semibold uppercase text-[color:var(--text-muted,#6b7280)]">
+        Agregar nota interna
+      </label>
+      <textarea
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        rows={2}
+        maxLength={500}
+        placeholder="Ej: Llamé al cliente, no atiende."
+        className="w-full rounded-md border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm focus:border-[color:var(--primary,#111)] focus:outline-none"
+      />
+      <div className="mt-1 flex items-center justify-between">
+        <span className="text-xs text-[color:var(--text-muted,#6b7280)]">
+          Solo visible para el equipo, queda en el historial.
+        </span>
+        <button
+          type="submit"
+          disabled={!note.trim() || state === 'submitting'}
+          className="rounded-md bg-[color:var(--primary,#111)] px-3 py-1.5 text-xs font-semibold text-[color:var(--primary-foreground,#fff)] hover:opacity-90 disabled:opacity-50"
+        >
+          {state === 'submitting' ? 'Guardando…' : 'Guardar nota'}
+        </button>
+      </div>
+      {state === 'error' ? (
+        <p role="alert" className="mt-1 text-xs text-red-700">
+          No pudimos guardar. Intentá de nuevo.
+        </p>
+      ) : null}
+    </form>
+  )
+}

--- a/web/components/commerce/checkout-form.tsx
+++ b/web/components/commerce/checkout-form.tsx
@@ -72,7 +72,7 @@ export function CheckoutForm({ siteSlug, locale = 'es' }: Props) {
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    if (!cart) return
+    if (!cart || submitting) return
     setSubmitting(true)
     setError(null)
 

--- a/web/components/commerce/checkout-progress-indicator.tsx
+++ b/web/components/commerce/checkout-progress-indicator.tsx
@@ -1,0 +1,65 @@
+/**
+ * Visual "Carrito → Datos → Pago → Listo" indicator rendered at the top
+ * of commerce flow pages. Pure presentation — the caller picks `current`
+ * based on which page is rendering it.
+ *
+ * Server-component only; no client JS. Keep the component small so any
+ * page that wants to show the breadcrumb-like progression can drop it
+ * in without thinking about hydration.
+ */
+type Step = 'cart' | 'checkout' | 'payment' | 'done'
+
+const STEP_ORDER: Step[] = ['cart', 'checkout', 'payment', 'done']
+const LABELS: Record<Step, string> = {
+  cart: 'Carrito',
+  checkout: 'Datos',
+  payment: 'Pago',
+  done: 'Listo',
+}
+
+export function CheckoutProgressIndicator({ current }: { current: Step }) {
+  const currentIdx = STEP_ORDER.indexOf(current)
+  return (
+    <nav aria-label="Progreso del pedido" className="mb-6">
+      <ol className="flex items-center gap-1 text-xs sm:gap-2 sm:text-sm">
+        {STEP_ORDER.map((step, i) => {
+          const isCurrent = i === currentIdx
+          const isDone = i < currentIdx
+          return (
+            <li key={step} className="flex items-center gap-1 sm:gap-2">
+              <span
+                className={
+                  isCurrent
+                    ? 'inline-flex h-6 w-6 items-center justify-center rounded-full bg-[color:var(--primary,#111)] text-xs font-semibold text-[color:var(--primary-foreground,#fff)] sm:h-7 sm:w-7'
+                    : isDone
+                      ? 'inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-600 text-xs font-semibold text-white sm:h-7 sm:w-7'
+                      : 'inline-flex h-6 w-6 items-center justify-center rounded-full border border-[color:var(--border,#e5e7eb)] bg-white text-xs font-semibold text-[color:var(--text-muted,#6b7280)] sm:h-7 sm:w-7'
+                }
+                aria-current={isCurrent ? 'step' : undefined}
+              >
+                {isDone ? '✓' : i + 1}
+              </span>
+              <span
+                className={
+                  isCurrent
+                    ? 'font-semibold text-[color:var(--text,#111)]'
+                    : isDone
+                      ? 'text-green-700'
+                      : 'text-[color:var(--text-muted,#6b7280)]'
+                }
+              >
+                {LABELS[step]}
+              </span>
+              {i < STEP_ORDER.length - 1 ? (
+                <span
+                  aria-hidden="true"
+                  className={`mx-0.5 h-px w-4 sm:w-8 ${isDone ? 'bg-green-600' : 'bg-[color:var(--border,#e5e7eb)]'}`}
+                />
+              ) : null}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/web/components/commerce/order-confirmation.tsx
+++ b/web/components/commerce/order-confirmation.tsx
@@ -161,13 +161,12 @@ export function OrderConfirmation({ siteSlug, locale, businessName, initialOrder
           >
             Seguir comprando
           </Link>
-          <button
-            type="button"
-            onClick={() => window.print()}
+          <Link
+            href={`/s/${locale}/${siteSlug}/orden/${order.id}/recibo`}
             className="inline-block rounded-lg border border-[color:var(--border,#e5e7eb)] px-4 py-2 font-medium text-[color:var(--text-muted,#6b7280)] hover:bg-[color:var(--surface-muted,#f3f4f6)]"
           >
-            Imprimir comprobante
-          </button>
+            📄 Descargar recibo
+          </Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes four deferred items from Batches F and G1. Progress indicator renders on /carrito + /checkout + /checkout/transfer. /orden/[id] now links to the /recibo page shipped in Batch E. Admin order detail has a free-form note field that writes note_added events to the timeline. Double-clicking the checkout submit button no longer re-submits.