### PR TITLE
feat(analytics): wire trackLeadSubmit into newsletter + exit-intent

### DIFF
--- a/web/components/consent/exit-intent-modal.tsx
+++ b/web/components/consent/exit-intent-modal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { trackLeadSubmit } from '@/lib/analytics/marketing-events'
 import { X } from 'lucide-react'
 
 const STORAGE_KEY = 'nexa:exit-intent:seen'
@@ -59,11 +60,14 @@ export function ExitIntentModal(props: ExitIntentModalProps) {
       })
       if (!res.ok) throw new Error(`status_${res.status}`)
       setStatus('success')
+      trackLeadSubmit({ source: 'exit-intent', success: true, tenant: props.siteSlug })
     } catch {
       const subject = encodeURIComponent('Exit-intent lead — Nexa Paraguay')
       const body = encodeURIComponent(`New subscriber: ${email}`)
       window.location.href = `mailto:${props.fallbackEmail}?subject=${subject}&body=${body}`
       setStatus('success')
+      // lead_fallback — API call failed, mailto used; still worth counting.
+      trackLeadSubmit({ source: 'exit-intent', success: false, tenant: props.siteSlug })
     }
   }
 

--- a/web/components/sections/newsletter-signup-section.tsx
+++ b/web/components/sections/newsletter-signup-section.tsx
@@ -4,6 +4,7 @@ import { Container } from '@/components/ui/container'
 import { Heading } from '@/components/ui/heading'
 import { Button } from '@/components/ui/button'
 import { useState } from 'react'
+import { trackLeadSubmit } from '@/lib/analytics/marketing-events'
 
 export interface NewsletterSignupProps {
   title?: string
@@ -42,8 +43,10 @@ export function NewsletterSignupSection({
         body: JSON.stringify({ email, consent, source: tenantSlug ? `${tenantSlug}-newsletter` : 'newsletter' }),
       })
       setState(res.ok ? 'ok' : 'err')
+      trackLeadSubmit({ source: 'newsletter', success: res.ok, tenant: tenantSlug })
     } catch {
       setState('err')
+      trackLeadSubmit({ source: 'newsletter', success: false, tenant: tenantSlug })
     }
   }
 


### PR DESCRIPTION
## Summary
Wires `trackLeadSubmit` (shipped in #272) into the two highest-priority lead-capture surfaces:

1. **Newsletter signup** — footer/resources form
2. **Exit-intent modal** — last-chance conversion before bounce

## Events fired per submit
- `lead_submit` + `generate_lead` on API success (generate_lead is GA4's standard that feeds the built-in Conversions report without custom setup)
- `lead_fallback` when the API is down and the form falls through to mailto

This lets us see:
- Total leads per surface (exit-intent vs newsletter)
- Fallback rates — signals API health without needing a separate uptime dashboard
- Conversion attribution in GA4 without configuring custom events

## Out of scope
- Contact form + intake-wizard wiring — separate PRs, different file scopes
- Hero / tier-CTA click tracking — needs server-to-client component refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)