### PR TITLE
feat(commerce): Batch Q — admin home commerce badges + CSV filters

### DIFF
--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -54,6 +54,34 @@ export default async function AdminDashboard() {
     // Silent — show zeros.
   }
 
+  // Commerce tile counts — awaiting_payment + of-those-with-comprobante-sent
+  // + low-stock products across ALL tenants. Best-effort; failures show 0.
+  let commerceAwaitingCount = 0
+  let commerceComprobanteSentCount = 0
+  let commerceLowStockCount = 0
+  try {
+    const supabase = await createClient()
+    const { data: orders } = await supabase
+      .from('orders')
+      .select('status, comprobante_sent_at')
+      .eq('status', 'awaiting_payment')
+      .limit(1000)
+    const oRows = (orders ?? []) as Array<{ status: string; comprobante_sent_at: string | null }>
+    commerceAwaitingCount = oRows.length
+    commerceComprobanteSentCount = oRows.filter((o) => o.comprobante_sent_at).length
+    const { data: products } = await supabase
+      .from('products')
+      .select('inventory_qty, low_stock_threshold, inventory_policy, status')
+      .eq('inventory_policy', 'deny')
+      .eq('status', 'active')
+      .lte('inventory_qty', 10)
+      .limit(500)
+    commerceLowStockCount = ((products ?? []) as Array<{ inventory_qty: number; low_stock_threshold: number | null }>)
+      .filter((p) => p.inventory_qty <= (p.low_stock_threshold ?? 3)).length
+  } catch {
+    // Silent.
+  }
+
   return (
     <main className="min-h-screen bg-gray-50">
       {/* Header */}
@@ -142,13 +170,30 @@ export default async function AdminDashboard() {
             href="/admin/commerce"
             className="group rounded-lg border bg-white p-5 transition-all hover:-translate-y-0.5 hover:border-blue-300 hover:shadow-sm"
           >
-            <p className="text-xs uppercase tracking-wider text-gray-500">Tiendas</p>
+            <div className="flex items-start justify-between">
+              <p className="text-xs uppercase tracking-wider text-gray-500">Tiendas</p>
+              {commerceAwaitingCount > 0 && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800">
+                  {commerceAwaitingCount} esperando
+                </span>
+              )}
+            </div>
             <p className="mt-1 text-base font-semibold text-gray-900 group-hover:text-blue-700">
               Commerce
             </p>
             <p className="mt-1 text-sm text-gray-500">
               Pedidos, productos e inventario por tenant.
             </p>
+            {commerceComprobanteSentCount > 0 && (
+              <p className="mt-2 text-xs font-medium text-green-700">
+                {commerceComprobanteSentCount} con comprobante listo para verificar
+              </p>
+            )}
+            {commerceLowStockCount > 0 && (
+              <p className="mt-1 text-xs font-medium text-red-600">
+                {commerceLowStockCount} {commerceLowStockCount === 1 ? 'producto con stock bajo' : 'productos con stock bajo'}
+              </p>
+            )}
           </Link>
           <Link
             href="/admin/tenants"

--- a/web/app/api/admin/commerce/[businessId]/orders/export/route.ts
+++ b/web/app/api/admin/commerce/[businessId]/orders/export/route.ts
@@ -19,12 +19,15 @@ function csvEscape(v: string | number | null | undefined): string {
 }
 
 export const GET = withRequestLog<{ businessId: string }>(
-  async (_req, _ctx, { businessId }) => {
+  async (req, _ctx, { businessId }) => {
+    const url = new URL(req.url)
+    const query = (url.searchParams.get('q') ?? '').trim()
+    const statusFilter = (url.searchParams.get('status') ?? '').trim()
     const admin = await requireAdminUser()
     if (!admin) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
 
     const supabase = await createAdminClient()
-    const { data } = await supabase
+    let q2 = supabase
       .from('orders')
       .select(
         'order_number, status, customer_name, customer_email, customer_phone, subtotal_cents, shipping_cents, discount_cents, total_cents, currency, shipping_address, notes, tracking_carrier, tracking_number, comprobante_sent_at, created_at, placed_at, paid_at, shipped_at, delivered_at',
@@ -32,6 +35,14 @@ export const GET = withRequestLog<{ businessId: string }>(
       .eq('business_id', businessId)
       .order('created_at', { ascending: false })
       .limit(MAX_ROWS)
+    if (statusFilter) q2 = q2.eq('status', statusFilter)
+    if (query) {
+      const escaped = query.replace(/[\\%_,]/g, (ch) => `\\${ch}`)
+      q2 = q2.or(
+        `order_number.ilike.*${escaped}*,customer_name.ilike.*${escaped}*,customer_email.ilike.*${escaped}*,customer_phone.ilike.*${escaped}*`,
+      )
+    }
+    const { data } = await q2
 
     const rows = Array.isArray(data) ? data : []
     const header = [


### PR DESCRIPTION
/admin commerce tile shows awaiting_payment count + comprobante-sent subcount + low-stock count. CSV export now respects ?q= and ?status= filters.