### PR TITLE
a11y: demote embedded section titles from <h1> to <h2>

### DIFF
--- a/web/components/sections/b2b-wholesale-section.tsx
+++ b/web/components/sections/b2b-wholesale-section.tsx
@@ -133,7 +133,7 @@ export function B2BWholesaleSection({ business }: B2BPageProps) {
             <Building2 className="w-4 h-4" />
             Soluciones para Negocios
           </div>
-          <Heading level={1} className="text-4xl sm:text-5xl lg:text-6xl font-bold text-gray-900 mb-6 leading-tight">
+          <Heading level={2} className="text-4xl sm:text-5xl lg:text-6xl font-bold text-gray-900 mb-6 leading-tight">
             Huevos Frescos de Calidad
             <span className="block text-orange-600">para tu Restaurante, Panadería o Hotel</span>
           </Heading>

--- a/web/components/sections/our-story-section.tsx
+++ b/web/components/sections/our-story-section.tsx
@@ -225,7 +225,7 @@ export function OurStorySection({ business, overrides }: OurStorySectionProps) {
           <div className="grid md:grid-cols-2 gap-12 items-center">
             <div>
               <Badge className="mb-4 bg-orange-100 text-orange-800 hover:bg-orange-100">{heroBadge}</Badge>
-              <Heading level={1} className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
+              <Heading level={2} className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
                 {heroHeadPrefix}
                 {heroHeadAccent ? (
                   <>

--- a/web/components/sections/recipe-section.tsx
+++ b/web/components/sections/recipe-section.tsx
@@ -261,7 +261,7 @@ export function RecipeSection({ business }: RecipePageProps) {
       <div className="max-w-6xl mx-auto">
         {/* Hero */}
         <div className="text-center mb-12">
-          <Heading level={1} className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">
+          <Heading level={2} className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">
             Recetas con <span className="text-orange-600">Huevos Frescos</span>
           </Heading>
           <p className="text-xl text-gray-600 max-w-2xl mx-auto">


### PR DESCRIPTION
Audit found /granja-cabral has 4 <h1> tags. Each page should have exactly 1. Demoted 3 section components (b2b-wholesale, our-story, recipe grid header) from level={1} → level={2}. Hero keeps H1. Blog-index/blog-post (which ARE page titles) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)