### PR TITLE
fix(seo): tenant titles stop trailing '| ParaguAI Builder' platform suffix

### DIFF
--- a/web/app/s/[locale]/[site]/[[...page]]/page.tsx
+++ b/web/app/s/[locale]/[site]/[[...page]]/page.tsx
@@ -111,7 +111,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const twitterImageUrl = twitterCardAsset?.src ?? ogImageUrl
 
     return {
-      title: composed.meta.title,
+      // Use `absolute` so the root layout's `%s | ParaguAI Builder` template
+      // doesn't bleed into tenant pages. Each tenant owns its own browser
+      // title and SEO headline end-to-end.
+      title: { absolute: composed.meta.title },
       description: composed.meta.description,
       alternates: { languages: alternates },
       ...(Object.keys(icons).length > 0 && { icons }),


### PR DESCRIPTION
The root layout's `title.template = '%s | ParaguAI Builder'` was bleeding into every tenant page. Fun4me browser tab read 'Fun4Me — Sex Shop... | ParaguAI Builder'; de-abasto-a-casa title was >100 chars because of the suffix.

Fix: return `title: { absolute: composed.meta.title }` from tenant `generateMetadata` — template bypass. Each tenant owns its own title + SEO headline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)