### PR TITLE
feat(analytics): wire GA4 into intake wizard

### DIFF
--- a/web/components/sections/intake-wizard-section.tsx
+++ b/web/components/sections/intake-wizard-section.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { trackWizardStep, trackWizardComplete } from '@/lib/analytics/marketing-events'
 import { Container } from '@/components/ui/container'
 import { Heading } from '@/components/ui/heading'
 import { ArrowLeft, ArrowRight, Check } from 'lucide-react'
@@ -283,7 +284,26 @@ export function IntakeWizardSection({
 
   const handleNext = () => {
     if (!answered) return
+    // Emit a wizard_step event for every advance — lets us see where
+    // prospects drop out of the 4-step funnel in GA4.
+    trackWizardStep({
+      step: stepIdx + 1,
+      stepKey: String(currentStepKey),
+      answerKey: answers[currentStepKey] || '',
+      answerLabel: currentStep.options.find((o) => o.key === answers[currentStepKey])?.label || '',
+      tenant: __siteSlug,
+    })
     if (isLastStep) {
+      // Compute the recommendation eagerly here so the wizard_complete
+      // event carries the correct `recommended_tier` instead of firing
+      // on a subsequent render cycle.
+      const tier = recommendTier({
+        goal: answers.goal || '',
+        income: answers.income || '',
+        needs: answers.needs || '',
+        timeline: answers.timeline || '',
+      })
+      trackWizardComplete({ recommendedTier: tier, tenant: __siteSlug })
       setDone(true)
     } else {
       setStepIdx(stepIdx + 1)


### PR DESCRIPTION
## Summary
Every step advance fires `wizard_step` with the selected answer; the final advance additionally fires `wizard_complete` with the recommended tier. Uses the helpers from #272.

## What GA4 will now see
- **Step completion rate** — how far prospects get in the 4-step funnel (goal → income → needs → timeline → recommendation)
- **Answer correlation** — which answer clusters correlate with drop-off or with a given recommended tier
- **Tier distribution** — base / business / investor / tierras mix from real prospects

## Implementation notes
`trackWizardComplete` fires the tier synchronously in `handleNext` (not via a useEffect on the `done` flag). This carries the correct `recommended_tier` value without a render-cycle race. The tier computation is duplicated in handleNext + the `done` render — `recommendTier` is pure, so that's cheap.

## Next wire-ins (separate PRs)
- Contact form submit → `trackLeadSubmit`
- Tier CTA clicks on `programs-comparison` → `trackTierCta`
- Hero primary/secondary CTA → `trackHeroCta` (needs client wrapper since hero is a Server Component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)