### PR TITLE
fix(nexa): process-timeline UX — contrast + centered numbers + duration-first + CTA pop

### DIFF
--- a/sites/nexa-paraguay/content/en.json
+++ b/sites/nexa-paraguay/content/en.json
@@ -295,7 +295,7 @@
         },
         {
           "number": 4,
-          "title": "Company and banking",
+          "title": "Entity setup & banking",
           "description": "We incorporate your company and coordinate the bank opening.",
           "icon": "Building",
           "image": {
@@ -642,7 +642,7 @@
         },
         {
           "number": 4,
-          "title": "Company and banking",
+          "title": "Entity setup & banking",
           "description": "We incorporate your company and coordinate the bank opening.",
           "icon": "Building",
           "image": {

--- a/web/components/sections/process-timeline-section.tsx
+++ b/web/components/sections/process-timeline-section.tsx
@@ -43,7 +43,7 @@ function IconByName({ name, size = 28 }: { name?: string; size?: number }) {
   if (!name) return null
   const Icon = (Icons as unknown as Record<string, React.ComponentType<{ size?: number; className?: string }>>)[name]
   if (!Icon) return null
-  return <Icon size={size} className="text-[var(--secondary)]" />
+  return <Icon size={size} className="text-[var(--secondary-foreground)]" strokeWidth={2.25} />
 }
 
 export function ProcessTimelineSection({
@@ -71,6 +71,15 @@ export function ProcessTimelineSection({
           )}
         </AnimatedSectionHeader>
 
+        {totalDuration && (
+          <div className="mt-6 flex justify-center">
+            <span className="inline-flex items-center gap-2 rounded-full bg-[var(--primary)]/10 px-4 py-1.5 text-xs font-semibold uppercase tracking-wider text-[var(--primary)]">
+              <span aria-hidden="true">⏱</span>
+              {totalDuration}
+            </span>
+          </div>
+        )}
+
         {variant === 'vertical' ? (
           <Vertical steps={steps} />
         ) : variant === 'stepped' ? (
@@ -79,21 +88,15 @@ export function ProcessTimelineSection({
           <Horizontal steps={steps} />
         )}
 
-        {(totalDuration || ctaLabel) && (
-          <div className="mt-12 flex flex-col items-center gap-3 text-center">
-            {totalDuration && (
-              <p className="text-sm text-[var(--text-muted)]">
-                {totalDuration}
-              </p>
-            )}
-            {ctaLabel && ctaHref && (
-              <a
-                href={ctaHref}
-                className="inline-flex items-center gap-2 rounded-md bg-[var(--secondary)] px-6 py-3 text-[var(--secondary-foreground)] shadow-button transition-all hover:-translate-y-0.5"
-              >
-                {ctaLabel}
-              </a>
-            )}
+        {ctaLabel && ctaHref && (
+          <div className="mt-12 flex justify-center">
+            <a
+              href={ctaHref}
+              className="inline-flex items-center gap-2 rounded-md bg-[var(--primary)] px-6 py-3 font-semibold text-[var(--primary-foreground,white)] shadow-button transition-all hover:-translate-y-0.5 hover:shadow-lg"
+            >
+              {ctaLabel}
+              <span aria-hidden="true">→</span>
+            </a>
           </div>
         )}
       </Container>
@@ -161,7 +164,7 @@ function Horizontal({ steps }: { steps: ProcessStep[] }) {
                 )}
                 <span
                   aria-hidden="true"
-                  className="absolute -top-2 -right-2 flex h-7 w-7 items-center justify-center rounded-full bg-[var(--primary)] text-xs font-bold text-white shadow-md"
+                  className="absolute -top-3 left-1/2 flex h-8 w-8 -translate-x-1/2 items-center justify-center rounded-full bg-[var(--primary)] text-sm font-bold text-white shadow-md ring-2 ring-[var(--surface)]"
                 >
                   {step.number ?? i + 1}
                 </span>
@@ -173,7 +176,7 @@ function Horizontal({ steps }: { steps: ProcessStep[] }) {
               >
                 {step.title}
               </Heading>
-              <p className="text-sm text-[var(--text-light)]">{step.description}</p>
+              <p className="min-h-[3.25rem] text-sm text-[var(--text-light)]">{step.description}</p>
               {step.duration && (
                 <p className="mt-2 text-xs uppercase tracking-wider text-[var(--text-muted)]">
                   {step.duration}


### PR DESCRIPTION
Addresses visual audit of the /proceso section:

**Priority fixes**
1. **Icon contrast** — lucide icons inside the tan circles were `text-[var(--secondary)]` on `bg-[var(--secondary)]` — same color. Flipped to `text-[var(--secondary-foreground)]` + stroke 2.25 so they actually show.
2. **Number placement** — step badges moved from `-top-2 -right-2` (looking like notification dots) to top-center with `ring-2 ring-[var(--surface)]` — reads as a clear step marker.
3. **Text-length balance** — descriptions get `min-h-[3.25rem]` so the 5 columns bottom-align at the next element.
4. **CTA pop** — bottom button flipped from `bg-[var(--secondary)]` (same-tone as circles) to `bg-[var(--primary)]` high-contrast + arrow affordance.

**Information hierarchy**
5. **Duration-first** — "8–12 semanas" chip moved above the grid instead of below the CTA. Context-before-scan.
6. **Step 4 title** — "Company and banking" → "Entity setup & banking" (en only; other locales already use idiomatic phrasing).

Connector arrows left as-is — they're lucide, consistent with the rest of the nexa visual language; swapping to connecting lines would cascade into the vertical + stepped variants too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)