### PR TITLE
chore: recover stashed showcase + blog path fixes

### DIFF
--- a/sites/nexa-paraguay/blog/en/nexa-process-week-by-week.mdx
+++ b/sites/nexa-paraguay/blog/en/nexa-process-week-by-week.mdx
@@ -5,7 +5,7 @@ date: "2026-04-21"
 author: "Nexa Paraguay"
 category: "Process"
 excerpt: "We say 8–12 weeks. Here's what happens in each of those weeks — what we do, what you do, and what can slip the timeline."
-coverImage: "/sites/nexa-paraguay/images/blog/process-week-by-week.webp"
+coverImage: "/sites/nexa-paraguay/images/blog/residencia-2024.webp"
 readingMinutes: 7
 draft: false
 ---

--- a/sites/nexa-paraguay/blog/en/paraguay-10-percent-rule.mdx
+++ b/sites/nexa-paraguay/blog/en/paraguay-10-percent-rule.mdx
@@ -5,7 +5,7 @@ date: "2026-04-21"
 author: "Nexa Paraguay"
 category: "Tax"
 excerpt: "Paraguay's 10% IRE and 0% tax on foreign income are real — but only if your structure qualifies. Here's the decision tree we run through on every consultation."
-coverImage: "/sites/nexa-paraguay/images/blog/tax-guide-2026.webp"
+coverImage: "/sites/nexa-paraguay/images/blog/comparativa-fiscal-w1920.webp"
 readingMinutes: 8
 draft: false
 ---

--- a/sites/nexa-paraguay/blog/en/paraguay-vs-uruguay-vs-panama-2026.mdx
+++ b/sites/nexa-paraguay/blog/en/paraguay-vs-uruguay-vs-panama-2026.mdx
@@ -5,7 +5,7 @@ date: "2026-04-21"
 author: "Nexa Paraguay"
 category: "Residency"
 excerpt: "Every European investor we talk to has shortlisted Paraguay, Uruguay, and Panama. Here's the honest side-by-side — what each actually requires, what it actually costs, and where each one breaks down."
-coverImage: "/sites/nexa-paraguay/images/blog/comparativa-fiscal.webp"
+coverImage: "/sites/nexa-paraguay/images/blog/paraguay-uruguay-panama-w1920.webp"
 readingMinutes: 9
 draft: false
 ---

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -9,6 +9,7 @@ import {
   Menu, X as XIcon, PlayCircle,
   UtensilsCrossed, Fish, CircleDot,
   RotateCcw, Activity, Unlock,
+  Egg, Building2, BarChart3,
   type LucideIcon,
 } from 'lucide-react'
 import Link from 'next/link'
@@ -216,7 +217,10 @@ const TEMPLATES: Template[] = [
   { id: 'pestanas', name: 'Pestañas y Cejas', icon: Eye, leads: 49, pct: 76, color: '#6c5ce7', demoSlug: 'pestanas-flore' },
   { id: 'depilacion', name: 'Depilación', icon: Zap, leads: 20, pct: 78, color: '#e17055', demoSlug: 'depilacion-perfecta' },
   { id: 'relocation', name: 'Reubicación', icon: Globe, leads: 0, pct: 0, color: '#1e3a5f', demoSlug: 'nexa-paraguay' },
+  { id: 'real_estate', name: 'Inmobiliaria', icon: Building2, leads: 0, pct: 0, color: '#2d6a4f', demoSlug: 'nexa-propiedades' },
   { id: 'meal_prep', name: 'Meal Prep & Compras', icon: ShoppingCart, leads: 0, pct: 0, color: '#3a6b4a', demoSlug: 'de-abasto-a-casa' },
+  { id: 'egg_farm', name: 'Granja / Huevos', icon: Egg, leads: 0, pct: 0, color: '#c89b3c', demoSlug: 'granja-cabral' },
+  { id: 'data_analytics_consulting', name: 'Consultoría Datos', icon: BarChart3, leads: 0, pct: 0, color: '#0f4c81', demoSlug: 'stoicfinch' },
   { id: 'restaurant', name: 'Restaurante', icon: UtensilsCrossed, leads: 0, pct: 0, color: '#8B4513', demoSlug: 'la-trattoria' },
   { id: 'sushi_bar', name: 'Sushi Bar', icon: Fish, leads: 0, pct: 0, color: '#1A1A1A', demoSlug: 'sakura-sushi' },
   { id: 'kaiten_zushi', name: 'Sushi Cinta', icon: CircleDot, leads: 0, pct: 0, color: '#2196F3', demoSlug: 'kaiten-express' },
@@ -299,6 +303,20 @@ const REAL_CLIENTS = [
     vertical: 'Comida · pedidos WhatsApp',
     href: '/de-abasto-a-casa',
     color: '#3a6b4a',
+  },
+  {
+    name: 'Granja Cabral',
+    tagline: 'Huevos frescos de granja',
+    vertical: 'Agro · mayorista + recetas',
+    href: '/s/es/granja-cabral',
+    color: '#c89b3c',
+  },
+  {
+    name: 'Stoic Finch',
+    tagline: 'Consultoría de datos boutique',
+    vertical: 'Canadá · EN',
+    href: '/s/en/stoicfinch',
+    color: '#0f4c81',
   },
 ]
 


### PR DESCRIPTION
## Summary

Recovers 2 of 14 stashed WIP items — the ones that apply cleanly against current Main. Remaining 12 stashes conflict with current Main (shared components like contact-section, features-section, testimonials were already refactored in subsequent PRs).

### Contents

1. **`web/app/page.tsx`** — adds new demo templates (`egg_farm`, `real_estate`, `data_analytics_consulting`) and `REAL_CLIENTS` entries for Granja Cabral and Stoic Finch. Makes the platform homepage showcase the tenants that landed via #310.

2. **3 nexa-paraguay EN blog posts** — cover image path fixes (residencia-2024.webp, comparativa-fiscal-w1920.webp, week-by-week updates).

### Stashes preserved (not in this PR)

Kept in local stash@{1-13} for manual review. Each has conflicts against current Main:

| Stash | Content | Conflict |
|---|---|---|
| Analytics consolidation (-123 LOC) | `lib/analytics/events.ts` refactor | Drops `EventTypes` + `trackSectionView` used elsewhere |
| Nexa comparison page | `nexa-paraguay/content/*.json` + tenant-data regen | Content JSON conflicts with #310 |
| Product brand/tags | admin commerce forms | Form schema already evolved |
| PDP wishlist + reviews | product detail pages | wishlist-store.ts already exists |
| CI/CD overhaul + recipe refactor | .github/workflows + recipe-section | Workflows rebuilt recently |
| Demo data stockCount/location | demo-data.ts | DemoBusiness interface doesn't have these fields |
| Contact section + pagopar | 2 files | contact-section.tsx heavily refactored in #309 |
| Features section variants | features-section.tsx + 3 files | features-section refactored separately |
| Testimonials refactor | testimonials-section.tsx | Component structure already evolved |
| Relocation vertical overhaul | 10 shared components | Too many conflicts in shared components (hero, header, footer) |
| UI polish (5 files) | leads + activity + sections | leads-dashboard refactored separately |
| Validation + nexa-uruguay | validate-sites.ts + content | New nexa-uruguay tenant, needs review |

### Recovery notes

- 11 stashes originally marked A/C bucket (already-in-main or unresolvable) have been dropped.
- 10 local branches marked "unmerged" were all subsumed by merged PRs (#276, #279, #295, #307, #310, etc.) and have been deleted.
- 14 stashes remain for case-by-case manual recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)