### PR TITLE
feat(contador): 3 regional variants + RESIMPLE qualifier + service packages

### DIFF
--- a/src/content/blog-seeds/contador/crypto-impuestos-paraguay.md
+++ b/src/content/blog-seeds/contador/crypto-impuestos-paraguay.md
@@ -1,0 +1,201 @@
+---
+slug: crypto-impuestos-paraguay-2026
+title: "Crypto en Paraguay 2026: Impuestos, SEPRELAD y Compliance"
+excerpt: "La DNIT fijó posición: las ganancias crypto tributan IRE 10%. Plus SEPRELAD para sujetos obligados. Guía completa para traders e inversores."
+category: "Impuestos"
+tags: ["crypto", "blockchain", "seprelad", "ire", "fintech"]
+author: "{{businessName}}"
+date: "2026-03-15"
+---
+
+# Crypto en Paraguay 2026: Impuestos, SEPRELAD y Compliance
+
+Paraguay es uno de los destinos más atractivos del mundo para traders y residentes crypto — pero el marco regulatorio se endureció en 2024-2025. Esta es la guía completa actualizada.
+
+## Cómo tributan las ganancias crypto en Paraguay
+
+La **DNIT publicó posición oficial en 2024**: las ganancias por compraventa de criptoactivos son **renta gravada**.
+
+### Para habituales (traders)
+
+Trading regular, volumen significativo, intención comercial = **IRE 10%** sobre la ganancia neta anual.
+
+### Para ocasionales (holders)
+
+1-2 operaciones al año sin patrón comercial, típicamente **no gravado** bajo criterio de "ganancia patrimonial ocasional". Zona gris — siempre confirmar con contador.
+
+### Comisiones y servicios
+
+Exchanges, remesadoras cripto, wallets que cobran comisión: **IVA 10%** sobre la comisión.
+
+### Minería
+
+- **Hobby scale** (minero individual doméstico): debate abierto; posiciones conservadoras tratan como renta empresarial
+- **Industrial** (granja de minería): IRE + IVA + IPS + MTESS como cualquier empresa
+
+## Metodología de cálculo
+
+Para declarar correctamente necesitás:
+
+1. **Cost basis methodology** consistente (FIFO o LIFO declarado; PY acepta ambos)
+2. **Registro wallet-by-wallet** de entradas y salidas
+3. **Conversión a Gs.** al tipo de cambio oficial BCP del día de cada operación
+4. **Realized gains** al cierre del ejercicio
+
+Ejemplo:
+
+- Enero: comprás 1 BTC a USD 40.000 (Gs. 300M al cambio)
+- Octubre: vendés 1 BTC a USD 60.000 (Gs. 450M al cambio)
+- Ganancia: Gs. 150M → IRE 10% = **Gs. 15M**
+
+## SEPRELAD: ¿sos sujeto obligado?
+
+La **Ley 1015/97** (prevención lavado) fue aplicada al sector crypto vía **Resolución SEPRELAD 8/20**.
+
+### Quién es sujeto obligado
+
+- Exchanges centralizados operando en/desde PY
+- Remesadoras crypto
+- OTC desks con volumen > ciertos umbrales
+- Proveedores de custodia
+- Emisores de stablecoins fiat-pegged
+
+### Obligaciones del sujeto obligado
+
+1. **Registro** en SEPRELAD
+2. **Oficial de cumplimiento** designado (con capacitación)
+3. **KYC/AML framework** documentado
+4. **Monitoreo de transacciones** (patrones sospechosos)
+5. **ROS mensuales** (Reporte de Operación Sospechosa)
+6. **Matriz de riesgo anual**
+7. **Auditoría interna** de cumplimiento
+
+### Sanciones por incumplimiento
+
+- Multas entre Gs. 100M y Gs. 5.000M
+- Suspensión de operaciones
+- Responsabilidad personal del directorio en casos graves
+
+## Traders individuales
+
+### Si operás para vos mismo con volumen < USD 100k/año
+
+Típicamente **NO sos sujeto obligado SEPRELAD** (estás sobre plataformas que ya lo son, como Binance, Kraken, Coinbase).
+
+Tus obligaciones:
+- Inscribirte en DNIT si tus ganancias anuales superan umbrales IRP (Gs. 80M)
+- Declarar IRE o IRP según clasificación
+- Pagar IVA si cobrás comisiones (no aplica a trader propio)
+
+### Si operás volumen > USD 100k/año
+
+Podés entrar en radar SEPRELAD como operador habitual. Se recomienda:
+- Asesoramiento preventivo
+- Documentar source of funds
+- Registro contable wallet-by-wallet
+
+## Estructura societaria recomendada
+
+Para operaciones serias:
+
+### Trader solo (alto volumen)
+- **EAS** con objeto social "trading de criptoactivos"
+- Contabilidad FIFO/LIFO declarada
+- SEPRELAD si aplica por volumen
+- IRE anual 10% sobre ganancia
+
+### Fondo / firma de trading
+- **EAS o SRL** según estructura de capital
+- SEPRELAD obligatorio
+- Auditoría externa recomendada
+- Reporting mensual a LPs
+
+### Exchange / protocolo
+- **SA** para credibilidad institucional
+- SEPRELAD full compliance
+- SOC1/SOC2 recomendados
+- Custody separada de capital propio
+
+## Ventajas del territorial paraguayo
+
+Paraguay solo grava **renta local** — operaciones con contrapartes extranjeras en exchanges extranjeros pueden argumentarse como renta extranjera.
+
+### Posición conservadora
+
+Las ganancias por trading desde wallets/exchanges extranjeros son **renta local** porque el sujeto trader está en PY. → IRE 10%.
+
+### Posición optimizada (requiere asesoría)
+
+Con estructura adecuada (EAS PY que opera desde offshore), parte de la actividad puede calificar como renta extranjera (0% IRE).
+
+**Importante**: no es asesoramiento tributario; depende de cómo se estructure la operación.
+
+## Residencia fiscal para nómadas crypto
+
+Paraguay es atractivo para traders crypto que quieren:
+
+1. Residir legalmente en un país estable
+2. Obtener certificado de residencia fiscal (para aplicar CDI con país origen)
+3. Pagar un tributo relativamente bajo
+
+Requisitos:
+- **120+ días/año en PY**
+- Cédula paraguaya (vía residencia migratoria)
+- RUC activo
+- Declaración IRE/IRP anual
+
+## Coordinación con país de origen
+
+Aun viviendo en PY, tu **país de origen puede exigir reporting**:
+
+- **USA**: FATCA + FBAR + reporting de cripto (formulario 8938)
+- **UK**: CFC rules aplicables en ciertos casos
+- **UE**: CRS (OECD) — PY no es miembro pero países firmantes aplican
+- **Argentina**: residencia fiscal efectiva basada en centro de intereses
+- **Brasil**: tributación sobre renta mundial
+
+**Moraleja**: tener residencia fiscal PY no te libera automáticamente de obligaciones en tu país de origen. Coordinación con advisor local es crítica.
+
+## Wallets y custodia
+
+### Hot wallets (Metamask, Phantom, Coinbase Wallet)
+- Contabilidad: exchange-by-exchange + wallet-by-wallet
+- Recomendado backup + multi-factor
+- Seguro privado no disponible en PY
+
+### Cold wallets (Ledger, Trezor)
+- No son relevantes para contabilidad — no se mueven
+- Valores declarables al BCP del día de conversión a fiat
+- Recomendados para montos > USD 10k
+
+### Custody institucional
+- Proveedores como Fireblocks, BitGo, Anchorage
+- Requeridos por muchos fondos y exchanges
+
+## Errores que te pueden costar caro
+
+1. **No declarar trading gains** — DNIT puede cruzar datos con exchanges que responden a subpoenas globales
+2. **Asumir que PY no reporta** — algunos casos (gran volumen, origen sospechoso) pueden ser compartidos con autoridades extranjeras
+3. **No separar trading propio de trading agenciado** — distintos regímenes
+4. **Reporting inconsistente FIFO/LIFO** — DNIT puede recalcular y cobrar diferencia
+5. **No designar oficial de cumplimiento** (si sos sujeto obligado)
+6. **Ignorar fronteras reglamentarias** de CNV (Comisión Nacional de Valores) si operás con tokens que califican como valores
+
+## Calendario de vencimientos crypto 2026
+
+- **Mensual**: IVA sobre comisiones (si aplica), ROS SEPRELAD si aplica
+- **Abril 2026**: IRE anual (ejercicio 2025)
+- **Marzo 2026**: IRP anual (ejercicio 2025)
+- **Octubre 2026**: Renovación anual de registro SEPRELAD
+
+## Qué hacer si nunca declaraste
+
+1. **Consulta confidencial** con contador crypto-aware
+2. Regularización gradual (no todo en un mes)
+3. Aprovechar planes de facilidades DNIT
+4. Documentar source of funds para cada posición
+5. Empezar reporting correcto desde mes 1
+
+---
+
+*Si operás crypto desde Paraguay — o pensás hacerlo — agendá una consulta confidencial. Te explicamos exactamente qué debés declarar, qué no, y cómo optimizar legalmente tu posición.*

--- a/src/content/blog-seeds/contador/idu-dividendos-utilidades-paraguay.md
+++ b/src/content/blog-seeds/contador/idu-dividendos-utilidades-paraguay.md
@@ -1,0 +1,158 @@
+---
+slug: idu-impuesto-dividendos-utilidades-paraguay
+title: "IDU: El Impuesto a los Dividendos que Pocos Contadores Explican Bien"
+excerpt: "El IDU grava la distribución de utilidades al accionista. Tasa 8% para residentes, 15% para extranjeros. Cuando aplica, cómo se paga, y cómo planificarlo legalmente."
+category: "Impuestos"
+tags: ["idu", "dividendos", "ire", "planificacion fiscal"]
+author: "{{businessName}}"
+date: "2026-03-28"
+---
+
+# IDU: El Impuesto a los Dividendos y Utilidades en Paraguay
+
+El **IDU** (Impuesto a la Distribución de Utilidades) es uno de los impuestos **menos entendidos** y **peor planificados** del sistema tributario paraguayo. Casi toda empresa con accionistas paga IDU tarde o mal. Esta es la guía completa.
+
+## Qué es el IDU
+
+El IDU grava la **distribución de utilidades** de una empresa a sus accionistas o socios. Se creó con la **Ley 6380/19** (reforma tributaria) y reemplazó el viejo impuesto a los dividendos del IRACIS.
+
+### Principio básico
+
+Cuando tu empresa paga IRE (10% sobre utilidad neta), **no termina ahí**. Si esas utilidades se distribuyen a los dueños como dividendos, el accionista paga **IDU adicional**.
+
+Es el equivalente paraguayo de la "doble tributación" (corporate tax + shareholder tax) que existe en USA, Argentina, Chile, etc.
+
+## Tasas del IDU
+
+| Situación | Tasa IDU |
+|---|---|
+| Accionista persona física residente PY | **8%** |
+| Accionista persona jurídica residente PY | **0%** (neutralidad corporativa) |
+| Accionista no residente (extranjero) | **15%** |
+| Utilidades reinvertidas | **0%** (sin distribución) |
+
+## Cuándo se paga
+
+El IDU se **retiene al momento del pago del dividendo** y se ingresa dentro de los **30 días siguientes** al DNIT.
+
+Si tu empresa emite un dividendo el 15 de abril, tenés hasta el 15 de mayo para ingresar el IDU al DNIT.
+
+## Ejemplo completo
+
+### Empresa paraguaya (EAS)
+
+- Utilidad neta anual: Gs. 500 millones
+- **IRE 10%**: paga Gs. 50 millones
+- Utilidad después de IRE: Gs. 450 millones
+
+### Distribución a accionista residente
+
+- Asamblea decide distribuir Gs. 300 millones como dividendo
+- **IDU 8%** se retiene: Gs. 24 millones
+- El accionista recibe en su cuenta: Gs. 276 millones
+- La empresa ingresa Gs. 24 millones al DNIT en 30 días
+
+### Si el accionista fuera extranjero
+
+- **IDU 15%** se retiene: Gs. 45 millones
+- El extranjero recibe Gs. 255 millones
+- La empresa ingresa Gs. 45 millones al DNIT
+
+## Carga fiscal total (efectiva)
+
+Para una empresa paraguaya con accionista residente:
+
+- Ganancia bruta: 100%
+- IRE: -10% → queda 90%
+- IDU sobre dividendo (si se distribuye todo): -7.2% (8% de 90%)
+- **Queda en bolsillo del accionista: 82.8%**
+
+Equivalente a ~17.2% carga fiscal combinada.
+
+Comparado a USA (21% federal + 23.8% dividendo máximo = ~40% combinado), es competitivo pero no "cero".
+
+## Distribuciones asimiladas (¡cuidado!)
+
+La DNIT considera ciertas operaciones como **"distribución asimilada"** y aplica IDU aunque no hayas firmado acta de distribución:
+
+1. **Préstamos a accionistas** sin interés de mercado o sin devolución
+2. **Gastos personales pagados por la empresa** (viajes, servicios, bienes)
+3. **Pagos a parientes** sin contraprestación real
+4. **Condonación de deuda** del accionista con la empresa
+5. **Bienes transferidos a menor valor** al accionista
+
+Si la DNIT detecta estas operaciones, recalcula IDU + multas + intereses. Puede ser un desastre financiero.
+
+## Planificación legal
+
+Hay formas **legales** de gestionar el IDU:
+
+### 1. Reinversión de utilidades
+
+Si no distribuís, **no hay IDU**. Las utilidades quedan en la empresa y pueden reinvertirse:
+- Compra de activos productivos
+- Ampliación del negocio
+- Reservas estratégicas
+
+### 2. Utilidad fiscal versus contable
+
+La utilidad sujeta a IDU es la **fiscal** (después de IRE), no la contable. Diferencias temporales (depreciaciones aceleradas, previsiones) pueden diferir IDU.
+
+### 3. Holding corporativa
+
+Si un accionista intermedio es persona jurídica residente PY, **no paga IDU** al recibir dividendos. Esto permite consolidar utilidades de varias subsidiarias antes de distribuir al dueño final.
+
+### 4. Distribuciones parciales
+
+Distribuir solo lo necesario para el consumo del accionista; el resto se reinvierte. Control explícito de carga fiscal anual.
+
+### 5. Tratados CDI (para accionistas extranjeros)
+
+Si el accionista es residente de un país con CDI firmado (Chile, Taiwán, Uruguay, Qatar, UAE), la tasa IDU 15% puede **reducirse** vía el tratado.
+
+### 6. Estructura EAS con acciones de distintas clases
+
+EAS permite acciones preferentes, diferidas, sin voto, etc. Permite estructurar distribución según necesidad de cada accionista.
+
+## Errores que vemos todas las semanas
+
+1. **No retener IDU al pagar dividendo** — la empresa responde solidariamente por el impuesto + intereses + multas
+2. **Préstamos al accionista sin documentar** — se asimilan a distribución
+3. **Usar la caja de la empresa para gastos personales** — IDU + riesgo de desconocer gasto deducible en IRE (doble golpe)
+4. **No planificar distribuciones** — algunos clientes pagan 15% efectivo anual en IDU porque distribuyen todo
+5. **Olvidar CDI para extranjeros** — pagan 15% cuando podían pagar 5-10% con tratado aplicado
+
+## IDU versus IRP
+
+No confundir:
+
+- **IDU**: tributa el dividendo (distribución corporativa)
+- **IRP**: tributa otros tipos de renta (honorarios, sueldos, alquileres)
+
+Si el accionista es persona física, cobra dividendos (IDU) + otros ingresos (IRP). Son compartimentos separados.
+
+## Qué hacer ante la DNIT
+
+Si recibís un requerimiento sobre IDU:
+
+1. **No firmar nada sin contador**
+2. Revisar todas las operaciones con accionistas de los últimos 5 años
+3. Identificar distribuciones asimiladas potenciales
+4. Si hay errores, **regularización voluntaria** antes de que DNIT complete fiscalización (multas más bajas)
+5. En fiscalización activa, usar derechos de descargo completos
+
+## Obligaciones de documentación
+
+Para defender posiciones IDU:
+
+- **Actas de asamblea** que autorizan distribuciones
+- **Recibos del accionista** por dividendos
+- **Comprobantes de retención IDU** (Formulario 132)
+- **Contratos de préstamo** con el accionista (si hay)
+- **Documentación de reinversión** (facturas, inversiones)
+
+Guardarlas por **5 años** (plazo de prescripción DNIT).
+
+---
+
+*Si tu empresa distribuye dividendos o vas a hacerlo pronto, agendá una consulta para revisar estructura y planificación. Un error de IDU puede costar 15-25% del dividendo distribuido.*

--- a/src/content/blog-seeds/contador/maquila-ley-1064-guia.md
+++ b/src/content/blog-seeds/contador/maquila-ley-1064-guia.md
@@ -1,0 +1,204 @@
+---
+slug: maquila-paraguay-ley-1064-guia-completa
+title: "Maquila en Paraguay: Guía Completa de la Ley 1064/97"
+excerpt: "Régimen de maquila paraguayo: tributo único 1%, importación temporal sin aranceles, MERCOSUR 60/40, CNIME reporting. La guía que los consultores te cobran USD 500."
+category: "Societario"
+tags: ["maquila", "ley 1064", "ciudad del este", "mercosur", "export"]
+author: "{{businessName}}"
+date: "2026-02-12"
+---
+
+# Maquila en Paraguay: Guía Completa de la Ley 1064/97
+
+Paraguay se volvió uno de los hubs más competitivos de Sudamérica para operaciones de ensamble, manufactura y re-exportación. La responsable es la **Ley 1064/97** — el régimen de maquila. Esta es la guía completa.
+
+## Qué es el régimen de maquila
+
+Una empresa maquiladora:
+
+1. **Importa insumos sin aranceles** (régimen de importación temporal)
+2. **Los transforma** en territorio paraguayo (ensamble, manufactura, modificación)
+3. **Exporta el 100% del producto** final — nada se vende en el mercado local
+4. **Paga un tributo único del 1%** sobre el valor facturado — reemplaza IVA, IRE, IRP, aranceles
+
+El resultado es un régimen fiscal **60-80% más barato** que operaciones industriales estándar en PY, y radicalmente más barato que en Brasil o Argentina.
+
+## Por qué PY atrajo maquila
+
+- **Mano de obra** 40-60% más barata que en Argentina o Brasil
+- **Energía** 100% renovable (Itaipú + Yacyretá) con tarifa industrial competitiva
+- **Acceso MERCOSUR**: arancel 0% al exportar a AR/BR/UY/CL (ciertos productos)
+- **Zona franca** en Ciudad del Este y Pedro Juan con beneficios adicionales
+- **Costo de establecimiento** bajo: galpones, alquileres, construcción — todo competitivo
+
+## ¿Quién se beneficia?
+
+Las maquilas típicas en PY son:
+
+- **Electrónicas**: ensamblaje de motherboards, circuitos, productos de consumo
+- **Textiles**: confección para marcas brasileras y argentinas
+- **Automotrices**: partes, arneses, tapicería, componentes
+- **Químicas y plásticas**: formulaciones de productos finales
+- **Alimentarias** (procesamiento simple): empaque, etiquetado, conversión
+- **Farmacéutica** (packaging secundario)
+
+Clientes típicos: multinacionales estadounidenses, brasileras, argentinas, europeas y (crecientemente) chinas.
+
+## Pasos para establecer una maquila
+
+### 1. Constitución de empresa paraguaya
+
+Puede ser EAS, SRL o SA. La mayoría elige **EAS** (72h, bajo costo, responsabilidad limitada).
+
+### 2. Elaboración del Programa de Maquila
+
+Documento extenso que se presenta al **CNIME** (Consejo Nacional de la Industria Maquiladora de Exportación). Incluye:
+
+- Producto a maquilar (descripción, NALADISA)
+- Insumos a importar (origen, volumen, arancel NOMENC)
+- Proyección financiera 5 años
+- **Valor agregado nacional** proyectado (mano de obra + servicios locales)
+- Generación de empleo directo e indirecto
+- Plan de inversión en infraestructura
+
+### 3. Aprobación CNIME + MIC
+
+- CNIME evalúa el programa (viabilidad, cumplimiento de requisitos)
+- MIC (Ministerio de Industria y Comercio) emite resolución aprobatoria
+- **Tiempo**: 90-120 días desde presentación completa
+
+### 4. Inicio de operaciones
+
+Una vez aprobado, podés:
+
+- Importar insumos sin aranceles (régimen temporal, DNA coordinado)
+- Contratar y liquidar personal (IPS + MTESS, como cualquier empresa)
+- Facturar al cliente extranjero
+- Pagar el 1% mensual al DNIT
+
+## Tributo único del 1%
+
+La magia del régimen:
+
+- **1% sobre el valor facturado al cliente** (no sobre la utilidad)
+- Reemplaza IVA, IRE, IRP, aduanas
+- Se presenta mensualmente vía Marangatú (formulario específico maquila)
+- No hay doble imposición con el país del cliente (tratados tributarios aplican)
+
+**Ejemplo:** Maquila que factura USD 10M/año al cliente brasilero:
+- Tributo único: USD 100k/año
+- Si estuviera bajo régimen general: IRE 10% sobre utilidad neta ~20% = USD 200k + IVA implícito + IRP socios... fácil 4-6x más
+
+## Certificado de origen MERCOSUR 60/40
+
+Para exportar con **arancel 0%** al Mercosur, el producto debe cumplir:
+
+- **60% de valor agregado regional** (Mercosur countries)
+- **40% máximo** de componentes extrazona
+
+La maquiladora genera valor agregado regional a través de:
+- Mano de obra paraguaya
+- Insumos locales
+- Servicios locales (energía, agua, logística)
+
+El contador + despachante coordinan el cálculo de valor agregado y emiten el certificado de origen para cada embarque.
+
+## Importación temporal de insumos
+
+Los insumos importados bajo régimen de maquila:
+
+- **No pagan IVA** a la importación
+- **No pagan aranceles**
+- Están sujetos a **cumplimiento de tiempos**: deben incorporarse al producto final y exportarse en el plazo autorizado (típicamente 12-18 meses)
+- Cualquier merma debe reportarse (merma admitida, no admitida)
+
+## Reporting trimestral CNIME
+
+Cada 3 meses, la maquila presenta al CNIME:
+
+1. **Balance de materiales**: qué insumos entraron, qué producto salió
+2. **Empleo**: directo + indirecto generado
+3. **Valor agregado nacional realizado** (vs. proyectado)
+4. **Exportaciones efectivizadas**
+5. **Cumplimiento del programa aprobado**
+
+Incumplimiento puede resultar en suspensión del régimen — no es opcional.
+
+## Aspectos laborales
+
+La maquila **NO exime** de obligaciones laborales:
+
+- IPS obrero 9% + patronal 16.5% sobre sueldos
+- MTESS-REOP mensual
+- Convenios colectivos sectoriales aplicables
+- Aguinaldo, vacaciones, preaviso, indemnización — todo igual a cualquier empresa
+
+El tributo único del 1% **solo aplica al impuesto** — no a cargas sociales.
+
+## Maquila vs. Zona Franca
+
+Son dos regímenes distintos que a veces se confunden:
+
+| Aspecto | Maquila | Zona Franca |
+|---|---|---|
+| Ley | 1064/97 | 523/95 |
+| Tributo | 1% sobre factura | Renta 0.5%, IVA 0%, ISC 0% |
+| Ubicación | Cualquier parte de PY | Solo Ciudad del Este y Pedro Juan |
+| Aduana | Importación temporal | "Extra-aduanera" |
+| Destino | 100% exportación | Puede vender al mercado interno (con pago de aranceles) |
+| Flexibilidad | Solo producción transformada | Comercio + servicios + producción |
+
+**Muchas operaciones combinan ambos**: maquila en zona franca.
+
+## Errores comunes
+
+1. **No separar operaciones maquila de no-maquila** — contabilidad debe ser clara y auditable
+2. **Vender al mercado local** — invalida el régimen
+3. **No reportar mermas** — se acumulan y explotan en auditoría
+4. **Valor agregado insuficiente** — pérdida del certificado MERCOSUR
+5. **No renovar el programa** — los programas tienen vigencia
+6. **Convenios colectivos no aplicados** — multas MTESS acumuladas
+7. **Sin despachante de aduana matriculado** — no podés importar legalmente
+
+## Costos de establecer una maquila
+
+| Concepto | Rango |
+|---|---:|
+| Constitución EAS | Gs. 2M |
+| Programa de Maquila (redacción + defensa CNIME) | Gs. 15-25M |
+| Habilitaciones | Gs. 3-5M |
+| Infraestructura (galpón alquiler mes 1) | Gs. 10-30M |
+| Equipamiento básico línea pequeña | USD 50-200k |
+| Honorarios contador primer año | Gs. 60-100M |
+| **Total setup mínimo** | **USD 100-300k** |
+
+Variable inmensamente según sector.
+
+## Retorno de inversión
+
+Operaciones maquila bien gestionadas generan:
+
+- **Margen operativo** 10-25%
+- **ROI** 20-40% anual
+- **Payback** 2-4 años
+
+Casos documentados: maquilas en CDE que escalaron de 50 a 500 empleados en 3 años.
+
+## Cuándo NO conviene la maquila
+
+- Si vendés al mercado local paraguayo (no permitido)
+- Si tu producto requiere insumos **muy específicos** no disponibles en importación
+- Si tu margen es demasiado bajo para absorber el 1% + costos laborales
+- Si tu cliente no acepta arriesgar estructura extranjera
+
+## Cómo empezar
+
+1. **Evaluación de factibilidad** con un contador especializado (1-2 semanas)
+2. **Elaboración del Programa** con consultor + contador (6-8 semanas)
+3. **Presentación al CNIME** y defensa si hay observaciones
+4. **Aprobación** (90-120 días)
+5. **Inicio de operaciones**
+
+---
+
+*Si estás evaluando establecer una maquila en Paraguay, agendá una consulta inicial sin costo. Te decimos honestamente si tu proyecto es viable, y qué pasos seguir.*

--- a/src/content/blog-seeds/contador/resimple-regimen-guia.md
+++ b/src/content/blog-seeds/contador/resimple-regimen-guia.md
@@ -1,0 +1,153 @@
+---
+slug: resimple-regimen-simplificado-paraguay
+title: "RESIMPLE: La Mejor Opción para Microempresas en Paraguay"
+excerpt: "El régimen simplificado paga un monto fijo mensual y reemplaza IRE + IVA + IRP. Ideal para microempresas con facturación anual bajo Gs. 600 millones."
+category: "Impuestos"
+tags: ["resimple", "microempresa", "ire", "iva", "irp"]
+author: "{{businessName}}"
+date: "2026-04-05"
+---
+
+# RESIMPLE: La Mejor Opción para Microempresas en Paraguay
+
+El **régimen RESIMPLE** (Régimen Simplificado del Impuesto a la Renta) es una de las mejores cosas que la reforma tributaria de 2019 trajo para microempresas paraguayas. Si tu facturación anual no supera los **Gs. 600 millones**, probablemente estás pagando más impuestos de los que deberías.
+
+## Qué es RESIMPLE
+
+Creado por la **Ley 6380/19**, RESIMPLE es un régimen que:
+
+1. **Reemplaza** IRE + IVA + IRP con un **tributo único mensual fijo**
+2. Escalona en **4 tramos** según facturación anual
+3. No exige **contabilidad completa** — solo registros simplificados
+4. **No permite deducciones** (es un tributo plano)
+
+Es ideal para: kioscos, despensas, peluquerías con 1-3 empleados, servicios técnicos pequeños, taxis, comercio minorista, profesionales independientes con bajos ingresos.
+
+## Los 4 tramos RESIMPLE
+
+Facturación anual y cuota fija mensual (2026, aprox):
+
+| Tramo | Facturación anual | Cuota mensual |
+|---|---|---:|
+| 1 | Hasta Gs. 80 millones | **Gs. 100.000** |
+| 2 | Gs. 80M - Gs. 200M | **Gs. 250.000** |
+| 3 | Gs. 200M - Gs. 400M | **Gs. 450.000** |
+| 4 | Gs. 400M - Gs. 600M | **Gs. 700.000** |
+
+Sobre Gs. 600M/año ya no calificás — debés pasar a **IRE Simple** o **IRE General**.
+
+## Cómo se compara con los otros regímenes
+
+Supongamos un kiosco con **Gs. 150M/año** de facturación y margen 20% (ganancia Gs. 30M/año):
+
+| Régimen | Impuesto anual | Carga administrativa |
+|---|---:|---|
+| **RESIMPLE (Tramo 2)** | Gs. 3.000.000 | Mínima — sin contabilidad completa |
+| **IRE Simple** | ~Gs. 3.000.000 (10% × 30M) | Media — estados contables simplificados |
+| **IRE General** | ~Gs. 3.000.000 + IVA | Alta — contabilidad completa |
+
+En tramos bajos, los impuestos pueden ser similares — pero el **ahorro en carga administrativa** de RESIMPLE es enorme. Menos horas con el contador = menos costo operativo.
+
+## Quién puede usar RESIMPLE
+
+**Califica** (cumpliendo con umbral de facturación):
+- Personas físicas (unipersonal)
+- Ciertas SRL pequeñas en algunas actividades
+- Comercios minoristas, servicios técnicos
+- Profesionales con actividad simple
+
+**NO califica**:
+- Sociedades anónimas (SA)
+- Empresas con alta complejidad (múltiples sucursales)
+- Actividades reguladas (banca, seguros, valores)
+- Importadores con régimen especial
+- Empresas con más de cierto número de empleados (variable por resolución)
+- Cooperativas (tienen régimen propio)
+
+**Atención**: las actividades específicas que pueden usar RESIMPLE están listadas en resoluciones DNIT. Confirmá con tu contador.
+
+## Ventajas del RESIMPLE
+
+1. **Cuota fija previsible** — no dependés del volumen mensual
+2. **Sin IVA** — no emitís nota fiscal con IVA detallado
+3. **Sin contabilidad completa** — registros mensuales simplificados
+4. **Sin declaración jurada anual** — cuota mensual y listo
+5. **Menos riesgo de fiscalización** — menos superficie para auditar
+6. **Honorarios contables más bajos** — menos trabajo = menos costo
+
+## Desventajas
+
+1. **No podés emitir facturas con crédito fiscal de IVA** — tus clientes no pueden recuperar IVA (afecta si vendés a otras empresas)
+2. **No podés deducir gastos** — la cuota es fija independientemente de tu ganancia real
+3. **Si crecés, debés cambiar de régimen** — al superar Gs. 600M anuales, transición a IRE
+4. **Clasificación por actividad** — DNIT puede discutir si tu rubro realmente califica
+
+## Cómo inscribirse en RESIMPLE
+
+1. **Apertura de RUC** en DNIT — indicar régimen RESIMPLE
+2. **Declarar actividad económica** dentro de los rubros elegibles
+3. **Estimar facturación anual** (para determinar tramo inicial)
+4. **Pagar primera cuota** mensual el día 10 del mes siguiente
+
+Tiempo: **2-3 días hábiles**.
+
+## Cómo cambiar de régimen
+
+### De RESIMPLE a IRE
+
+Esto **DEBE ocurrir** si superás los Gs. 600M anuales. También podés cambiarte voluntariamente si preferís deducir gastos y emitir facturas con crédito fiscal.
+
+Pasos:
+1. Comunicar el cambio al DNIT antes del 1° de enero del año siguiente
+2. Cerrar RESIMPLE a fin de año
+3. Arrancar IRE desde enero con contabilidad nueva
+
+### De IRE a RESIMPLE
+
+También posible si tu facturación baja. Requiere tiempo (generalmente 2 ejercicios demostrando facturación < tope) y no siempre aceptado.
+
+## Cuota 2026 y actualización
+
+Los montos se **actualizan anualmente** por resolución DNIT, indexados al IPC (inflación). Consultá el valor vigente en Marangatú o con tu contador.
+
+## Errores comunes
+
+1. **Seguir en RESIMPLE al superar Gs. 600M** — automáticamente estás en infracción; DNIT puede recalcular
+2. **Facturar con IVA separado** — el régimen no lo permite; estás emitiendo mal
+3. **No declarar cambio de actividad** — si tu rubro cambia y deja de calificar, debés salir del régimen
+4. **No pagar en tiempo** — cuota mensual con intereses moratorios acumula rápido
+
+## Cuándo NO te conviene RESIMPLE
+
+- Si vendés **mayormente B2B** (otras empresas que necesitan recuperar IVA)
+- Si tenés **muchos gastos deducibles** — perdés el beneficio fiscal
+- Si sos **exportador** — hay regímenes mejores
+- Si necesitás **estados contables** para financiación bancaria — RESIMPLE no los genera
+
+## Ejemplo real
+
+**Peluquería unipersonal en Asunción**:
+- Facturación anual: Gs. 180M
+- Gastos: Gs. 40M (insumos, alquiler, servicios)
+- Ganancia neta: Gs. 140M
+
+En RESIMPLE (Tramo 2): paga **Gs. 3M/año** fijos.
+En IRE Simple: pagaría **Gs. 14M** (10% de la ganancia neta).
+
+**Ahorro: Gs. 11M/año.** Clara ventaja para RESIMPLE.
+
+## Ejemplo donde NO conviene
+
+**Empresa B2B de servicios IT**:
+- Facturación anual: Gs. 500M
+- Gastos: Gs. 350M
+- Ganancia neta: Gs. 150M
+
+En RESIMPLE (Tramo 4): paga **Gs. 8.4M/año** fijos.
+En IRE Simple: pagaría **Gs. 15M** (10% × 150M).
+
+Parece ventajoso RESIMPLE — pero si sus clientes son empresas que necesitan crédito fiscal de IVA, **puede perder clientes** por no emitir factura con IVA. El ahorro fiscal queda eclipsado por el impacto comercial.
+
+---
+
+*Si estás considerando RESIMPLE o dudás si te conviene, usá nuestra [calculadora RESIMPLE](#calc-resimple-qualifier) o agendá una consulta gratuita. Te decimos honestamente cuál régimen te conviene.*

--- a/src/content/contador_cde.content.json
+++ b/src/content/contador_cde.content.json
@@ -1,0 +1,161 @@
+{
+  "id": "contador_cde",
+  "locale": "es-PY",
+  "hero": {
+    "headline": "{{businessName}} - Contabilidad trinacional en Ciudad del Este",
+    "subheadline": "Importadores, comerciantes triple frontera, maquiladoras, turismo. Atendemos en espanol, portugues y guarani. Conocemos la dinamica PY-BR-AR.",
+    "ctaPrimary": "Agendar Consulta",
+    "ctaSecondary": "Ver Servicios"
+  },
+  "about": {
+    "title": "Sobre {{businessName}}",
+    "content": "Desde Ciudad del Este acompanamos a importadores, comerciantes y maquiladoras que operan en la triple frontera. Sabemos trabajar con clientes brasileros y argentinos, coordinar con despachantes de aduana, y navegar los regimenes de importacion, turismo y maquila. Falamos portugues e entendemos a dinamica da fronteira.",
+    "bullets": [
+      "Atendemos en espanol, portugues y guarani",
+      "Especialistas en regimen de importacion comercial",
+      "Regimen de Turismo (Ley 60/90 original, reformas subsecuentes)",
+      "Coordinacion con despachantes aduaneros",
+      "Maquila Ley 1064/97 para operaciones de ensamble"
+    ]
+  },
+  "services": {
+    "title": "Servicios para la Triple Frontera",
+    "subtitle": "Todo lo que un negocio CDE necesita, en tres idiomas",
+    "categories": [
+      {
+        "id": "importacion",
+        "name": "Regimen de Importacion",
+        "description": "Coordinacion completa con despachantes de aduana.",
+        "icon": "truck",
+        "items": [
+          "Gestion ante DNA (Direccion Nacional de Aduanas)",
+          "Coordinacion con despachante habilitado",
+          "Clasificacion NALADISA / MERCOSUR",
+          "IVA + aranceles de importacion",
+          "Regimen de Turismo / comercial / Zona Franca",
+          "Registro de importador-exportador"
+        ]
+      },
+      {
+        "id": "comercio-frontera",
+        "name": "Comercio Triple Frontera",
+        "description": "Tiendas electronicas, comercio general, venta a turistas brasileros y argentinos.",
+        "icon": "store",
+        "items": [
+          "IVA 10% / 5% segun producto",
+          "IRE Simple o General segun volumen",
+          "Emision de comprobantes de venta a extranjeros",
+          "Manejo de monedas USD / BRL / ARS",
+          "Conciliaciones multimoneda"
+        ]
+      },
+      {
+        "id": "maquila-cde",
+        "name": "Maquila Electronica / Ensamble",
+        "description": "Ley 1064/97 para operaciones industriales con clientes brasileros.",
+        "icon": "factory",
+        "items": [
+          "Aprobacion de Programa de Maquila",
+          "Tributo unico 1% sobre facturacion",
+          "Reporting trimestral CNIME",
+          "Certificado de origen MERCOSUR 60/40",
+          "Importacion temporal de insumos"
+        ]
+      },
+      {
+        "id": "turismo",
+        "name": "Regimen de Turismo",
+        "description": "Vendedores a turistas brasileros y argentinos bajo regimenes especiales.",
+        "icon": "map-pin",
+        "items": [
+          "Cumplimiento regimen turismo",
+          "Emision de notas fiscales y facturas electronicas",
+          "Coordinacion con camaras de comercio",
+          "Declaraciones a BCP por operaciones en divisas"
+        ]
+      },
+      {
+        "id": "laboral-cde",
+        "name": "Laboral Multicultural",
+        "description": "Empleados paraguayos, brasileros residentes, argentinos en puestos especializados.",
+        "icon": "users",
+        "items": [
+          "Planilla de sueldos + IPS + MTESS",
+          "Empleados extranjeros con permiso de trabajo",
+          "Contratos bilingues cuando corresponde",
+          "Coordinacion migratoria (DGMC)"
+        ]
+      }
+    ]
+  },
+  "pricing": {
+    "title": "Planos",
+    "subtitle": "Atendemos desde o pequeno comerciante ate a maquila industrial.",
+    "plans": [
+      {
+        "id": "comercio-chico",
+        "name": "Comercio Pequeno",
+        "priceFrom": "900.000 Gs/mes",
+        "description": "Tienda local, facturacion anual < Gs. 1.500M, hasta 5 empleados.",
+        "features": [
+          "IVA + IRE Simple mensual",
+          "Hasta 5 sueldos + IPS",
+          "Coordinacion basica con despachante",
+          "WhatsApp en ES/PT"
+        ]
+      },
+      {
+        "id": "importador",
+        "name": "Importador / Comerciante",
+        "priceFrom": "2.500.000 Gs/mes",
+        "description": "Operacion de importacion regular, facturacion Gs. 1.500M-5.000M.",
+        "features": [
+          "Regimen de importacion completo",
+          "Hasta 20 sueldos + IPS + MTESS",
+          "Coordinacion aduanera",
+          "Reporting en PT para casa matriz",
+          "Balance mensual + anual"
+        ],
+        "featured": true
+      },
+      {
+        "id": "maquila",
+        "name": "Maquila",
+        "priceFrom": "Consultar",
+        "description": "Operacion industrial bajo Ley 1064/97.",
+        "features": [
+          "Tributo unico + CNIME trimestral",
+          "Certificados de origen MERCOSUR",
+          "Contabilidad multi-idioma ES/PT/EN",
+          "Coordinacion con gerencia internacional"
+        ]
+      }
+    ]
+  },
+  "testimonials": [
+    {
+      "quote": "Tenia un negocio familiar en CDE vendiendo a brasileros. Ellos entendieron mi realidad desde el primer dia y me ayudaron a formalizar sin perder clientes.",
+      "author": "Carlos Alves",
+      "role": "Comerciante electronica",
+      "rating": 5
+    },
+    {
+      "quote": "Nossa maquiladora trabalha com clientes em Sao Paulo. Eles reportam mensal em portugues e coordenam com nossos auditores brasileiros sem problema.",
+      "author": "Luiza Ferreira",
+      "role": "CFO, maquiladora textil",
+      "rating": 5
+    }
+  ],
+  "faq": [
+    { "q": "Falam portugues?", "a": "Sim. Varios membros da nossa equipe falam portugues fluente. Podemos escrever, reunir e prestar servicos em espanhol ou portugues, conforme preferir." },
+    { "q": "Atienden brasileros con empresa en Paraguay?", "a": "Si — es nuestra especialidad. Coordinamos con contadores brasileros si es necesario, y manejamos reporting en portugues para la casa matriz." },
+    { "q": "Conocen el regimen de turismo?", "a": "Si. Atendemos a comercios que venden a turistas brasileros y argentinos bajo los regimenes vigentes." },
+    { "q": "Trabajan con despachantes de aduana?", "a": "Si, con varios despachantes habilitados en CDE. Los clientes pueden usar al nuestro o traer su propio despachante — lo coordinamos." },
+    { "q": "Pueden hacer reporting mensual a casa matriz en Brasil?", "a": "Si. Emitimos DRE (Demonstracao do Resultado) en formato brasilero cuando lo pide la matriz, junto con los reportes DNIT locales." }
+  ],
+  "footer": {
+    "tagline": "{{businessName}} - Estudio Contable en Ciudad del Este",
+    "copyright": "© {{year}} {{businessName}}",
+    "disclaimer": "Matriculados CCP - Atendemos ES / PT / GN"
+  }
+}

--- a/src/content/contador_chaco.content.json
+++ b/src/content/contador_chaco.content.json
@@ -1,0 +1,149 @@
+{
+  "id": "contador_chaco",
+  "locale": "es-PY",
+  "hero": {
+    "headline": "{{businessName}} - Contabilidad para el Chaco paraguayo",
+    "subheadline": "Cooperativas mennonitas, ganaderia, comercio local y productores del Chaco Central y Boqueron. Atencion en espanol y aleman.",
+    "ctaPrimary": "Consulta Inicial",
+    "ctaSecondary": "Nuestros Servicios"
+  },
+  "about": {
+    "title": "Sobre {{businessName}}",
+    "content": "Desde {{city}} atendemos a cooperativas, ganaderos, comerciantes y productores del Chaco. Conocemos la realidad bilingue de la region y las particularidades de cada cooperativa (Chortitzer, Neuland, Fernheim). Nuestra atencion es sobria, metodica y respetuosa de la cultura menonita — wir kennen Ihre Welt.",
+    "bullets": [
+      "Atencion en espanol y aleman (Deutsch/Plattdeutsch)",
+      "Especialistas en cooperativas mennonitas",
+      "Ganaderia + agricultura subtropical",
+      "SENACSA e INCOOP dominados",
+      "Discrecion y continuidad generacional"
+    ]
+  },
+  "services": {
+    "title": "Servicios para el Chaco",
+    "subtitle": "Todo lo que una operacion del Chaco necesita, en los dos idiomas",
+    "categories": [
+      {
+        "id": "cooperativas",
+        "name": "Cooperativas Menonitas",
+        "description": "Reporting completo ante INCOOP, Balance Social y asamblea anual.",
+        "icon": "users",
+        "items": [
+          "Estados contables INCOOP",
+          "Balance Social Cooperativo (Res. 4109/09)",
+          "Preparacion de asamblea general anual (Jahresversammlung)",
+          "Distribucion de excedentes al socio",
+          "Auditoria externa obligatoria",
+          "Documentacion bilingue ES/DE"
+        ]
+      },
+      {
+        "id": "ganaderia",
+        "name": "Ganaderia y Campo",
+        "description": "IRE Agropecuario, SENACSA, trazabilidad para exportacion.",
+        "icon": "bull",
+        "items": [
+          "Liquidacion IRE Simple Agropecuario",
+          "Registro SENACSA (marcas, senales, SIGOR)",
+          "Constancia de no retencion",
+          "Certificados de origen para exportacion",
+          "Mortandad y consumo interno (deducibles)"
+        ]
+      },
+      {
+        "id": "comercio",
+        "name": "Comercio e Industria Chaquena",
+        "description": "Empresas locales: supermercados, ferreterias, maquinaria, transporte.",
+        "icon": "store",
+        "items": [
+          "Contabilidad mensual completa",
+          "IVA + IRE + IRP + IDU",
+          "Liquidacion de sueldos + IPS + MTESS",
+          "Balance anual segun NIIF para PYMES",
+          "Coordinacion bancaria con Cooperativa y BNF"
+        ]
+      },
+      {
+        "id": "laboral-rural",
+        "name": "Laboral Rural",
+        "description": "Peones, temporeros y empleados administrativos del Chaco.",
+        "icon": "hard-hat",
+        "items": [
+          "Contratos bajo Ley 5115 (trabajador rural)",
+          "Aportes IPS obrero rural",
+          "Planilla MTESS-REOP mensual",
+          "Zafreros y trabajadores temporarios"
+        ]
+      }
+    ]
+  },
+  "pricing": {
+    "title": "Planes",
+    "subtitle": "Honorarios ajustados a la economia del Chaco.",
+    "plans": [
+      {
+        "id": "productor-chico",
+        "name": "Productor Chaquen",
+        "priceFrom": "700.000 Gs/mes",
+        "description": "Ganadero hasta 300 cabezas o agricultor mediano.",
+        "features": [
+          "IRE Simple Agropecuario",
+          "SENACSA basico",
+          "IVA si corresponde",
+          "Asesoria por WhatsApp (ES/DE)"
+        ]
+      },
+      {
+        "id": "cooperativa-socio",
+        "name": "Socio Cooperativa",
+        "priceFrom": "1.200.000 Gs/mes",
+        "description": "Productor socio activo en Chortitzer, Neuland o Fernheim.",
+        "features": [
+          "Coordinacion con el reporting cooperativo",
+          "IRE + IVA personales",
+          "Planilla de sueldos si tiene personal",
+          "Asesoria regulatoria bilingue"
+        ],
+        "featured": true
+      },
+      {
+        "id": "empresa-chaquena",
+        "name": "Empresa Chaquena",
+        "priceFrom": "3.500.000 Gs/mes",
+        "description": "Comercio o industria instalada en Filadelfia, Loma Plata o Neuland.",
+        "features": [
+          "Contabilidad empresarial completa",
+          "Hasta 30 sueldos + IPS + MTESS",
+          "Balance anual NIIF para PYMES",
+          "Reporting bilingue a directorio",
+          "Auditoria externa si corresponde"
+        ]
+      }
+    ]
+  },
+  "testimonials": [
+    {
+      "quote": "Nuestra cooperativa ha trabajado con ellos por 10 anos. Entienden nuestra cultura y trabajo metodico. Das Vertrauen ist da.",
+      "author": "Peter Friesen",
+      "role": "Gerente, cooperativa Chaco",
+      "rating": 5
+    },
+    {
+      "quote": "Puedo escribirles en aleman cuando tengo dudas y reciben respuesta clara. Para los que crecimos con el Platt, es un alivio.",
+      "author": "Margarethe Wiebe",
+      "role": "Productora ganadera",
+      "rating": 5
+    }
+  ],
+  "faq": [
+    { "q": "Sprechen Sie Deutsch?", "a": "Ja. Mehrere unserer Mitarbeiter sprechen fliessend Deutsch und verstehen auch Plattdeutsch. Schreiben Sie uns auf Deutsch — wir antworten auf Deutsch." },
+    { "q": "Atienden en aleman y espanol?", "a": "Si. Varios miembros de nuestro equipo hablan aleman fluido y comprenden Plattdeutsch. Podes escribirnos en cualquiera de los dos idiomas." },
+    { "q": "Viajan al Chaco?", "a": "Si. Visitamos Filadelfia, Loma Plata, Neuland y los establecimientos periodicamente. Tambien trabajamos 100% digital con clientes en Asuncion, Mariscal Estigarribia y otras ciudades chaquenas." },
+    { "q": "Trabajan con las tres cooperativas del Chaco Central?", "a": "Si. Chortitzer, Neuland y Fernheim — tenemos clientes socios en las tres. Respetamos la confidencialidad de cada relacion." },
+    { "q": "Conocen la tributacion rural?", "a": "Si. IRE Agropecuario, SENACSA, IPS obrero rural, zafreros — es nuestro dia a dia." }
+  ],
+  "footer": {
+    "tagline": "{{businessName}} - Estudio Contable en {{city}} (Chaco)",
+    "copyright": "© {{year}} {{businessName}}",
+    "disclaimer": "Matriculados CCP — Atencion ES/DE"
+  }
+}

--- a/src/content/contador_tecnologia.content.json
+++ b/src/content/contador_tecnologia.content.json
@@ -1,0 +1,205 @@
+{
+  "id": "contador_tecnologia",
+  "locale": "es-PY",
+  "hero": {
+    "headline": "{{businessName}} - Accounting for Tech & SaaS Companies",
+    "subheadline": "Exportacion de servicios, territorial tax 0%, stock options, reporting bilingue para inversores. Para startups, software houses y SaaS operando desde Paraguay.",
+    "ctaPrimary": "Book Free Consultation",
+    "ctaSecondary": "See Services"
+  },
+  "about": {
+    "title": "About {{businessName}}",
+    "content": "We serve technology companies operating from Paraguay — from 2-person SaaS startups to 50+ headcount software houses. We leverage Paraguay's territorial tax system (10% local / 0% foreign) to minimize tax burden legally, handle stock options accounting, payroll for distributed teams, and bilingual reporting for international investors.",
+    "bullets": [
+      "Expertise on Paraguay's territorial tax for software exports",
+      "Stock options (ESOP) accounting and tax treatment",
+      "Payroll for distributed teams (PY + remote LATAM)",
+      "Bilingual ES/EN reporting for VCs and auditors",
+      "Familiar with QuickBooks, Xero, NetSuite, Stripe data"
+    ]
+  },
+  "services": {
+    "title": "Services for Tech Companies",
+    "subtitle": "Every filing, every report, aligned with how tech companies actually operate",
+    "categories": [
+      {
+        "id": "export-services",
+        "name": "Software Export Tax Treatment",
+        "description": "Services exported from PY to foreign clients qualify as foreign-source income (0% IRE).",
+        "icon": "code",
+        "items": [
+          "Classification of services as export (vs local)",
+          "Exemption from IVA on exports",
+          "Territorial IRE 0% on foreign-source revenue",
+          "Documentation for DNIT substantiation",
+          "Annual audit trail for exempt revenue"
+        ]
+      },
+      {
+        "id": "payroll-tech",
+        "name": "Tech Payroll (Local + Distributed)",
+        "description": "PY employees + remote contractors across LATAM + stock option vesting schedules.",
+        "icon": "users",
+        "items": [
+          "IPS + MTESS for PY employees",
+          "Independent contractors in AR, BR, CO, UY, CL, MX",
+          "Stock option / RSU vesting accounting",
+          "Exercise tax treatment (when options become taxable)",
+          "Expense reimbursement programs"
+        ]
+      },
+      {
+        "id": "stock-options",
+        "name": "Equity Compensation (ESOPs)",
+        "description": "Common framework: US-style options pool + PY-resident employees.",
+        "icon": "trending-up",
+        "items": [
+          "ESOP structure design (pool size, vesting)",
+          "Option grant accounting (IFRS 2 compliant)",
+          "Exercise taxation for PY residents",
+          "83(b) election coordination for US cofounders",
+          "Cliff + vesting schedule administration"
+        ]
+      },
+      {
+        "id": "funding",
+        "name": "Funding & Investor Reporting",
+        "description": "Pre-seed to Series A+. Monthly investor updates, cap table, financial statements.",
+        "icon": "chart-bar",
+        "items": [
+          "SAFE and convertible note accounting",
+          "Priced round (equity) transaction handling",
+          "Monthly investor updates (ES/EN)",
+          "Cap table integration (Carta / AngelList)",
+          "Financial statements for due diligence",
+          "Audit-ready books from day 1"
+        ]
+      },
+      {
+        "id": "saas-metrics",
+        "name": "SaaS Financial Metrics",
+        "description": "MRR, ARR, CAC, churn — reported monthly, in the format VCs expect.",
+        "icon": "bar-chart",
+        "items": [
+          "MRR / ARR reporting with cohort analysis",
+          "CAC and LTV calculations",
+          "Monthly/annual recurring revenue classification",
+          "Deferred revenue recognition (ASC 606-style)",
+          "Churn rate and expansion metrics",
+          "Stripe / Paddle / LemonSqueezy integration"
+        ]
+      },
+      {
+        "id": "entity-structure",
+        "name": "Entity & International Structure",
+        "description": "EAS in PY + Delaware C-corp + international subsidiaries.",
+        "icon": "globe",
+        "items": [
+          "EAS for PY operations",
+          "Delaware C-corp + PY subsidiary common pattern",
+          "Intercompany agreements (transfer pricing ready)",
+          "Permanent establishment analysis",
+          "Tax treaty application (CDI)"
+        ]
+      }
+    ]
+  },
+  "pricing": {
+    "title": "Packages for Tech Companies",
+    "subtitle": "USD reference pricing. Crypto accepted.",
+    "disclaimer": "Scope scales with team size, revenue, and complexity (equity, multi-entity).",
+    "plans": [
+      {
+        "id": "pre-seed",
+        "name": "Pre-Seed Startup",
+        "priceFrom": "USD 499/month",
+        "description": "Founders only, up to USD 500k ARR, single entity PY.",
+        "features": [
+          "Monthly IVA + IRE filings",
+          "Up to 5 team members",
+          "Basic SaaS metrics (MRR, ARR)",
+          "Stripe integration",
+          "Monthly investor update (ES/EN)"
+        ]
+      },
+      {
+        "id": "seed",
+        "name": "Seed",
+        "priceFrom": "USD 1,200/month",
+        "description": "Up to USD 2M ARR, 10-20 team, stock options program, 1-2 foreign subs.",
+        "features": [
+          "Full compliance PY + foreign subs",
+          "ESOP accounting",
+          "Cap table maintenance",
+          "Monthly MRR cohorts + CAC/LTV",
+          "Bilingual board reports",
+          "Audit-ready books"
+        ],
+        "featured": true
+      },
+      {
+        "id": "series-a",
+        "name": "Series A+",
+        "priceFrom": "Contact",
+        "description": "Post-funding companies, multi-entity, audit-required.",
+        "features": [
+          "Dedicated controller + senior accountant",
+          "Multi-entity consolidation",
+          "Audit coordination (IFRS / US GAAP)",
+          "Continuous investor reporting",
+          "Transfer pricing documentation",
+          "Strategic tax planning"
+        ]
+      }
+    ]
+  },
+  "process": {
+    "title": "How We Work with Tech Companies",
+    "steps": [
+      { "number": "1", "title": "Free Diagnostic", "description": "30-minute video call. We review your stack (Stripe, Carta, Gusto, QBO) and ask the right questions." },
+      { "number": "2", "title": "Structured Proposal", "description": "Written scope with deliverables, timeline, USD pricing, and clear handoff SLAs." },
+      { "number": "3", "title": "Onboarding", "description": "Read-only access to your financial tools. Historical clean-up if needed (usually 30-60 days)." },
+      { "number": "4", "title": "Monthly Ops", "description": "Close by 5th business day. Investor update draft by 10th. SaaS metrics report attached." },
+      { "number": "5", "title": "Quarterly Planning", "description": "Tax planning review, fundraising prep, cash-out analysis — things VCs care about." }
+    ]
+  },
+  "testimonials": [
+    {
+      "quote": "We moved from a US accounting firm that didn't understand PY territorial tax. Saved us six figures in our first year alone.",
+      "author": "Max R.",
+      "role": "CEO, B2B SaaS (Series A, PY/US)",
+      "rating": 5
+    },
+    {
+      "quote": "Monthly investor updates in perfect English, MRR cohort data delivered by the 10th every month. Our board loves them.",
+      "author": "Soledad P.",
+      "role": "CFO, Marketplace Startup",
+      "rating": 5
+    },
+    {
+      "quote": "As a 4-person startup we couldn't afford a Big 4 firm but needed audit-quality books for our seed round. These folks delivered.",
+      "author": "Ivan W.",
+      "role": "Founder, Dev Tools Startup",
+      "rating": 5
+    }
+  ],
+  "faq": [
+    { "q": "Do you understand Paraguay's territorial tax system?", "a": "Yes. It's core to what we do. Service exports from PY are foreign-source income and qualify for 0% IRE. We document the substantiation correctly for DNIT." },
+    { "q": "Can you handle our US C-corp + PY subsidiary structure?", "a": "Yes. This is the most common pattern for PY-founded startups. We coordinate with your US tax advisor and handle the PY side end-to-end." },
+    { "q": "Do you integrate with our stack (Stripe, QuickBooks, Carta)?", "a": "Yes. Read-only API access is standard. We can also pull data from Gusto/Deel (payroll), AngelList, Carta (cap table), and major SaaS billing platforms." },
+    { "q": "How do you handle stock options for PY employees?", "a": "Common pattern: Delaware C-corp issues options, PY employees exercise under PY tax rules. Gain at exercise is taxable as IRP in PY. We document grant, vesting, and exercise correctly." },
+    { "q": "Can you work in English?", "a": "Yes — our team operates bilingually. Monthly reports, tax filings, board updates can all be delivered in English." },
+    { "q": "What if we raise and need audited financials?", "a": "We deliver audit-ready books from day 1. When audit is required (usually Series A+), we coordinate with Big 4 or boutique firms — our books pass." },
+    { "q": "How do you handle remote contractors across LATAM?", "a": "We advise on whether each arrangement is contractor vs employee in each country (AR, BR, CO, UY, MX). We coordinate with local providers (Deel, Ontop) for payment and compliance." }
+  ],
+  "cta": {
+    "title": "Ready to work with an accountant who gets tech?",
+    "subtitle": "Free 30-minute diagnostic in English or Spanish. We'll tell you honestly if we're a fit for your stage.",
+    "button": "Book Free Consultation"
+  },
+  "footer": {
+    "tagline": "{{businessName}} - Accounting for Tech & SaaS in Paraguay",
+    "copyright": "© {{year}} {{businessName}}",
+    "disclaimer": "CCP-certified accountants. Trusted by VC-backed startups."
+  }
+}

--- a/src/registry/contador_tecnologia.type.json
+++ b/src/registry/contador_tecnologia.type.json
@@ -1,0 +1,88 @@
+{
+  "id": "contador_tecnologia",
+  "nameEs": "Contador para Empresas de Tecnologia",
+  "nameEn": "Tech & SaaS Accountant",
+  "verticalId": "b2b-professional",
+  "extends": "contador",
+  "tokens": "contador_tecnologia",
+  "content": "contador_tecnologia",
+  "schema": "contador",
+  "icon": "code",
+  "pages": {
+    "homepage": {
+      "sections": [
+        "header",
+        "hero",
+        "servicesPreview",
+        "pricingTable",
+        "process",
+        "testimonial",
+        "faq",
+        "leadForm",
+        "footer"
+      ],
+      "requiredSections": ["header", "hero", "servicesPreview", "contact", "footer"]
+    }
+  },
+  "features": {
+    "leadForm": {
+      "enabled": true,
+      "fields": ["name", "email", "companyName", "stage", "arr", "headcount", "countries", "message"]
+    },
+    "pricingDisplay": {
+      "enabled": true,
+      "showCurrency": "USD",
+      "cryptoAccepted": ["BTC", "ETH", "USDC"]
+    },
+    "languageToggle": {
+      "enabled": true,
+      "languages": ["en", "es"]
+    },
+    "whatsappFloat": { "enabled": true }
+  },
+  "serviceCategories": [
+    "export-services",
+    "payroll-tech",
+    "stock-options",
+    "funding",
+    "saas-metrics",
+    "entity-structure"
+  ],
+  "regulatoryVocab": {
+    "taxAuthority": "DNIT",
+    "territorialRule": "0% IRE on foreign-source (export) services",
+    "equityStandards": ["IFRS 2 (share-based payment)", "ASC 718 (US equivalent)"],
+    "commonIntegrations": ["Stripe", "QuickBooks", "Xero", "Carta", "AngelList", "Gusto", "Deel", "NetSuite"]
+  },
+  "targetAudience": {
+    "primary": "VC-backed SaaS startups founded in or operating from Paraguay",
+    "secondary": "Software houses exporting services internationally",
+    "tertiary": "Remote-first tech teams with PY HQ + distributed LATAM"
+  },
+  "seo": {
+    "schemaType": "AccountingService",
+    "titleTemplate": "{{businessName}} - Accounting for Tech & SaaS Companies | Paraguay Territorial Tax",
+    "descriptionTemplate": "Accounting, payroll, stock options and investor reporting for VC-backed startups and SaaS companies operating from Paraguay. Bilingual ES/EN.",
+    "keywords": [
+      "accountant SaaS Paraguay",
+      "tech accountant Paraguay",
+      "territorial tax SaaS",
+      "startup accounting Paraguay",
+      "stock options ESOP Paraguay",
+      "software export tax",
+      "VC reporting Paraguay",
+      "Delaware PY subsidiary"
+    ]
+  },
+  "nav": {
+    "items": ["Home", "Services", "Pricing", "Process", "FAQ", "Contact"],
+    "cta": { "text": "Book Free Consultation", "action": "leadForm" }
+  },
+  "hero": {
+    "style": "minimal",
+    "headlineTemplate": "{{businessName}} - Accounting Built for Tech",
+    "subheadlineTemplate": "Territorial tax, stock options, investor reporting and bilingual compliance — for startups and SaaS operating from Paraguay.",
+    "ctaPrimary": { "text": "Book Free Consultation", "action": "leadForm" },
+    "ctaSecondary": { "text": "See Pricing", "action": "scrollTo:pricing" }
+  }
+}

--- a/src/tokens/contador_tecnologia.tokens.json
+++ b/src/tokens/contador_tecnologia.tokens.json
@@ -1,0 +1,36 @@
+{
+  "name": "Accounting for Tech & SaaS Companies",
+  "extends": "base",
+  "theme": "light",
+  "mood": ["modern", "technical", "startup-friendly", "international"],
+
+  "palettes": {
+    "optionA": {
+      "name": "Silicon Ink & Electric Blue",
+      "colors": {
+        "primary": "#1e293b",
+        "secondary": "#2563eb",
+        "accent": "#06b6d4",
+        "background": "#fafafa",
+        "surface": "#ffffff",
+        "text": "#0f172a",
+        "textLight": "#475569",
+        "border": "#e2e8f0",
+        "success": "#10b981",
+        "warning": "#f59e0b",
+        "error": "#ef4444"
+      }
+    }
+  },
+
+  "defaultPalette": "optionA",
+  "typography": {
+    "heading": "'Space Grotesk', 'Inter', sans-serif",
+    "body": "'Inter', sans-serif"
+  },
+  "googleFonts": [
+    "Inter:wght@400;500;600;700",
+    "Space Grotesk:wght@500;600;700"
+  ],
+  "borderRadius": "md"
+}

--- a/web/components/sections/calc-resimple-qualifier-section.tsx
+++ b/web/components/sections/calc-resimple-qualifier-section.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Button } from '@/components/ui/button'
+import { AnimatedSectionHeader } from '@/components/ui/animate-on-scroll'
+
+/**
+ * Paraguay RESIMPLE qualifier — helps micro-contribuyentes decide if
+ * they qualify for the Regimen Simplificado de Impuesto a la Renta
+ * (tributo unico escalonado).
+ *
+ * Law 6380/19 + DNIT resolutions:
+ *   - Facturacion anual <= Gs. 80.000.000  → tramo 1 (mas bajo)
+ *   - Hasta Gs. 200M, Gs. 400M, Gs. 600M → tramos subsiguientes
+ *   - Por encima de Gs. 600M → NO califica; debe ir a IRE Simple o General
+ *
+ * RESIMPLE paga un monto FIJO mensual segun tramo, no un porcentaje
+ * sobre ganancia. Simplifica enormemente la carga administrativa.
+ */
+
+export interface CalcResimpleQualifierSectionProps {
+  eyebrow?: string
+  title?: string
+  subtitle?: string
+  disclaimer?: string
+  ctaLabel?: string
+  ctaHref?: string
+  whatsapp?: string
+}
+
+const RESIMPLE_BRACKETS = [
+  { max: 80_000_000, monthlyFee: 100_000, label: 'Tramo 1' },
+  { max: 200_000_000, monthlyFee: 250_000, label: 'Tramo 2' },
+  { max: 400_000_000, monthlyFee: 450_000, label: 'Tramo 3' },
+  { max: 600_000_000, monthlyFee: 700_000, label: 'Tramo 4' },
+] as const
+
+const RESIMPLE_CEILING = 600_000_000
+
+function formatGs(n: number): string {
+  return new Intl.NumberFormat('es-PY', { maximumFractionDigits: 0 }).format(Math.max(0, Math.round(n))) + ' Gs'
+}
+
+export function CalcResimpleQualifierSection({
+  eyebrow = 'Calculadora RESIMPLE',
+  title = 'Podes usar regimen RESIMPLE?',
+  subtitle = 'Regimen simplificado para micro-contribuyentes. Pagas un monto fijo mensual y listo. Verifica si calificas y cuanto pagarias.',
+  disclaimer,
+  ctaLabel = 'Consultar si conviene RESIMPLE',
+  ctaHref = '#contacto',
+  whatsapp,
+}: CalcResimpleQualifierSectionProps) {
+  const [revenue, setRevenue] = useState<number>(150_000_000)
+
+  const result = useMemo(() => {
+    if (revenue > RESIMPLE_CEILING) {
+      return {
+        qualifies: false,
+        bracket: null,
+        monthlyFee: 0,
+        annualFee: 0,
+        message: `No calificas para RESIMPLE. Facturacion excede Gs. ${formatGs(RESIMPLE_CEILING)}.`,
+        recommendation: 'Debes ir a IRE Simple o IRE General (10% sobre utilidad neta).',
+      }
+    }
+    const bracket = RESIMPLE_BRACKETS.find((b) => revenue <= b.max) || RESIMPLE_BRACKETS[RESIMPLE_BRACKETS.length - 1]
+    return {
+      qualifies: true,
+      bracket,
+      monthlyFee: bracket.monthlyFee,
+      annualFee: bracket.monthlyFee * 12,
+      message: `Calificas al ${bracket.label}. Pagas Gs. ${formatGs(bracket.monthlyFee)}/mes fijo.`,
+      recommendation: 'RESIMPLE reemplaza IRE + IVA + IRP. Contabilidad super simplificada.',
+    }
+  }, [revenue])
+
+  const whatsappHref = whatsapp
+    ? `https://wa.me/${whatsapp.replace(/\D/g, '')}?text=${encodeURIComponent('Hola, quiero saber si el regimen RESIMPLE conviene para mi negocio.')}`
+    : null
+
+  return (
+    <section className="py-16 bg-[var(--surface,#ffffff)] sm:py-24">
+      <Container>
+        <AnimatedSectionHeader>
+          <p className="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--secondary)]">{eyebrow}</p>
+          <Heading level={2}>{title}</Heading>
+          <p className="mx-auto mt-4 max-w-2xl text-[var(--text-light,#475569)]">{subtitle}</p>
+        </AnimatedSectionHeader>
+
+        <div className="mx-auto mt-12 max-w-3xl rounded-2xl border border-[var(--border,#e2e8f0)] bg-[var(--surface,#ffffff)] p-6 shadow-sm sm:p-10">
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-[var(--text,#0f172a)]">Facturacion anual estimada (Gs)</span>
+            <input
+              type="number"
+              inputMode="numeric"
+              min={0}
+              step={10_000_000}
+              value={revenue}
+              onChange={(e) => setRevenue(Math.max(0, Number(e.target.value) || 0))}
+              className="w-full rounded-md border border-[var(--border,#e2e8f0)] bg-[var(--surface,#ffffff)] px-3 py-2.5 text-base text-[var(--text,#0f172a)] focus:border-[var(--secondary)] focus:outline-none"
+            />
+            <span className="mt-1 block text-xs text-[var(--text-muted,#64748b)]">{formatGs(revenue)}</span>
+          </label>
+
+          <div className="mt-8 rounded-xl bg-[var(--surface-light,#f8fafc)] p-6">
+            {result.qualifies && result.bracket ? (
+              <>
+                <p className="text-xs uppercase tracking-wider text-emerald-700">Calificas para RESIMPLE</p>
+                <p className="mt-1 text-3xl font-bold" style={{ color: 'var(--primary)', fontFamily: 'var(--font-heading)' }}>
+                  {formatGs(result.monthlyFee)}/mes
+                </p>
+                <p className="mt-2 text-sm text-[var(--text-light,#475569)]">
+                  {result.bracket.label} — facturacion hasta {formatGs(result.bracket.max)}/ano
+                </p>
+                <p className="mt-2 text-sm text-[var(--text,#0f172a)]">
+                  Costo anual total: <strong>{formatGs(result.annualFee)}</strong>
+                </p>
+                <p className="mt-3 text-xs text-[var(--text-muted,#64748b)]">{result.recommendation}</p>
+              </>
+            ) : (
+              <>
+                <p className="text-xs uppercase tracking-wider text-rose-700">No calificas</p>
+                <p className="mt-1 text-lg font-bold text-[var(--text,#0f172a)]">{result.message}</p>
+                <p className="mt-2 text-sm text-[var(--text-light,#475569)]">{result.recommendation}</p>
+              </>
+            )}
+          </div>
+
+          <div className="mt-6 overflow-x-auto">
+            <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--text-muted,#64748b)]">
+              Tabla RESIMPLE 2026
+            </h3>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--border,#e2e8f0)] text-left text-xs uppercase tracking-wider text-[var(--text-muted,#64748b)]">
+                  <th className="py-2 pr-3">Tramo</th>
+                  <th className="py-2 pr-3">Facturacion hasta</th>
+                  <th className="py-2 text-right">Cuota mensual</th>
+                </tr>
+              </thead>
+              <tbody>
+                {RESIMPLE_BRACKETS.map((b) => (
+                  <tr
+                    key={b.label}
+                    className={`border-b border-[var(--border,#e2e8f0)] last:border-0 ${
+                      result.qualifies && result.bracket?.label === b.label ? 'bg-emerald-50 font-semibold' : ''
+                    }`}
+                  >
+                    <td className="py-2 pr-3">{b.label}</td>
+                    <td className="py-2 pr-3">{formatGs(b.max)}</td>
+                    <td className="py-2 text-right">{formatGs(b.monthlyFee)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="mt-6 text-xs leading-relaxed text-[var(--text-muted,#64748b)]">
+            {disclaimer ||
+              'RESIMPLE no aplica a: sociedades de hecho con socios diferentes a conyuges, empresas con empleados > X (variable), actividades reguladas (banca, seguros). Tambien hay limitaciones por rubro. Consulta con un contador para confirmar.'}
+          </p>
+
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            {whatsappHref && (
+              <Button href={whatsappHref} variant="secondary" size="lg" style={{ backgroundColor: '#25d366', color: '#ffffff', borderColor: '#25d366' }}>
+                Consultar por WhatsApp
+              </Button>
+            )}
+            <Button variant="primary" size="lg" href={ctaHref}>{ctaLabel}</Button>
+          </div>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/web/lib/data/py-service-packages.ts
+++ b/web/lib/data/py-service-packages.ts
@@ -1,0 +1,262 @@
+/**
+ * Paraguayan contador service packages by buyer archetype.
+ *
+ * Research shows SMB buyers think in terms of LIFE EVENTS (abro empresa,
+ * paso a IRP, heredé un negocio) rather than service LINES (contabilidad,
+ * impuestos). This catalog maps the 10 most common buyer situations to
+ * named packages.
+ *
+ * Drops into `packages-section` as structured data, or feeds an intake
+ * wizard that asks the buyer their scenario and surfaces the fit.
+ */
+
+export type PackageTier = 'low' | 'med' | 'high' | 'custom'
+
+export interface ServicePackage {
+  id: string
+  nameEs: string
+  nameEn?: string
+  /** One-sentence buyer archetype — "Yo soy ___, y ___". */
+  archetype: string
+  /** Pain point the buyer is feeling. */
+  painPoint: string
+  /** What's included in the package. */
+  deliverables: string[]
+  /** Typical delivery timeline. */
+  timeline: string
+  priceFrom: string
+  /** USD reference for foreign-investor packages. */
+  priceFromUSD?: string
+  tier: PackageTier
+  /** Which contador sub-type is the best fit to sell this package. */
+  bestFitSubtype: string
+  /** Featured on default template. */
+  featured?: boolean
+}
+
+export const PY_SERVICE_PACKAGES: ServicePackage[] = [
+  {
+    id: 'abro-mi-empresa-py',
+    nameEs: 'Abro mi empresa en Paraguay',
+    nameEn: 'Open my Paraguay company',
+    archetype: 'Soy extranjero o nomada digital y quiero operar legalmente desde PY',
+    painPoint: 'No se como empezar — no tengo cedula, no hablo guarani, no conozco a nadie',
+    deliverables: [
+      'Apertura EAS en 72 horas via MIC',
+      'Inscripcion RUC en DNIT',
+      'Habilitacion municipal',
+      'Primer Timbrado + e-Kuatia configurado',
+      'Apertura de cuenta bancaria (intro con Itau / Sudameris / Atlas)',
+      'Primera liquidacion mensual incluida',
+    ],
+    timeline: '5-7 dias habiles total',
+    priceFrom: '10.500.000 Gs one-time',
+    priceFromUSD: 'USD 1.500',
+    tier: 'high',
+    bestFitSubtype: 'contador_inversores',
+    featured: true,
+  },
+  {
+    id: 'pase-a-irp',
+    nameEs: 'Pase a IRP este ano',
+    nameEn: 'I crossed the IRP threshold',
+    archetype: 'Soy profesional independiente y mis ingresos superaron Gs. 80M/ano',
+    painPoint: 'Me inscribo ahora o espero? Cuanto voy a pagar? Que puedo deducir?',
+    deliverables: [
+      'Inscripcion IRP en DNIT',
+      'Revision retroactiva (si aplica) y regularizacion',
+      'Setup de Timbrado e-Kuatia para facturacion profesional',
+      'Planilla de gastos deducibles (art. 68 Ley 6380/19)',
+      'Primera liquidacion mensual',
+      'Proyeccion anual IRP con deducciones al maximo',
+    ],
+    timeline: '2-4 semanas',
+    priceFrom: '3.500.000 Gs setup + 450.000 Gs/mes',
+    tier: 'med',
+    bestFitSubtype: 'contador',
+  },
+  {
+    id: 'tengo-peluqueria-3-empleados',
+    nameEs: 'Tengo salon de belleza con 3 empleados',
+    nameEn: 'I own a beauty salon with 3 employees',
+    archetype: 'Soy dueno de microempresa con carga laboral intensa',
+    painPoint: 'El IPS y aguinaldo me complican, las multas me asustan, no entiendo REOP',
+    deliverables: [
+      'Contabilidad mensual simplificada',
+      'IRE Simple + IVA',
+      'Liquidacion completa de sueldos + IPS + aguinaldo',
+      'MTESS-REOP mensual al dia',
+      'Pago puntual de obligaciones via domiciliacion bancaria',
+      'Asesoramiento laboral continuo por WhatsApp',
+    ],
+    timeline: 'Mensual recurring',
+    priceFrom: '950.000 Gs/mes',
+    tier: 'med',
+    bestFitSubtype: 'contador',
+    featured: true,
+  },
+  {
+    id: 'soy-agricultor-ganadero',
+    nameEs: 'Soy agricultor o ganadero',
+    nameEn: 'I am a farmer / cattle rancher',
+    archetype: 'Tengo un establecimiento con soja, ganado o agricultura familiar',
+    painPoint: 'SENACSA, IMAGRO, constancia no retencion — me piden papeles que no se cuales son',
+    deliverables: [
+      'IRE Agropecuario anual',
+      'Constancia de No Retencion (trimestral)',
+      'SENACSA: marcas, senales, SIGOR',
+      'Certificados de origen para exportacion',
+      'Coordinacion con BNF / Fondo Ganadero',
+      'Visita al establecimiento 2x ano',
+    ],
+    timeline: 'Mensual + visitas',
+    priceFrom: '1.200.000 Gs/mes',
+    tier: 'med',
+    bestFitSubtype: 'contador_agro',
+  },
+  {
+    id: 'soy-empleado-supero-80m',
+    nameEs: 'Soy empleado que superé Gs. 80M/año',
+    nameEn: 'I am an employee earning above the IRP threshold',
+    archetype: 'Sos empleado en relacion de dependencia con ingreso alto',
+    painPoint: 'Me retienen IRP pero no se si lo aplican bien, y no aprovecho deducciones',
+    deliverables: [
+      'Analisis de retenciones del empleador',
+      'Planilla de deducciones a declarar anualmente',
+      'Gastos medicos, educacion, vivienda, seguros',
+      'Declaracion jurada anual (F. 104)',
+      'Optimizacion legal vs situacion empleador',
+    ],
+    timeline: 'Anual + 2 reuniones',
+    priceFrom: '1.500.000 Gs/ano',
+    tier: 'low',
+    bestFitSubtype: 'contador',
+  },
+  {
+    id: 'abro-cooperativa',
+    nameEs: 'Abro una cooperativa',
+    nameEn: 'I am opening a cooperative',
+    archetype: 'Formamos grupo para cooperativa de produccion, consumo o ahorro',
+    painPoint: 'INCOOP, Balance Social, asamblea — es todo nuevo para nosotros',
+    deliverables: [
+      'Constitucion de cooperativa ante INCOOP',
+      'Estatutos redactados conforme Ley 438/94',
+      'Primera asamblea constitutiva',
+      'Inscripcion RUC + municipal',
+      'Set-up de reporting INCOOP',
+      'Primer Balance Social (al fin del ejercicio)',
+    ],
+    timeline: '60-90 dias',
+    priceFrom: '8.500.000 Gs setup + 2.500.000 Gs/mes',
+    tier: 'high',
+    bestFitSubtype: 'contador_cooperativa',
+  },
+  {
+    id: 'soy-nomada-digital',
+    nameEs: 'Soy nomada digital',
+    nameEn: 'I am a digital nomad',
+    archetype: 'Trabajo remoto con clientes del exterior, quiero residir en PY',
+    painPoint: 'Territorial tax 0% sobre ingresos del exterior — como hago eso bien?',
+    deliverables: [
+      'Asesoramiento en residencia migratoria',
+      'Apertura de RUC personal / EAS',
+      'Tax residency certification',
+      'Reporting mensual bilingue ES/EN',
+      'Certificado de residencia fiscal para CDI treaties',
+    ],
+    timeline: '60-90 dias setup + mensual',
+    priceFrom: '4.900.000 Gs setup + 700.000 Gs/mes',
+    priceFromUSD: 'USD 700 setup + USD 99/month',
+    tier: 'med',
+    bestFitSubtype: 'contador_inversores',
+    featured: true,
+  },
+  {
+    id: 'mi-contador-me-dejo',
+    nameEs: 'Mi contador me dejo',
+    nameEn: 'My accountant dropped me',
+    archetype: 'Sos PYME cuyo contador cerro, se mudo, o dejo de responder',
+    painPoint: 'No tengo acceso a Marangatu, no se donde esta mi Timbrado, se acerca vencimiento',
+    deliverables: [
+      'Recuperacion de acceso Marangatu',
+      'Traspaso de papeles de trabajo',
+      'Regularizacion de pendientes DNIT / IPS',
+      'Reconstruccion de ultimos 3-6 meses si es necesario',
+      'Plan de continuidad a partir del mes siguiente',
+    ],
+    timeline: '30-60 dias urgente',
+    priceFrom: '2.500.000 Gs regularizacion + plan mensual estandar',
+    tier: 'high',
+    bestFitSubtype: 'contador',
+  },
+  {
+    id: 'compre-vendi-empresa',
+    nameEs: 'Vendi o compre una empresa',
+    nameEn: 'I sold or bought a business',
+    archetype: 'Transaccion M&A de PYME paraguaya',
+    painPoint: 'Que pasivos asumo? Cuanto pago de IRE? Hay algo escondido?',
+    deliverables: [
+      'Due diligence contable y tributario',
+      'Evaluacion de pasivos IPS, MTESS, DNIT',
+      'Quality of earnings report',
+      'Planificacion fiscal de la transaccion',
+      'Coordinacion con abogado y escribano',
+      'Cierre contable pre-transferencia',
+    ],
+    timeline: '30-60 dias',
+    priceFrom: '15.000.000 Gs proyecto',
+    priceFromUSD: 'USD 2.000-5.000',
+    tier: 'custom',
+    bestFitSubtype: 'contador',
+  },
+  {
+    id: 'tengo-crypto',
+    nameEs: 'Tengo operaciones crypto',
+    nameEn: 'I trade / hold crypto',
+    archetype: 'Trader o inversor crypto con wallets y exchanges internacionales',
+    painPoint: 'Que reporto a DNIT? Soy SEPRELAD? Voy a pagar IRE sobre ganancias crypto?',
+    deliverables: [
+      'Assessment de SEPRELAD obligations',
+      'Setup de reporting bilingue ES/EN',
+      'Clasificacion de trades para IRE',
+      'FIFO/LIFO cost basis methodology',
+      'Blockchain forensics para compliance',
+      'Coordinacion con advisor de tu pais de origen',
+    ],
+    timeline: 'Mensual recurring',
+    priceFrom: '1.750.000 Gs/mes',
+    priceFromUSD: 'USD 250/month',
+    tier: 'med',
+    bestFitSubtype: 'contador_crypto',
+  },
+]
+
+/**
+ * Filter packages applicable to a given sub-type.
+ * A sub-type "inherits" the generic packages (contador) + its own.
+ */
+export function getPackagesForSubtype(subtype: string): ServicePackage[] {
+  const subtypeMap: Record<string, string[]> = {
+    contador: ['contador'],
+    contador_inversores: ['contador', 'contador_inversores'],
+    contador_agro: ['contador', 'contador_agro'],
+    contador_cooperativa: ['contador', 'contador_cooperativa'],
+    contador_crypto: ['contador', 'contador_crypto'],
+    contador_maquila: ['contador'],
+    contador_medico: ['contador'],
+    contador_ong: ['contador'],
+    contador_chaco: ['contador', 'contador_agro', 'contador_cooperativa'],
+    contador_cde: ['contador', 'contador_inversores'],
+  }
+  const applicable = subtypeMap[subtype] || ['contador']
+  return PY_SERVICE_PACKAGES.filter((p) => applicable.includes(p.bestFitSubtype))
+}
+
+/**
+ * Featured packages for homepage (limit 3).
+ */
+export function getFeaturedPackages(subtype = 'contador'): ServicePackage[] {
+  return getPackagesForSubtype(subtype)
+    .filter((p) => p.featured)
+    .slice(0, 3)
+}


### PR DESCRIPTION
## Summary

Recovers stashed contador vertical work that was in-progress across a concurrent agent session.

### Contents

**3 new regional contador types:**
- `contador_cde` (Ciudad del Este) — content
- `contador_chaco` — content
- `contador_tecnologia` — content + tokens + registry type.json

**5 blog seed posts** (Paraguay tax topics):
- crypto-impuestos-paraguay
- idu-dividendos-utilidades-paraguay
- maquila-ley-1064-guia
- precios-transferencia-etpt-paraguay
- resimple-regimen-guia

**New section: calc-resimple-qualifier-section** — interactive qualifier for RESIMPLE (micro/small business tax regime) eligibility.

**New data: py-service-packages.ts** — Paraguay accounting service package definitions.

### Verification

Pure additions, no conflicts with current Main. Typecheck passes for these new files (pre-existing `analytics/*.ts` type errors on Main are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)