### PR TITLE
feat: recover 3 new sections + DNIT data + hreflang + wishlist store + docs

### DIFF
--- a/docs/GRANJA_CABRAL_COMPLETE_ANALYSIS.md
+++ b/docs/GRANJA_CABRAL_COMPLETE_ANALYSIS.md
@@ -1,0 +1,573 @@
+# Granja Cabral - Complete Analysis & Recommendations
+
+**Date:** April 20, 2026  
+**Analyst:** Paragu-AI Builder System  
+**Scope:** Current website, GitHub repo (laura-egg-business), and improvement opportunities
+
+---
+
+## 📊 EXECUTIVE SUMMARY
+
+Granja Cabral is a working egg farm in Coronel Oviedo, Paraguay, with a functional website but significant opportunities for improvement. The business has well-documented operations (in the GitHub repo) but the website only captures a fraction of what they actually offer and can deliver.
+
+**Current Status:**
+- ✅ Website live at paragu-ai.com/granja-cabral
+- ✅ Basic product catalog (6 products)
+- ✅ WhatsApp integration working
+- ✅ Demo data configured
+- ⚠️ Using placeholder contact info (+595981000000)
+- ❌ Missing real photos
+- ❌ Not leveraging full business potential
+
+---
+
+## 🌐 CURRENT WEBSITE ANALYSIS
+
+### What's Live Now
+
+**URL:** https://paragu-ai.com/granja-cabral
+
+**Sections Currently Active:**
+1. **Header/Navigation** - Clean, functional
+2. **Hero** - Basic headline and CTAs
+3. **Product Catalog** - 6 products with WhatsApp links
+4. **Services Section** - Delivery, wholesale, scheduled orders
+5. **Testimonials** - 3 placeholder reviews
+6. **Contact Section** - Phone, email, hours, address
+7. **Footer** - Navigation, social links
+8. **WhatsApp Float Button** - Always visible
+
+**Current Product Catalog:**
+| Product | Price | Stock Status |
+|---------|-------|--------------|
+| Huevos por Unidad | 800 Gs | ✅ In Stock |
+| Maple de 30 Huevos | 22.000 Gs | ✅ In Stock |
+| Bandeja de 12 Huevos | 9.500 Gs | ✅ In Stock |
+| Pollo Entero | 35.000 Gs | ⏰ Pre-order (24hs) |
+| Pollito Tierno | 22.000 Gs | ⏰ Pre-order (24hs) |
+| Fertilizante Orgánico 10kg | 15.000 Gs | ✅ In Stock |
+
+**Delivery Zones Configured:**
+- Centro de Coronel Oviedo: 5.000 Gs (free over 50.000 Gs)
+- Ruta 2 (Km 120-140): 8.000 Gs (free over 70.000 Gs)
+- Ruta 2 (Km 140-150): 12.000 Gs (free over 100.000 Gs)
+- Retiro en Granja: Gratis
+
+---
+
+## 📦 WHAT THEY REALLY HAVE (From GitHub Repo Analysis)
+
+The laura-egg-business GitHub repo reveals Granja Cabral is FAR more sophisticated than the website shows:
+
+### Core Operations (01_core_operations/)
+- **Farm Management:** Daily operations protocols, chicken coop management
+- **Financial Tracking:** Budgets, P&L, cash flow projections
+- **Production Logs:** Daily egg collection records
+
+### Products - Primary (02_products/primary/)
+1. **Eggs** - Fresh eggs (already on website)
+2. **Poultry** - Meat chickens (already on website)
+3. **Fertilizer** - Organic fertilizer (already on website)
+
+### Products - Derived/Value-Added (02_products/derived/) 🚀 MISSING FROM WEBSITE
+These are MAJOR revenue opportunities not mentioned on the site:
+1. **Liquid Egg** (Huevo Líquido) - For bakeries, restaurants
+2. **Egg Powder** (Huevo en Polvo) - Long shelf life, export potential
+3. **Pasta Products** (Fideos con Huevo) - Fresh pasta
+4. **Sauces** (Mayonesa/Salsas) - Value-added products
+5. **Feather Products** (Productos de Plumas) - Decoration, crafts
+6. **Processed Poultry** (Pollo Procesado) - Cut chicken, marinated
+
+### Sales Network (03_sales/contacts/) 🚀 HUGE ASSET
+**300+ Business Contacts** organized by category:
+- **Hotels & Restaurants** - 50+ establishments
+- **Supermarkets** - Major chains and local stores
+- **Bakeries** (Panaderías) - 30+ clients
+- **Institutions** - Schools, hospitals, government
+- **Ruta 2 Road Stops** (Paradores) - Truck driver customers
+
+### Supply Chain (04_supply_chain/)
+- **40+ Veterinary/Feed Suppliers** - Established relationships
+- **Feed Mills** (Molinos) - Bulk feed agreements
+- **Equipment Suppliers** - Infrastructure partners
+
+### Market Intelligence (05_market_intelligence/)
+- Competitor analysis
+- Pricing benchmarks
+- Global egg industry research
+
+### Business Plan (06_business_plan/) 📈 IMPRESSIVE
+**4-Phase Growth Strategy with $100K+ Investment Plan:**
+- **Phase 1:** 500 hens, local market dominance
+- **Phase 2:** 1,500 hens, derived products
+- **Phase 3:** 3,000+ hens, regional distribution
+- **Phase 4:** Export-ready, certified organic
+
+### Innovation (07_innovation/)
+- Future product R&D
+- Technology upgrades
+- Best practices library
+
+### Sustainability (08_sustainability/) 🌱 MARKETING GOLD
+- **Composting Program** - Waste transformation
+- **Biogas Production** - Renewable energy
+- **Water Management** - Conservation practices
+
+### Quality Control (13_quality_control/)
+- HACCP plans
+- Cold chain protocols
+- Feed quality standards
+
+---
+
+## 🎯 CRITICAL GAPS & MISSING OPPORTUNITIES
+
+### 🔴 CRITICAL (Fix Immediately)
+
+1. **Real Contact Information**
+   - Current: +595981000000 (placeholder)
+   - Need: Laura's actual WhatsApp number
+   - Impact: Customers can't actually order
+
+2. **Real Location Details**
+   - Current: "Ruta 2, Km 125-140" (vague)
+   - Need: Exact GPS coordinates, landmarks, directions
+   - Impact: Customers can't find the farm
+
+3. **Actual Photos**
+   - Current: Stock/placeholder images
+   - Need: Real photos of:
+     - Laura and her team
+     - The chicken coops/galpones
+     - Actual eggs in cartons
+     - Farm facilities
+     - Happy customers
+   - Impact: Zero trust/credibility without real photos
+
+4. **Verified Pricing**
+   - Current: Estimated prices
+   - Need: Laura's confirmed current prices
+   - Impact: Wrong pricing = confused customers
+
+### 🟡 IMPORTANT (High Conversion Impact)
+
+5. **Derived Products Section**
+   - Opportunity: Egg powder, liquid egg, pasta, sauces
+   - Market: B2B bakeries, restaurants, export
+   - Revenue Potential: 2-3x current revenue
+
+6. **B2B Wholesale Portal**
+   - Assets: 300+ contacts in CRM
+   - Missing: Dedicated wholesale pricing page
+   - Missing: Volume discount calculator
+   - Missing: Business customer login/tracking
+
+7. **Sustainability Story**
+   - Assets: Composting, biogas, water management
+   - Value: Premium pricing justification
+   - Market: Eco-conscious consumers, organic certification path
+
+8. **Recipe Section**
+   - Configured but empty
+   - Should have: Paraguayan classics (tortilla, sopa paraguaya, chipa guazú)
+   - Drives engagement, SEO, repeat visits
+
+9. **Google Business Profile Integration**
+   - Need: Connect to Google Maps
+   - Need: Reviews integration
+   - Need: Local SEO optimization
+
+### 🟢 GROWTH OPPORTUNITIES (Phase 2)
+
+10. **Subscription Service**
+    - Feature: Weekly/Monthly egg delivery
+    - Discount: 5% for subscribers
+    - Market: Busy families, restaurants
+
+11. **Referral Program**
+    - Feature: "Recommend and Win"
+    - Reward: Free maple for referrer, 10% off for friend
+    - Growth potential: Viral customer acquisition
+
+12. **Online Ordering System**
+    - Current: WhatsApp only
+    - Upgrade: Web cart with MercadoPago
+    - Impact: 24/7 ordering, payment upfront
+
+13. **Customer Portal**
+    - Order history
+    - Reorder with one click
+    - Loyalty points
+
+14. **Inventory Management Dashboard**
+    - Real-time stock levels
+    - Automated low-stock alerts
+    - Pre-order management
+
+15. **Analytics & Reporting**
+    - Sales by product
+    - Customer acquisition cost
+    - Delivery route optimization
+
+---
+
+## 📝 CONTENT UPDATES NEEDED
+
+### 1. Hero Section Rewrite
+**Current:**
+> "Produccion local en Coronel Oviedo. Huevos frescos recolectados diariamente..."
+
+**Improved:**
+> "Huevos de Granja 100% Paraguayos | De nuestras gallinas a tu mesa en 24 horas
+> 
+> 🥚 Recolectados diariamente | 🚚 Delivery en Coronel Oviedo | 🏆 Calidad garantizada
+> 
+> Granja familiar con 500+ gallinas ponedoras. Atendemos hogares, restaurantes y panaderías."
+
+### 2. About Section (Currently Missing!)
+**Need:** Full "Our Story" section with:
+- Laura's background and vision
+- Farm history and milestones
+- Mission and values
+- Team introduction
+
+### 3. Products - Add Derived Products
+```
+🏭 PRODUCTOS DE VALOR AGREGADO
+
+🥚 Huevo Líquido Pasteurizado
+   - Para panaderías y restaurantes
+   - Envases de 1L, 5L, 20L
+   - Precio mayorista: Consultar
+
+🥚 Huevo en Polvo
+   - Ideal para exportación
+   - Vida útil: 12 meses
+   - Aplicaciones: panadería, repostería industrial
+
+🍝 Fideos Caseros con Huevo
+   - Producción artesanal
+   - 100% natural, sin conservantes
+   - Precio: Consultar
+
+🥫 Mayonesa y Salsas Artesanales
+   - Elaboradas con nuestros huevos
+   - Recetas tradicionales
+   - Precio: Consultar
+```
+
+### 4. FAQ Section Expansion
+**Current:** 6 basic FAQs
+**Need:** 15+ comprehensive FAQs covering:
+- How to check egg freshness
+- Storage recommendations
+- Nutritional benefits
+- Cooking tips
+- Wholesale process
+- Delivery scheduling
+- Payment methods
+- Return policy
+
+### 5. Testimonials - Real Customer Stories
+**Current:** 3 placeholder testimonials
+**Need:** 10+ real testimonials with:
+- Customer names (with permission)
+- Business names (for B2B)
+- Specific product feedback
+- Photos of customers (if possible)
+
+### 6. Blog/Recipe Section
+**Topics:**
+- "Cómo hacer la tortilla paraguaya perfecta"
+- "5 desayunos paraguayos con huevos de granja"
+- "Diferencia entre huevos de granja y supermercado"
+- "Cómo conservar huevos frescos por más tiempo"
+- "Receta de chipa guazú tradicional"
+
+### 7. B2B Wholesale Page
+**Sections needed:**
+- Volume pricing tiers
+- Custom ordering process
+- Delivery schedules for businesses
+- Credit/payment terms
+- Client testimonials (B2B focus)
+- Industries served (restaurants, bakeries, hotels)
+
+### 8. Sustainability/Organic Page
+**Content:**
+- Composting practices
+- Biogas renewable energy
+- Water conservation
+- Animal welfare standards
+- Path to organic certification
+- Environmental impact metrics
+
+---
+
+## 🔧 TECHNICAL IMPROVEMENTS NEEDED
+
+### 1. SEO Optimization
+**Current State:** Basic
+**Needs:**
+- Meta descriptions for all pages
+- Structured data (Schema.org) for products
+- Local SEO (Coronel Oviedo focused)
+- Google My Business integration
+- Keyword optimization:
+  - "huevos frescos coronel oviedo"
+  - "granja de huevos paraguay"
+  - "huevo organico py"
+  - "delivery huevos ruta 2"
+
+### 2. Performance Optimization
+- Image optimization (WebP format)
+- Lazy loading for product images
+- CDN for static assets
+- Core Web Vitals optimization
+
+### 3. Mobile Experience
+- Test on various devices
+- WhatsApp button prominence
+- Click-to-call functionality
+- Mobile-optimized forms
+
+### 4. Analytics Setup
+**Missing:**
+- Google Analytics 4
+- Google Search Console
+- WhatsApp click tracking
+- Conversion tracking
+- Heatmap analysis (Hotjar)
+
+### 5. Security & Compliance
+- SSL certificate (✅ likely done)
+- Privacy policy page
+- Cookie consent banner
+- Terms of service
+
+---
+
+## 📸 PHOTO REQUIREMENTS
+
+### Priority 1 (Critical)
+1. **Laura Cabral portrait** - Professional, friendly, on the farm
+2. **Farm aerial/overview** - Shows scale and professionalism
+3. **Chicken coop interior** - Happy hens, clean facilities
+4. **Eggs in various containers** - Cartons, baskets, individual
+5. **Delivery/setup** - Shows operational capability
+
+### Priority 2 (Important)
+6. Team photos (if any employees)
+7. Product close-ups (yolks, shells)
+8. Fertilizer bags
+9. Chickens close-ups
+10. Farm facilities (storage, processing)
+
+### Priority 3 (Nice to Have)
+11. Customer testimonials with photos
+12. Delivery in action
+13. Process shots (collection, cleaning, packing)
+14. Recipe photos using their eggs
+15. Before/after comparisons (supermarket vs farm eggs)
+
+---
+
+## 💼 BUSINESS DEVELOPMENT OPPORTUNITIES
+
+### Immediate (0-30 days)
+1. **Activate all 300+ contacts** from CRM
+   - Personalized WhatsApp campaign
+   - Introduce website ordering
+   - Special launch promotion
+
+2. **Launch wholesale program**
+   - Dedicated B2B page
+   - Volume pricing structure
+   - Restaurant/bakery outreach
+
+3. **Implement subscription service**
+   - Weekly delivery plans
+   - Family size options
+   - 5% subscription discount
+
+### Short-term (1-3 months)
+4. **Start derived products pilot**
+   - Begin with liquid egg for bakeries
+   - Test pasta product demand
+   - Validate sauces market
+
+5. **Organic certification path**
+   - Document current practices
+   - Apply for SENACSA certifications
+   - Prepare for SENAVE organic certification
+
+6. **Google Business optimization**
+   - Claim/verify listing
+   - Add photos, hours, services
+   - Encourage customer reviews
+
+### Medium-term (3-6 months)
+7. **Expand delivery zones**
+   - Asunción metro area
+   - Caaguazú department
+   - Ruta 2 full coverage
+
+8. **E-commerce upgrade**
+   - Online payment (MercadoPago)
+   - Scheduled delivery slots
+   - Customer accounts
+
+9. **B2B portal launch**
+   - Business customer login
+   - Order history
+   - Invoicing integration
+
+### Long-term (6-12 months)
+10. **Export preparation**
+    - Egg powder production
+    - International certifications
+    - Logistics partnerships
+
+11. **Franchise/expansion model**
+    - Document operations
+    - Create training materials
+    - Explore other cities
+
+12. **Technology integration**
+    - IoT sensors in coops
+    - Automated feeding systems
+    - Production tracking dashboard
+
+---
+
+## 📋 ACTION PLAN FOR LAURA
+
+### Week 1: Foundation
+- [ ] Provide real WhatsApp number
+- [ ] Confirm exact farm location (GPS coordinates)
+- [ ] Verify current pricing
+- [ ] Approve color scheme and branding
+
+### Week 2: Content Collection
+- [ ] Schedule photo session (farm, products, Laura)
+- [ ] Write "Our Story" content
+- [ ] Collect 5 real customer testimonials
+- [ ] Provide business hours and availability
+
+### Week 3: Website Updates
+- [ ] Replace all placeholder contact info
+- [ ] Add real photos
+- [ ] Expand product descriptions
+- [ ] Add derived products section
+- [ ] Create sustainability page
+
+### Week 4: Launch & Promotion
+- [ ] Test all WhatsApp links
+- [ ] Verify mobile experience
+- [ ] Share with existing customers
+- [ ] Post on social media
+- [ ] Set up Google Analytics
+
+### Month 2: Growth
+- [ ] Activate wholesale program
+- [ ] Launch subscription service
+- [ ] Start referral program
+- [ ] Collect and add more testimonials
+- [ ] Optimize based on analytics
+
+### Month 3: Scale
+- [ ] Evaluate derived products demand
+- [ ] Expand delivery zones if demand exists
+- [ ] Consider online payment integration
+- [ ] Plan for organic certification
+
+---
+
+## 💰 REVENUE OPPORTUNITY ANALYSIS
+
+### Current State (Estimated)
+- 500 hens
+- ~350 eggs/day production
+- Current website: basic B2C
+- **Estimated Monthly Revenue:** 15-25 million Gs
+
+### With Full Implementation
+| Initiative | Revenue Impact | Timeline |
+|------------|----------------|----------|
+| B2B wholesale activation | +40-60% | Immediate |
+| Derived products (liquid egg) | +30-50% | 2-3 months |
+| Subscription service | +20-30% | 1 month |
+| Online payment convenience | +15-25% | 2 months |
+| Delivery zone expansion | +25-35% | 3 months |
+| Recipe/blog content SEO | +10-20% | 6 months |
+| Referral program | +10-15% | 1 month |
+| Export (egg powder) | +50-100% | 12 months |
+
+**Potential 12-Month Revenue Increase: 200-400%**
+
+---
+
+## 🎯 COMPETITIVE ADVANTAGES TO HIGHLIGHT
+
+Based on the GitHub repo analysis, Granja Cabral has significant advantages:
+
+1. **Scale & Capacity** - 500+ hens, room to grow to 3,000+
+2. **Professional Operations** - Documented processes, financial tracking
+3. **Diversified Products** - Not just eggs, but poultry, fertilizer, future derived products
+4. **Sustainability Focus** - Composting, biogas, water conservation
+5. **Strong B2B Network** - 300+ established contacts
+6. **Growth Capital** - $100K investment plan ready
+7. **Strategic Location** - Ruta 2, serving Coronel Oviedo + truck traffic
+8. **Quality Control** - HACCP plans, feed quality standards
+9. **Technology-Forward** - Comprehensive documentation, tracking systems
+10. **Family-Owned Authenticity** - Laura's personal story and commitment
+
+---
+
+## 🚀 PRIORITY RECOMMENDATIONS
+
+### Must Do Now (This Week)
+1. Get Laura's real WhatsApp number and update site
+2. Take 10 essential photos (farm, Laura, products)
+3. Confirm accurate pricing
+4. Write "Our Story" content
+
+### Should Do Soon (This Month)
+1. Add derived products section to website
+2. Create dedicated B2B wholesale page
+3. Implement subscription feature
+4. Add recipe section with 5+ recipes
+5. Set up Google Business Profile
+
+### Could Do Later (Next Quarter)
+1. Online payment integration
+2. Customer portal/login system
+3. Inventory dashboard
+4. Export preparation
+5. Organic certification process
+
+---
+
+## 📞 NEXT STEPS
+
+**Immediate Action Required:**
+1. Contact Laura to collect missing information
+2. Schedule photo session at the farm
+3. Update all placeholder data with real information
+4. Deploy updated website
+5. Set up analytics tracking
+
+**Success Metrics to Track:**
+- WhatsApp click-through rate
+- Orders per week
+- New vs. repeat customers
+- Average order value
+- B2B vs. B2C revenue split
+- Website traffic sources
+- Customer satisfaction (NPS)
+
+---
+
+*Analysis completed by Paragu-AI Builder*  
+*For: Granja Cabral - Laura Cabral*  
+*Contact: support@paragu-ai.com*

--- a/docs/GRANJA_CABRAL_QUICK_CHECKLIST.md
+++ b/docs/GRANJA_CABRAL_QUICK_CHECKLIST.md
@@ -1,0 +1,368 @@
+# Granja Cabral - Quick Action Checklist
+## Week-by-Week Implementation Guide
+
+---
+
+## 🔴 WEEK 1-2: CRITICAL FIXES (Do This First!)
+
+### Day 1-2: Get Real Information
+- [ ] **Get Laura's real WhatsApp number** (currently showing +595981000000)
+- [ ] **Confirm exact farm address** with GPS coordinates
+- [ ] **Verify current pricing** for all 6 products
+- [ ] **Confirm business hours** (currently: Lunes-Sábado 7-18, Domingo cerrado)
+
+### Day 3-5: Photo Session
+**Hire photographer or DIY with smartphone:**
+- [ ] Laura portrait (smiling, professional)
+- [ ] Farm overview shot (show scale)
+- [ ] Chicken coop (happy hens in natural light)
+- [ ] Eggs in cartons (show packaging)
+- [ ] Product shots (all 6 products)
+- [ ] Delivery setup/vehicle
+
+**Photo Tips:**
+- Shoot during "golden hour" (sunrise/sunset)
+- Use natural light
+- Clean backgrounds
+- Take 3-5 shots of each subject
+
+### Day 6-7: Update Website
+- [ ] Replace WhatsApp number EVERYWHERE
+- [ ] Upload new photos
+- [ ] Update pricing
+- [ ] Test all WhatsApp links
+- [ ] Set up Google Business Profile
+
+---
+
+## 🟡 WEEK 3-4: CONTENT CREATION
+
+### Write "Our Story" Page
+**Template:**
+```
+# La Historia de Granja Cabral
+
+Laura Cabral fundó Granja Cabral en [AÑO] con una visión: 
+producir alimentos frescos para Coronel Oviedo.
+
+## Hoy en Día
+- 500+ gallinas ponedoras
+- 350 huevos frescos diarios
+- 300+ clientes satisfechos
+- Entrega en Coronel Oviedo y Ruta 2
+
+## Nuestra Promesa
+✓ Recolección diaria
+✓ Gallinas en ambiente natural
+✓ Alimentación balanceada
+✓ Frescura garantizada
+
+## Visítanos
+Ruta 2, Km 125-140, Coronel Oviedo
+WhatsApp: [REAL NUMBER]
+```
+
+### Create 5 Essential Recipes
+**Start with these Paraguayan classics:**
+1. [ ] **Tortilla Paraguaya** (easiest)
+2. [ ] **Sopa Paraguaya** (most popular)
+3. [ ] **Chipa Guazú** (traditional)
+4. [ ] **Mbaipy** (simple)
+5. [ ] **Flan Casero** (dessert)
+
+**Recipe Format:**
+- Title
+- Photo of finished dish
+- Prep time / Cook time
+- Ingredients list
+- Step-by-step instructions
+- Tips section
+
+### Expand FAQ to 15 Questions
+**Most Important:**
+1. ¿Hacen delivery? ¿A qué zonas?
+2. ¿Cuánto duran los huevos?
+3. ¿Tienen precios para negocios?
+4. ¿Cómo hago un pedido?
+5. ¿De dónde vienen sus huevos?
+6. ¿Puedo visitar la granja?
+7. ¿Venden pollos vivos?
+8. ¿Aceptan tarjeta de crédito?
+9. ¿Tienen pedidos programados?
+10. ¿Qué hacen con las gallinas viejas?
+
+---
+
+## 🟢 WEEK 5-6: TECHNICAL SETUP
+
+### Set Up Google Analytics (Free)
+1. Go to analytics.google.com
+2. Create account for "Granja Cabral"
+3. Get tracking code
+4. Add to website (we'll help with this)
+5. Verify it's working
+
+### Set Up Google Business Profile (Free)
+1. Go to business.google.com
+2. Search for "Granja Cabral"
+3. Claim the business
+4. Add:
+   - Real address with map pin
+   - Phone number
+   - Hours
+   - 10+ photos
+   - Services (delivery, wholesale)
+5. Verify via postcard or phone
+
+### Set Up WhatsApp Business (Free)
+1. Download WhatsApp Business app
+2. Set up business profile:
+   - Logo/photo
+   - Description
+   - Hours
+   - Website link
+   - Catalog (products)
+3. Set up quick replies:
+   - "Hola! Gracias por contactar a Granja Cabral..."
+   - List of products and prices
+   - Delivery zones and costs
+
+---
+
+## 🟣 WEEK 7-8: GROWTH FEATURES
+
+### Launch Subscription Service
+**Create 2 plans:**
+
+**Plan Familiar (Weekly)**
+- 30 huevos/semana
+- Precio: 20.900 Gs (5% descuento)
+- Delivery gratis
+
+**Plan Familia Grande (Weekly)**
+- 60 huevos/semana
+- Precio: 38.000 Gs (5% descuento)
+- Delivery gratis
+
+**Steps:**
+1. [ ] Write subscription terms
+2. [ ] Create WhatsApp template
+3. [ ] Set up tracking spreadsheet
+4. [ ] Announce to existing customers
+
+### Set Up Referral Program
+**"Recomienda y Ganá"**
+
+**How it works:**
+1. Customer shares their code with friend
+2. Friend gets 10% off first order
+3. Customer gets maple de 30 FREE
+
+**Implementation:**
+- [ ] Create simple code system (e.g., LAURA001, LAURA002)
+- [ ] Track in spreadsheet
+- [ ] Announce on website and WhatsApp
+
+### Create B2B Page
+**Add to website:**
+```
+# Venta Mayorista para Negocios
+
+¿Tenés un restaurante, panadería o hotel?
+
+Ofrecemos:
+✓ Precios especiales desde 100 unidades
+✓ Entrega programada semanal
+✓ Facturación disponible
+✓ Calidad consistente garantizada
+
+Descuentos por volumen:
+- 100-300 huevos/semana: 10% OFF
+- 300-600 huevos/semana: 15% OFF
+- 600+ huevos/semana: 20% OFF + atención prioritaria
+
+[Botón: Solicitar Precios Mayoristas → WhatsApp]
+```
+
+---
+
+## 📊 WEEK 9-12: OPTIMIZATION
+
+### Collect Testimonials
+**Goal: 10 real testimonials**
+
+**Ask existing customers:**
+- "¿Podés dejarnos una reseña?"
+- "¿Qué te gusta de nuestros huevos?"
+- "¿Recomendarías Granja Cabral?"
+
+**Format:**
+```
+⭐⭐⭐⭐⭐
+"[Customer quote]"
+— [Name], [Location/Business]
+```
+
+### SEO Improvements
+**Do these once:**
+- [ ] Add meta descriptions to all pages
+- [ ] Add alt text to all images
+- [ ] Submit sitemap to Google
+- [ ] Get listed in local directories
+
+### Performance Check
+**Test these:**
+- [ ] Website loads in < 3 seconds
+- [ ] WhatsApp buttons work on mobile
+- [ ] All forms submit correctly
+- [ ] Images load properly
+- [ ] No broken links
+
+---
+
+## 📈 MEASURE SUCCESS
+
+### Track These Numbers Weekly:
+
+**Week 1-4:**
+- [ ] Website visitors: Goal 250+
+- [ ] WhatsApp clicks: Goal 50+
+- [ ] Orders received: Goal 20+
+
+**Week 5-8:**
+- [ ] Website visitors: Goal 500+
+- [ ] New customers: Goal 10+
+- [ ] Subscription signups: Goal 5+
+
+**Week 9-12:**
+- [ ] Website visitors: Goal 1000+
+- [ ] Total orders: Goal 100+
+- [ ] B2B clients: Goal 3+
+- [ ] Google reviews: Goal 5+
+
+---
+
+## 💰 BUDGET SUMMARY
+
+### Must Have (Essential):
+| Item | Cost |
+|------|------|
+| Photography | 1.500.000 Gs (~$200) |
+| **Total** | **1.500.000 Gs** |
+
+### Should Have (Recommended):
+| Item | Cost |
+|------|------|
+| Domain name | 200.000 Gs/year |
+| Business cards | 100.000 Gs |
+| **Total** | **300.000 Gs** |
+
+### Nice to Have (Future):
+| Item | Cost |
+|------|------|
+| Drone photos | 800.000 Gs |
+| Video production | 2.000.000 Gs |
+| Google Ads | 1.500.000 Gs/month |
+| **Total** | **4.300.000 Gs** |
+
+**Minimum Budget to Start:** 1.500.000 Gs ($200 USD)
+
+---
+
+## 🚀 IMMEDIATE NEXT STEPS
+
+### Do These 3 Things Today:
+1. **Send WhatsApp to Laura:** Get her real phone number
+2. **Schedule Photo Session:** This week if possible
+3. **Review Pricing:** Confirm current prices
+
+### Do These 5 Things This Week:
+1. **Update website** with real info
+2. **Set up Google Business**
+3. **Test all WhatsApp links**
+4. **Write "Our Story" content**
+5. **Ask 5 customers** for testimonials
+
+### Do These 10 Things This Month:
+1. Complete all critical fixes
+2. Add 5 recipes
+3. Expand FAQ
+4. Set up analytics
+5. Launch subscription service
+6. Create B2B page
+7. Start referral program
+8. Collect 10 testimonials
+9. Optimize for mobile
+10. First monthly review
+
+---
+
+## 📞 WHO TO CONTACT
+
+**Website Technical Support:**
+- Paragu-AI Builder Team
+- support@paragu-ai.com
+
+**WhatsApp Business Help:**
+- WhatsApp FAQ: business.whatsapp.com
+
+**Google Business Help:**
+- Google Support: support.google.com/business
+
+**Photography:**
+- [Find local photographer in Coronel Oviedo]
+- Or use smartphone with good lighting
+
+---
+
+## ✅ FINAL PRE-LAUNCH CHECKLIST
+
+**Before Going Live:**
+- [ ] Real WhatsApp number everywhere
+- [ ] 10+ professional photos uploaded
+- [ ] All pricing current and accurate
+- [ ] Google Business verified
+- [ ] WhatsApp Business app set up
+- [ ] Website loads fast (< 3 seconds)
+- [ ] Mobile-friendly test passed
+- [ ] All links working
+- [ ] Laura approves everything
+
+**Launch Day Tasks:**
+- [ ] Post on personal Facebook/Instagram
+- [ ] Update WhatsApp status
+- [ ] Send message to existing customers
+- [ ] Ask friends to share
+- [ ] Monitor inquiries closely
+
+---
+
+## 🎯 SUCCESS INDICATORS
+
+**You're on track if:**
+- WhatsApp inquiries increase 50%+
+- New customers mention "vi tu web"
+- B2B clients find you through Google
+- People ask about subscriptions
+- You get 5+ Google reviews in first month
+
+**Red flags (call us if):**
+- Website not loading
+- WhatsApp links broken
+- No inquiries after 1 week
+- Customers confused by pricing
+- Technical issues
+
+---
+
+**Questions? Need help?**
+📧 support@paragu-ai.com
+🌐 paragu-ai.com/granja-cabral
+
+**Let's make Granja Cabral the best egg farm website in Paraguay! 🥚🇵🇾**
+
+---
+
+*Document: Quick Action Checklist v1.0*  
+*Created: April 20, 2026*  
+*For: Laura Cabral - Granja Cabral*

--- a/docs/supabase-setup-for-claude.md
+++ b/docs/supabase-setup-for-claude.md
@@ -1,0 +1,125 @@
+# Supabase + tenant setup — what I need from you
+
+Short checklist of the info I need from you to finish the commerce go-live for **nexaparaguay**. I can do every step via the Supabase MCP — you just paste decisions here or reply in chat.
+
+---
+
+## 1. Admin auth user (Supabase Auth)
+
+Needed so you can log in at `https://paragu-ai.com/admin/*` once the chain is deployed.
+
+**Tell me:**
+
+- **Email to register:** `________________________`
+  (recommend your personal + deliverable inbox — not a role account yet)
+
+- **Onboarding method:** pick one
+  - [ ] **Magic link** — I create the user with an unlisted password, then send a one-time login link to your email. You click it, set your own password. ← **recommended**
+  - [ ] **Temporary password** — I create + set a password. I tell you once in chat (you rotate it on first login).
+
+Once you reply with those two, I run the Supabase MCP call immediately. 1 minute.
+
+---
+
+## 2. Enable commerce on `nexaparaguay`
+
+### ⚠️ First — confirm this is what you want
+
+`nexaparaguay` is type `relocation` (CLAUDE.md says "PENDING"). The commerce stack is built for **product catalogs with stock** (tienda-style). For relocation, it only makes sense if you want to:
+
+- Sell **relocation packages as products** ("Mudanza Express", "Mudanza Completa", etc. — one line item per package, fixed price)
+- Take a **booking deposit** via the storefront checkout
+- Skip the stock/inventory aspect (relocation services aren't inventoried)
+
+**If yes, I'll proceed.** If you'd rather pilot commerce on an actual retail tenant first (`dayah-litworks`, or a new `tienda-demo`), tell me which.
+
+### What I'll do if you confirm
+
+```sql
+-- Inject commerce config into nexaparaguay's data_json so the resolver
+-- picks it up without touching the relocation registry entry.
+UPDATE businesses
+SET data_json = jsonb_set(
+  COALESCE(data_json, '{}'::jsonb),
+  '{commerce}',
+  '{"enabled": true, "provider": "pagopar", "currency": "PYG", "launchPhase": "pilot"}'::jsonb
+)
+WHERE slug = 'nexaparaguay';
+```
+
+Then I'll seed 3-5 starter "packages" (you review + edit):
+
+- Mudanza Local — Gs 2.500.000
+- Mudanza Completa con embalaje — Gs 4.500.000
+- Mudanza Express (hasta 50km) — Gs 3.500.000
+- Gestión de documentos para relocación — Gs 800.000
+- Seguimiento personalizado 30 días — Gs 1.200.000
+
+These are placeholders based on typical PY relocation pricing. **Tell me what's real** and I'll overwrite.
+
+### Commission config for nexaparaguay
+
+Nexa is in the 3-month free-premium window per launch-source-of-truth. I'll set `commission_exempt_until = 2026-07-20` (3 months from today) so no commission is charged during the pilot. After that, defaults to 5%.
+
+---
+
+## 3. Pagopar credentials — three separate decisions
+
+### 3a. For the tenant (nexaparaguay) — needed to actually charge shoppers
+
+**Does nexaparaguay already have a Pagopar merchant account?**
+
+- [ ] **Yes** — tell me in chat that you have tokens. I'll walk you through `/admin/commerce/<nexaparaguay-business-id>/payments` to paste them (they're encrypted before DB insert).
+- [ ] **No — I want to help them open one** — tell me and I'll generate a pre-filled message in Spanish walking them through the Pagopar signup + token collection flow (Básico plan, Gs 49k/mo).
+- [ ] **No — for now just WhatsApp checkout** — tell me this and I'll keep commerce disabled on nexaparaguay's storefront, or enable commerce but route purchases to the existing "Pedir por WhatsApp" path without Pagopar.
+
+### 3b. For Paragu-AI (our own) — needed ONLY for commission splitting
+
+If you skip this, commerce on nexaparaguay still works — we just don't automatically skim commission from each sale. Since nexa is commission-exempt during the 3-month window anyway, **you can skip this entirely for now.**
+
+Set up later when you have a tenant outside the free window AND you want automatic commission.
+
+### 3c. For SaaS billing — NOT NEEDED
+
+Already swapped to bank-transfer + WhatsApp (PR #87). Your alias is wired in. Done.
+
+---
+
+## 4. Grant me additional Supabase access? (optional)
+
+I already have Supabase MCP access to the `paragu-ai` project (ref `qyvokpribmbrosafntqa`). I can:
+
+- ✅ Apply migrations (already doing this post-merge)
+- ✅ Run SELECTs to read tenant rows
+- ✅ Create Auth users (once you give me email for step 1)
+- ✅ Update rows to enable commerce
+- ✅ See security advisors
+
+**Nothing extra needed** — the MCP connection covers everything above.
+
+If you ever want to scope it down, you can revoke the MCP grant anytime from <https://claude.ai/integrations> → Supabase → disconnect. I'd lose the ability to do the above but your data stays intact.
+
+---
+
+## 5. After you reply — what happens
+
+1. I create the admin user (step 1)
+2. I enable commerce on nexaparaguay + seed 5 packages (step 2) — if you confirmed
+3. I report: login URL, admin user created, tenant's storefront URL
+4. You log in, walk through `/admin/commerce/<id>/products` + `/admin/commerce/<id>/orders` — see the UI for real
+5. Based on step 3a choice, either you bring Pagopar tokens or we defer
+
+---
+
+## Copy-paste reply template
+
+Fill in and paste back:
+
+```
+Admin email: ______________________
+Method: magic-link | temp-password
+Commerce on nexaparaguay: yes | no (switch to: __________)
+Pagopar for nexa: has-tokens | help-them-open | WhatsApp-only-for-now
+```
+
+That's it. Everything else I'll do.

--- a/src/content/blog-seeds/contador/precios-transferencia-etpt-paraguay.md
+++ b/src/content/blog-seeds/contador/precios-transferencia-etpt-paraguay.md
@@ -1,0 +1,174 @@
+---
+slug: precios-transferencia-etpt-paraguay
+title: "Precios de Transferencia (ETPT) en Paraguay: Guía Completa"
+excerpt: "Si operás con empresas vinculadas del exterior, ETPT aplica. Obligación de reporte, documentación comparable y cómo no caer en ajustes fiscales."
+category: "Impuestos"
+tags: ["precios transferencia", "etpt", "multinacionales", "ire"]
+author: "{{businessName}}"
+date: "2026-04-15"
+---
+
+# Precios de Transferencia (ETPT) en Paraguay: Guía Completa
+
+Si tu empresa paraguaya realiza operaciones con **empresas vinculadas del exterior** (matriz, subsidiaria, hermana), la normativa de **Estudios Técnicos de Precios de Transferencia (ETPT)** se aplica. Ignorarla es uno de los errores fiscales más caros en el país.
+
+## Qué son los precios de transferencia
+
+Cuando dos empresas **relacionadas** (misma propiedad, directorio común, control compartido) transaccionan entre sí:
+
+- Venden productos o servicios
+- Prestan dinero
+- Cobran regalías o licencias
+- Reparten costos
+- Distribuyen beneficios
+
+El **precio** que se fijan entre sí puede **distorsionarse** para mover utilidades al país con menor impuesto. Por eso las autoridades fiscales exigen que esos precios sean **"de mercado" (arm's length principle)**.
+
+En Paraguay, la normativa se introdujo con la **Ley 6380/19** y se desarrolló por **Decreto 3182/19** y resoluciones DNIT subsecuentes.
+
+## Quién debe presentar ETPT
+
+Toda empresa paraguaya que:
+
+1. **Forma parte de un grupo multinacional** (matriz o subsidiaria del exterior)
+2. Tiene **operaciones intercompañía** con la parte relacionada
+3. Supera umbrales de operaciones (variable según actividad, pero típicamente > USD 50k anuales)
+
+**También aplica si**:
+- Tu cliente o proveedor está en un **país de baja o nula tributación** (listado DNIT)
+- Tu empresa local tiene **multiples accionistas comunes** con otra entidad
+
+## Tipos de operaciones sujetas a ETPT
+
+1. **Compraventa de bienes** (inventario, materias primas, activo fijo)
+2. **Prestación de servicios** (consultoría, licencias IT, soporte técnico)
+3. **Financiación** (préstamos intercompañía, intereses)
+4. **Regalías** (uso de marca, patente, know-how)
+5. **Costos compartidos** (headquarter costs, R&D pooling)
+
+Tanto como **deudor como acreedor** debe justificarse que el precio sea de mercado.
+
+## Métodos de comparación aceptados
+
+El DNIT acepta los 5 métodos OECD (Directrices OCDE):
+
+1. **CUP** (Comparable Uncontrolled Price) — precio de bienes/servicios idénticos en mercado abierto
+2. **Costo plus** — costo + margen razonable para el sector
+3. **Reventa** — precio final - margen estándar del distribuidor
+4. **Margen neto** (TNMM) — comparación con márgenes de empresas similares
+5. **Partición de beneficios** — cuando operaciones son muy complejas
+
+La elección del método depende de la operación y disponibilidad de comparables.
+
+## Documentación requerida
+
+### 1. Estudio Técnico (ETPT)
+
+Documento que incluye:
+- Estructura del grupo multinacional (cap table, directorio)
+- Descripción de la operación controlada
+- Análisis funcional (funciones, activos, riesgos)
+- Selección y justificación del método
+- Identificación y análisis de comparables
+- Rango de plena competencia (arm's length range)
+- Conclusión sobre si el precio intercompañía cumple o no
+
+### 2. Informe Anual
+
+Presentación anual al DNIT que resume:
+- Operaciones controladas del ejercicio
+- Método aplicado a cada una
+- Ajustes realizados (si corresponde)
+
+### 3. Base Erosion & Profit Shifting (BEPS)
+
+Si el grupo multinacional supera umbrales, además:
+- **Country-by-Country Report (CbCR)**
+- **Master File** (estructura global del grupo)
+- **Local File** (detalle de la entidad paraguaya)
+
+## Plazos
+
+- **Informe anual ETPT**: dentro de los **6 meses** posteriores al cierre del ejercicio
+- **CbCR/Master File/Local File** (si aplica BEPS): similar
+
+Presentación vía Marangatú.
+
+## Riesgos de no cumplir
+
+1. **Ajuste fiscal**: DNIT recalcula el precio a "arm's length" y aplica IRE adicional + intereses + multa
+2. **No deducibilidad de gastos**: si el precio pagado a vinculada es "excesivo" vs comparables, el exceso no es deducible
+3. **Multas**: por no presentar informe anual o documentación incompleta
+4. **Exposición reputacional**: controversias de precios de transferencia son públicas y afectan valuación
+
+## Ejemplos típicos de ajustes
+
+### Caso 1: Regalías excesivas
+
+Matriz en Luxemburgo cobra 15% de regalías a subsidiaria paraguaya por uso de marca. Comparables del sector pagan 3-7%.
+
+**Ajuste**: DNIT puede limitar el gasto deducible al 7%. El 8% extra se suma a la utilidad gravada = IRE adicional + intereses + multa.
+
+### Caso 2: Préstamo con interés fuera de mercado
+
+Matriz presta USD 1M a subsidiaria paraguaya al 2% anual. Tasa arm's length para operación similar: 7-9%.
+
+**Ajuste**: DNIT puede re-caracterizar parte del "préstamo" como aporte de capital + recalcular el interés a tasa de mercado.
+
+### Caso 3: Servicios sobrecobrados
+
+Headquarter cobra USD 500k/año por servicios no documentados. Los servicios no se prestan efectivamente (o no benefician a la entidad local).
+
+**Ajuste**: Desconocimiento del gasto. USD 500k se suma a utilidad = IRE 10% adicional.
+
+## Señales de alerta
+
+- **Empresa paraguaya perdiendo dinero año tras año** mientras la matriz lucra
+- **Compras a precio muy superior al de mercado** (distorsionando márgenes)
+- **Servicios sin contrato formalizado** o sin sustento documental
+- **Préstamos intercompañía al 0% interés**
+- **Repartos de costos arbitrarios** sin base económica
+
+Cualquiera de estos es bandera roja en fiscalización.
+
+## Casos en que NO aplica ETPT
+
+- Operaciones con **empresas paraguayas no vinculadas**
+- Operaciones con vinculadas paraguayas (no cross-border)
+- Empresas puramente domésticas sin grupo multinacional
+- Operaciones bajo umbral (típicamente < USD 50k/año, consultar resolución vigente)
+
+## Estrategia preventiva
+
+Para evitar problemas:
+
+1. **Documentar desde el inicio** — contratos firmados, benchmarking
+2. **Actualizar ETPT cada año** — no hacer uno solo al principio y olvidarlo
+3. **Usar métodos robustos** (TNMM suele ser más defendible)
+4. **Registrar en Marangatú en tiempo** — demora = multa automática
+5. **Planificar precios antes de firmar** — no es lo mismo "corregir" que "defender"
+
+## Costos de ETPT
+
+Un estudio técnico serio requiere:
+
+- Licencia a bases de datos (Amadeus, Osiris, RoyaltyStat) — USD 5-20k/año según alcance
+- Consultor especializado — USD 10-30k por proyecto
+- Tiempo de análisis — 4-8 semanas
+
+Algunas firmas ofrecen ETPT desde **Gs. 25M-70M por operación**. Para grupos con múltiples operaciones, puede superar **Gs. 200M anuales**.
+
+## Cuándo tercerizar a especialistas
+
+ETPT es una disciplina técnica especializada. Contador generalista **no la domina** y puede cometer errores caros.
+
+Recomendamos especialista cuando:
+- Múltiples tipos de operaciones intercompañía
+- Grupo multinacional con presencia en 3+ países
+- Activos intangibles complejos (patentes, marcas)
+- Historia de auditorías o controversias fiscales
+- Expansión internacional reciente
+
+---
+
+*Si tu empresa tiene operaciones con el exterior y no tenés ETPT formal, agendá una consulta. Revisamos exposición y definimos la estrategia — antes de que DNIT llegue.*

--- a/web/components/sections/blog-section.tsx
+++ b/web/components/sections/blog-section.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { ArrowRight, Calendar, Clock, Search, Tag, User } from 'lucide-react'
+
+type LocalizedString = Partial<Record<'es' | 'en' | 'nl' | 'de', string>>
+
+interface BlogPost {
+  slug: string
+  title: LocalizedString
+  excerpt: LocalizedString
+  category: string
+  author: string
+  date: string
+  readTime: string
+  image?: string
+  tags?: string[]
+}
+
+interface BlogSectionProps {
+  title?: LocalizedString
+  subtitle?: LocalizedString
+  posts?: BlogPost[]
+  locale?: 'es' | 'en' | 'nl' | 'de'
+  showAllLink?: string
+}
+
+const DEFAULT_POSTS: BlogPost[] = [
+  {
+    slug: 'impuesto-territorial-paraguay-2026',
+    title: {
+      es: 'Impuesto Territorial: Cómo funciona en 2026',
+      en: 'Territorial Tax: How it works in 2026',
+    },
+    excerpt: {
+      es: 'El sistema fiscal paraguayo es único en América Latina. Descubrí cómo funciona el impuesto territorial y cuánto podés ahorrar.',
+      en: 'The Paraguayan tax system is unique in Latin America. Discover how the territorial tax works and how much you can save.',
+    },
+    category: 'fiscal',
+    author: 'Nexa Team',
+    date: '2026-04-15',
+    readTime: '8 min',
+    tags: ['tax', 'fiscal', 'paraguay'],
+  },
+  {
+    slug: 'residencia-paraguay-paso-a-paso',
+    title: {
+      es: 'Residencia en Paraguay: Paso a Paso',
+      en: 'Residency in Paraguay: Step by Step',
+    },
+    excerpt: {
+      es: 'Guía completa para obtener tu residencia en Paraguay. Documentos, tiempos y consejos prácticos.',
+      en: 'Complete guide to obtaining residency in Paraguay. Documents, timelines and practical tips.',
+    },
+    category: 'residencia',
+    author: 'Nexa Team',
+    date: '2026-04-10',
+    readTime: '12 min',
+    tags: ['residency', 'immigration', 'guide'],
+  },
+  {
+    slug: 'costo-de-vida-asuncion',
+    title: {
+      es: 'Costo de Vida Asunción: Números Reales',
+      en: 'Cost of Living Asunción: Real Numbers',
+    },
+    excerpt: {
+      es: 'Cuánto cuesta vivir en Asunción en 2026. Alquileres, comida, transporte y más.',
+      en: 'How much does it cost to live in Asunción in 2026. Rent, food, transport and more.',
+    },
+    category: 'lifestyle',
+    author: 'Nexa Team',
+    date: '2026-04-05',
+    readTime: '6 min',
+    tags: ['cost of living', 'asuncion', 'lifestyle'],
+  },
+]
+
+const CATEGORIES: Array<{ id: string; label: LocalizedString }> = [
+  { id: 'all', label: { es: 'Todos', en: 'All' } },
+  { id: 'fiscal', label: { es: 'Fiscal', en: 'Tax' } },
+  { id: 'residencia', label: { es: 'Residencia', en: 'Residency' } },
+  { id: 'lifestyle', label: { es: 'Estilo de Vida', en: 'Lifestyle' } },
+  { id: 'negocios', label: { es: 'Negocios', en: 'Business' } },
+  { id: 'consejos', label: { es: 'Consejos', en: 'Tips' } },
+]
+
+export function BlogSection({
+  title,
+  subtitle,
+  posts = DEFAULT_POSTS,
+  locale = 'es',
+  showAllLink = '/blog',
+}: BlogSectionProps) {
+  const [activeCategory, setActiveCategory] = useState('all')
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const filteredPosts = posts.filter((post) => {
+    const matchesSearch =
+      searchQuery === '' ||
+      post.title[locale]?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      post.excerpt[locale]?.toLowerCase().includes(searchQuery.toLowerCase())
+    const matchesCategory = activeCategory === 'all' || post.category === activeCategory
+    return matchesSearch && matchesCategory
+  })
+
+  return (
+    <section className="bg-[var(--surface-light)] py-16" id="blog">
+      <div className="mx-auto max-w-6xl px-6">
+        {title && (
+          <div className="mb-12 text-center">
+            <h2 className="text-3xl font-bold text-[var(--text)]">{title[locale] || title.es}</h2>
+            {subtitle && <p className="mt-2 text-[var(--text-muted)]">{subtitle[locale] || subtitle.es}</p>}
+          </div>
+        )}
+
+        <div className="mb-8">
+          <div className="relative">
+            <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-[var(--text-muted)]" />
+            <input
+              type="text"
+              placeholder="Search articles..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface)] py-3 pl-12 pr-4 text-[var(--text)] placeholder-[var(--text-muted)] focus:border-[var(--primary)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]/20"
+            />
+          </div>
+        </div>
+
+        <div className="mb-8 flex flex-wrap justify-center gap-2">
+          {CATEGORIES.map((cat) => (
+            <button
+              key={cat.id}
+              onClick={() => setActiveCategory(cat.id)}
+              className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+                activeCategory === cat.id
+                  ? 'bg-[var(--primary)] text-[var(--primary-foreground)]'
+                  : 'bg-[var(--surface)] text-[var(--text-muted)] hover:bg-[var(--primary)]/10'
+              }`}
+            >
+              {cat.label[locale] || cat.label.es}
+            </button>
+          ))}
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {filteredPosts.map((post) => (
+            <article
+              key={post.slug}
+              className="group flex flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)] transition-all hover:-translate-y-1 hover:shadow-lg"
+            >
+              {post.image && (
+                <div className="h-48 overflow-hidden bg-[var(--surface-light)]">
+                  <img
+                    src={post.image}
+                    alt={post.title[locale] || post.title.es}
+                    className="h-full w-full object-cover transition-transform group-hover:scale-105"
+                  />
+                </div>
+              )}
+              <div className="flex flex-1 flex-col p-6">
+                <div className="mb-3 flex items-center gap-2 text-xs text-[var(--text-muted)]">
+                  <span className="rounded-full bg-[var(--primary)]/10 px-2 py-1 font-medium text-[var(--primary)]">
+                    {post.category}
+                  </span>
+                  <span>·</span>
+                  <span className="flex items-center gap-1">
+                    <Clock size={12} />
+                    {post.readTime}
+                  </span>
+                </div>
+                <h3 className="mb-2 text-lg font-bold text-[var(--text)] group-hover:text-[var(--primary)]">
+                  {post.title[locale] || post.title.es}
+                </h3>
+                <p className="mb-4 flex-1 text-sm text-[var(--text-muted)]">
+                  {post.excerpt[locale] || post.excerpt.es}
+                </p>
+                <div className="flex items-center justify-between border-t border-[var(--border)] pt-4">
+                  <div className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
+                    <Calendar size={12} />
+                    {post.date}
+                  </div>
+                  <Link
+                    href={`/blog/${post.slug}`}
+                    className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--primary)]"
+                  >
+                    Read more
+                    <ArrowRight size={14} className="transition-transform group-hover:translate-x-1" />
+                  </Link>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        {filteredPosts.length === 0 && (
+          <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-8 text-center">
+            <p className="text-[var(--text-muted)]">No articles found. Try a different search term or category.</p>
+          </div>
+        )}
+
+        {showAllLink && (
+          <div className="mt-8 text-center">
+            <Link
+              href={showAllLink}
+              className="inline-flex items-center gap-2 rounded-xl bg-[var(--primary)] px-6 py-3 font-semibold text-[var(--primary-foreground)] transition-colors hover:bg-[var(--primary)]/90"
+            >
+              View all articles
+              <ArrowRight size={18} />
+            </Link>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/web/components/sections/success-stories.tsx
+++ b/web/components/sections/success-stories.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import { useState } from 'react'
+import { ArrowRight, Quote, MapPin, Calendar, TrendingUp, Users } from 'lucide-react'
+
+type LocalizedString = Partial<Record<'es' | 'en' | 'nl' | 'de', string>>
+
+interface Testimonial {
+  id: string
+  name: string
+  country: string
+  quote: LocalizedString
+  rating: number
+  before?: LocalizedString
+  after?: LocalizedString
+  metrics?: { label: string; value: string }[]
+  program?: string
+}
+
+interface SuccessStoriesProps {
+  title?: LocalizedString
+  subtitle?: LocalizedString
+  items: Testimonial[]
+  locale?: 'es' | 'en' | 'nl' | 'de'
+}
+
+const DEFAULT_STORIES: Testimonial[] = [
+  {
+    id: 'janssen-family',
+    name: 'Familia Janssen',
+    country: 'Netherlands',
+    quote: {
+      es: 'Nos ayudaron con todo el proceso de residencia y la compra de nuestra propiedad. Excelente servicio desde el primer día.',
+      en: 'They helped us with the entire residency process and the purchase of our property. Excellent service from day one.',
+    },
+    rating: 5,
+    before: {
+      es: 'Buscando información confusa en línea, sin saber qué documentos necesitaban',
+      en: 'Searching for confusing information online, not knowing what documents they needed',
+    },
+    after: {
+      es: 'Residencia permanente obtenida en 4 meses, propiedad en Asunción',
+      en: 'Permanent residency obtained in 4 months, property in Asunción',
+    },
+    metrics: [
+      { label: 'Timeline', value: '4 months' },
+      { label: 'Savings', value: '$45K/year' },
+    ],
+    program: 'Business Residency',
+  },
+  {
+    id: 'schmidt-michael',
+    name: 'Michael Schmidt',
+    country: 'Germany',
+    quote: {
+      es: 'Komplette Unterstützung bei der Firmengründung. Sehr zu empfehlen! El equipo Handles toda la documentación.',
+      en: 'Complete support for company formation. Highly recommended! The team handles all documentation.',
+    },
+    rating: 5,
+    before: {
+      es: 'Preocupado por la burocracia paraguaya',
+      en: 'Worried about Paraguayan bureaucracy',
+    },
+    after: {
+      es: 'SRL operativa en 3 semanas, cuenta bancaria abierta',
+      en: 'Operating SRL in 3 weeks, bank account opened',
+    },
+    metrics: [
+      { label: 'Timeline', value: '3 weeks' },
+      { label: 'Tax Savings', value: '60%' },
+    ],
+    program: 'Company Formation',
+  },
+  {
+    id: 'garcia-muller',
+    name: 'Familia García-Müller',
+    country: 'Spain',
+    quote: {
+      es: 'El proceso fue mucho más sencillo de lo que esperábamos. Gracias a Nexa por hacer todo tan fácil.',
+      en: 'The process was much simpler than we expected. Thanks to Nexa for making everything so easy.',
+    },
+    rating: 5,
+    before: {
+      es: 'Espera de 2 años en lista para golden visa en Portugal',
+      en: '2-year wait on golden visa list in Portugal',
+    },
+    after: {
+      es: 'Residencia temporal approved en 8 semanas',
+      en: 'Temporary residency approved in 8 weeks',
+    },
+    metrics: [
+      { label: 'Timeline', value: '8 weeks' },
+      { label: 'Investment', value: '$0' },
+    ],
+    program: 'Temporary Residency',
+  },
+]
+
+export function SuccessStories({
+  title,
+  subtitle,
+  items = DEFAULT_STORIES,
+  locale = 'es',
+}: SuccessStoriesProps) {
+  const [activeStory, setActiveStory] = useState(0)
+
+  return (
+    <section className="bg-gradient-to-b from-[var(--surface)] to-[var(--surface-light)] py-16" id="testimonials">
+      <div className="mx-auto max-w-6xl px-6">
+        {title && (
+          <div className="mb-12 text-center">
+            <h2 className="text-3xl font-bold text-[var(--text)]">{title[locale] || title.es}</h2>
+            {subtitle && <p className="mt-2 text-[var(--text-muted)]">{subtitle[locale] || subtitle.es}</p>}
+          </div>
+        )}
+
+        <div className="grid gap-8 lg:grid-cols-2">
+          <div className="space-y-4">
+            {items.map((story, idx) => (
+              <button
+                key={story.id}
+                onClick={() => setActiveStory(idx)}
+                className={`group w-full text-left transition-all ${
+                  activeStory === idx
+                    ? 'rounded-2xl border-2 border-[var(--primary)] bg-[var(--surface)] p-4'
+                    : 'rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 opacity-70 hover:opacity-100'
+                }`}
+              >
+                <div className="flex items-start gap-4">
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-[var(--primary)]/10 text-[var(--primary)]">
+                    <Users size={20} />
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold text-[var(--text)]">{story.name}</span>
+                      <span className="flex text-yellow-400">
+                        {Array.from({ length: story.rating }).map((_, i) => (
+                          <Quote key={i} size={12} fill="currentColor" />
+                        ))}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 text-sm text-[var(--text-muted)]">
+                      <MapPin size={14} />
+                      {story.country}
+                    </div>
+                    {story.program && (
+                      <span className="mt-2 inline-block rounded-full bg-[var(--primary)]/10 px-3 py-1 text-xs font-medium text-[var(--primary)]">
+                        {story.program}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+
+          <div className="rounded-3xl border border-[var(--border)] bg-[var(--surface)] p-8">
+            <div className="mb-6 flex items-start gap-4">
+              <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-[var(--primary)]/10 text-[var(--primary)]">
+                <Quote size={32} />
+              </div>
+              <div>
+                <p className="text-lg italic text-[var(--text)]">"{items[activeStory].quote[locale] || items[activeStory].quote.es}"</p>
+              </div>
+            </div>
+
+            {items[activeStory].before && items[activeStory].after && (
+              <div className="mb-6 grid grid-cols-2 gap-4">
+                <div className="rounded-xl bg-[var(--error)]/5 p-4">
+                  <p className="mb-1 text-xs font-semibold uppercase text-[var(--error)]">Before</p>
+                  <p className="text-sm text-[var(--text)]">{items[activeStory].before?.[locale] || items[activeStory].before?.es}</p>
+                </div>
+                <div className="rounded-xl bg-[var(--success)]/5 p-4">
+                  <p className="mb-1 text-xs font-semibold uppercase text-[var(--success)]">After</p>
+                  <p className="text-sm text-[var(--text)]">{items[activeStory].after?.[locale] || items[activeStory].after?.es}</p>
+                </div>
+              </div>
+            )}
+
+            {items[activeStory].metrics && (
+              <div className="flex gap-4">
+                {items[activeStory].metrics?.map((metric, idx) => (
+                  <div
+                    key={idx}
+                    className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface-light)] p-3 text-center"
+                  >
+                    <div className="flex items-center justify-center gap-2">
+                      <TrendingUp size={16} className="text-[var(--success)]" />
+                      <span className="text-lg font-bold text-[var(--text)]">{metric.value}</span>
+                    </div>
+                    <p className="text-xs text-[var(--text-muted)]">{metric.label}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="mt-6 flex items-center justify-between">
+              <div className="flex items-center gap-2 text-sm text-[var(--text-muted)]">
+                <Calendar size={16} />
+                <span>{items[activeStory].country}</span>
+              </div>
+              <a
+                href="/contacto"
+                className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--primary)] hover:underline"
+              >
+                Get similar results
+                <ArrowRight size={14} />
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/web/components/sections/trust-badges.tsx
+++ b/web/components/sections/trust-badges.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useState } from 'react'
+import { Check, Award, Users, Clock, Shield, Star } from 'lucide-react'
+
+interface TrustBadge {
+  id: string
+  value: string
+  label: string
+}
+
+interface Certification {
+  name: string
+  description: string
+}
+
+interface TrustBadgesProps {
+  title?: { es: string; en: string }
+  badges?: TrustBadge[]
+  certifications?: Certification[]
+}
+
+const DEFAULT_BADGES: TrustBadge[] = [
+  { id: 'years', value: '8+', label: 'Years experience' },
+  { id: 'clients', value: '500+', label: 'Satisfied clients' },
+  { id: 'success', value: '100%', label: 'Success rate' },
+  { id: 'response', value: '24h', label: 'Response time' },
+]
+
+const DEFAULT_CERTIFICATIONS: Certification[] = [
+  { name: 'ISO 9001', description: 'Quality Management System' },
+  { name: 'Member of AIPY', description: 'Paraguayan Investors Association' },
+]
+
+const BADGE_ICONS: Record<string, typeof Users> = {
+  years: Clock,
+  clients: Users,
+  success: Award,
+  response: Clock,
+}
+
+export function TrustBadges({
+  title,
+  badges = DEFAULT_BADGES,
+  certifications = DEFAULT_CERTIFICATIONS,
+}: TrustBadgesProps) {
+  const [hoveredBadge, setHoveredBadge] = useState<string | null>(null)
+
+  return (
+    <section className="bg-gradient-to-b from-[var(--surface)] to-[var(--surface-light)] py-16">
+      <div className="mx-auto max-w-6xl px-6">
+        {title && (
+          <div className="mb-10 text-center">
+            <h2 className="text-2xl font-bold text-[var(--text)]">{title.es}</h2>
+          </div>
+        )}
+
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {badges.map((badge) => {
+            const Icon = BADGE_ICONS[badge.id] || Star
+            return (
+              <div
+                key={badge.id}
+                className="group relative rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 text-center transition-all hover:border-[var(--primary)]/30 hover:shadow-lg"
+                onMouseEnter={() => setHoveredBadge(badge.id)}
+                onMouseLeave={() => setHoveredBadge(null)}
+              >
+                <div className="mb-3 flex justify-center">
+                  <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[var(--primary)]/10 text-[var(--primary)] transition-transform group-hover:scale-110">
+                    <Icon size={28} />
+                  </div>
+                </div>
+                <p className="text-4xl font-bold text-[var(--primary)]">{badge.value}</p>
+                <p className="mt-1 text-sm font-medium text-[var(--text-muted)]">{badge.label}</p>
+              </div>
+            )
+          })}
+        </div>
+
+        {certifications && certifications.length > 0 && (
+          <div className="mt-12 border-t border-[var(--border)] pt-8">
+            <div className="flex flex-wrap items-center justify-center gap-8">
+              {certifications.map((cert, idx) => (
+                <div key={idx} className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--success)]/10">
+                    <Shield size={20} className="text-[var(--success)]" />
+                  </div>
+                  <div>
+                    <p className="font-semibold text-[var(--text)]">{cert.name}</p>
+                    <p className="text-xs text-[var(--text-muted)]">{cert.description}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export function TrustBadgeMinimal() {
+  const badges = [
+    { icon: Award, value: '8+', label: 'Years' },
+    { icon: Users, value: '500+', label: 'Clients' },
+    { icon: Check, value: '100%', label: 'Success' },
+  ]
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-6">
+      {badges.map((badge) => (
+        <div key={badge.label} className="flex items-center gap-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--primary)]/10">
+            <badge.icon size={16} className="text-[var(--primary)]" />
+          </div>
+          <span className="text-sm font-semibold text-[var(--text)]">
+            {badge.value} {badge.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/lib/data/py-dnit-resolutions.ts
+++ b/web/lib/data/py-dnit-resolutions.ts
@@ -1,0 +1,230 @@
+/**
+ * Key DNIT (ex-SET) resolutions 2020-2026 quick-reference.
+ *
+ * Surfaces the most-cited resolutions for the contador template's
+ * "novedades DNIT" section. Not exhaustive — curated to what SMB-facing
+ * contadores reference weekly. Updated quarterly.
+ */
+
+export type ResolutionCategory =
+  | 'general'
+  | 'iva'
+  | 'ire'
+  | 'irp'
+  | 'idu'
+  | 'laboral'
+  | 'facturacion-electronica'
+  | 'agro'
+  | 'maquila'
+  | 'crypto'
+  | 'precios-transferencia'
+  | 'resimple'
+
+export interface DnitResolution {
+  number: string
+  year: number
+  title: string
+  summary: string
+  category: ResolutionCategory
+  impact: 'high' | 'medium' | 'low'
+  /** Who is affected */
+  affects: string[]
+  /** Optional permalink (DNIT site structure varies). */
+  link?: string
+}
+
+/**
+ * Curated DNIT resolutions — key ones an SMB contador should know cold.
+ * Ordered by most recent first.
+ */
+export const DNIT_RESOLUTIONS: DnitResolution[] = [
+  {
+    number: 'RG 001/2026',
+    year: 2026,
+    title: 'Actualizacion calendario perpetuo de vencimientos IVA/IRP/IRE',
+    summary: 'Reajuste de fechas segun ultimo digito del RUC para vencimientos mensuales y anuales. Sin cambios estructurales vs 2025.',
+    category: 'general',
+    impact: 'high',
+    affects: ['Todos los contribuyentes', 'Contadores'],
+  },
+  {
+    number: 'RG 047/2025',
+    year: 2025,
+    title: 'REOP-MTESS integracion obligatoria',
+    summary: 'Comunicacion electronica de liquidaciones salariales al MTESS-REOP es obligatoria desde 2025. Multa por empleado por mes en caso de omision.',
+    category: 'laboral',
+    impact: 'high',
+    affects: ['Empleadores con personal en relacion de dependencia'],
+  },
+  {
+    number: 'RG 015/2024',
+    year: 2024,
+    title: 'Renombramiento SET a DNIT',
+    summary: 'La Subsecretaria de Estado de Tributacion (SET) pasa a denominarse Direccion Nacional de Ingresos Tributarios (DNIT). Marangatu, e-Kuatia y formularios se mantienen vigentes.',
+    category: 'general',
+    impact: 'medium',
+    affects: ['Todos'],
+  },
+  {
+    number: 'Nota DNIT 2024',
+    year: 2024,
+    title: 'Posicion sobre tributacion de criptoactivos',
+    summary: 'Las ganancias habituales por compraventa de criptoactivos se consideran renta gravada y tributan IRE 10%. Comisiones de intermediacion estan sujetas a IVA 10%.',
+    category: 'crypto',
+    impact: 'high',
+    affects: ['Traders crypto', 'Exchanges', 'Remesadoras cripto'],
+  },
+  {
+    number: 'RG 82/2023',
+    year: 2023,
+    title: 'Obligados a facturacion electronica e-Kuatia',
+    summary: 'Expansion del universo obligado a emitir facturas electronicas via e-Kuatia. Grandes contribuyentes + exportadores + sectores regulados. Cronograma por segmentos.',
+    category: 'facturacion-electronica',
+    impact: 'high',
+    affects: ['Grandes contribuyentes', 'Exportadores', 'Sectores regulados'],
+  },
+  {
+    number: 'RG 57/2023',
+    year: 2023,
+    title: 'Procedimientos facturacion electronica e-Kuatia\'i',
+    summary: 'Alternativa mas simple para pequenos contribuyentes — emision de comprobantes electronicos via e-Kuatia\'i.',
+    category: 'facturacion-electronica',
+    impact: 'medium',
+    affects: ['Pequenos contribuyentes', 'Profesionales independientes'],
+  },
+  {
+    number: 'Decreto 3182/2019',
+    year: 2019,
+    title: 'Reglamentacion de precios de transferencia (ETPT)',
+    summary: 'Establece obligaciones para operaciones con partes relacionadas del exterior. Metodos OCDE aceptados. Documentacion anual.',
+    category: 'precios-transferencia',
+    impact: 'high',
+    affects: ['Grupos multinacionales', 'Empresas con matriz o subsidiaria exterior'],
+  },
+  {
+    number: 'Ley 6380/2019',
+    year: 2019,
+    title: 'Reforma tributaria — Ley de Modernizacion',
+    summary: 'Reforma estructural del sistema tributario paraguayo. Crea IRE, IRP, IDU. Define RESIMPLE, IRE Simple, IRE General. Deroga IRACIS, IRPC, IRAGRO, IRP anterior.',
+    category: 'general',
+    impact: 'high',
+    affects: ['Todos los contribuyentes'],
+  },
+  {
+    number: 'Decreto 3110/2019',
+    year: 2019,
+    title: 'Reglamentacion del IRP (art. 68 — deducciones)',
+    summary: 'Detalla las deducciones permitidas del IRP: gastos medicos, educacion, vivienda, vehiculo, insumos profesionales, capacitacion.',
+    category: 'irp',
+    impact: 'high',
+    affects: ['Profesionales independientes', 'Empleados con IRP'],
+  },
+  {
+    number: 'RG 55/2020',
+    year: 2020,
+    title: 'Calendario perpetuo IVA, IRP, IRE',
+    summary: 'Establece el calendario perpetuo escalonado por ultimo digito del RUC para vencimientos mensuales y anuales.',
+    category: 'general',
+    impact: 'high',
+    affects: ['Todos los contribuyentes'],
+  },
+  {
+    number: 'RG 39/2020',
+    year: 2020,
+    title: 'Distribucion de dividendos y utilidades (IDU)',
+    summary: 'Reglamenta la retencion del IDU (8% para residentes, 15% para no residentes) al momento de distribucion. Vencimiento 30 dias post-pago.',
+    category: 'idu',
+    impact: 'high',
+    affects: ['Empresas con accionistas', 'SRL con distribucion de utilidades'],
+  },
+  {
+    number: 'Res. SEPRELAD 8/2020',
+    year: 2020,
+    title: 'Sujeto obligado crypto',
+    summary: 'Empresas crypto con ciertos volumenes son sujetos obligados SEPRELAD. Registro, oficial de cumplimiento, ROS mensuales.',
+    category: 'crypto',
+    impact: 'high',
+    affects: ['Exchanges crypto', 'Remesadoras', 'OTC desks'],
+  },
+  {
+    number: 'Ley 6480/2020',
+    year: 2020,
+    title: 'EAS — Empresa por Acciones Simplificadas',
+    summary: 'Crea la figura EAS. Constitucion online via MIC en 72 horas. Capital minimo cero. Socio unico valido. Responsabilidad limitada.',
+    category: 'general',
+    impact: 'high',
+    affects: ['Nuevos emprendimientos', 'Nomadas digitales', 'Inversores extranjeros'],
+  },
+  {
+    number: 'Ley 1064/1997',
+    year: 1997,
+    title: 'Industria Maquiladora de Exportacion',
+    summary: 'Regimen de maquila: tributo unico 1% sobre facturacion, importacion temporal sin aranceles, obligacion de exportar 100%. Aprobacion via CNIME.',
+    category: 'maquila',
+    impact: 'high',
+    affects: ['Maquiladoras', 'Empresas en Ciudad del Este', 'Zona Franca'],
+  },
+  {
+    number: 'Res. INCOOP 4109/2009',
+    year: 2009,
+    title: 'Balance Social Cooperativo',
+    summary: 'Documento anual obligatorio para cooperativas. Mide cumplimiento de los 7 principios cooperativos, indicadores de educacion e integracion.',
+    category: 'general',
+    impact: 'medium',
+    affects: ['Cooperativas'],
+  },
+  {
+    number: 'Ley 5115/2013',
+    year: 2013,
+    title: 'Trabajador rural',
+    summary: 'Establece regimen laboral especifico para trabajadores rurales: zafreros, peones de campo, trabajadores agropecuarios.',
+    category: 'laboral',
+    impact: 'medium',
+    affects: ['Empleadores rurales', 'Productores agropecuarios'],
+  },
+  {
+    number: 'Res. CGR 106/2024',
+    year: 2024,
+    title: 'Rendicion ONGs a Contraloria',
+    summary: 'Establece procedimiento de rendicion anual online al CGR para ONGs y fundaciones.',
+    category: 'general',
+    impact: 'medium',
+    affects: ['ONGs', 'Fundaciones'],
+  },
+]
+
+/**
+ * Get most recent high-impact resolutions (for homepage "novedades" widget).
+ */
+export function getRecentHighImpact(limit = 5): DnitResolution[] {
+  return DNIT_RESOLUTIONS.filter((r) => r.impact === 'high')
+    .sort((a, b) => b.year - a.year)
+    .slice(0, limit)
+}
+
+/**
+ * Get resolutions by category (for category-filtered news feed).
+ */
+export function getResolutionsByCategory(category: ResolutionCategory): DnitResolution[] {
+  return DNIT_RESOLUTIONS.filter((r) => r.category === category)
+}
+
+/**
+ * Get resolutions relevant to a sub-type (for tailored "novedades" per tenant).
+ */
+export function getResolutionsForSubtype(subtype: string): DnitResolution[] {
+  const subtypeCategories: Record<string, ResolutionCategory[]> = {
+    contador: ['general', 'iva', 'ire', 'irp', 'idu', 'resimple', 'laboral', 'facturacion-electronica'],
+    contador_inversores: ['general', 'ire', 'idu', 'precios-transferencia', 'facturacion-electronica'],
+    contador_agro: ['general', 'ire', 'agro', 'laboral'],
+    contador_cooperativa: ['general', 'ire', 'laboral'],
+    contador_crypto: ['crypto', 'ire', 'idu'],
+    contador_maquila: ['maquila', 'general', 'facturacion-electronica'],
+    contador_medico: ['irp', 'general', 'facturacion-electronica'],
+    contador_tecnologia: ['ire', 'general', 'idu', 'precios-transferencia'],
+    contador_ong: ['general', 'laboral', 'irp'],
+  }
+  const cats = subtypeCategories[subtype] || subtypeCategories.contador
+  return DNIT_RESOLUTIONS.filter((r) => cats.includes(r.category))
+    .sort((a, b) => b.year - a.year)
+}

--- a/web/lib/seo/hreflang.tsx
+++ b/web/lib/seo/hreflang.tsx
@@ -1,0 +1,129 @@
+/**
+ * Hreflang helper for multi-language SEO.
+ * 
+ * Usage: Add to the Head of your page:
+ * import { generateHreflang } from '@/lib/seo/hreflang'
+ * 
+ * const hreflangs = generateHreflang('/path', ['es', 'en', 'nl', 'de'], 'https://nexaparaguay.com')
+ */
+
+export interface HrefLang {
+  hreflang: string
+  href: string
+}
+
+export type Locale = 'es' | 'en' | 'nl' | 'de'
+
+export const LOCALES: Record<Locale, string> = {
+  es: 'es',
+  en: 'en',
+  nl: 'nl',
+  de: 'de',
+}
+
+export const LOCALE_NAMES: Record<Locale, string> = {
+  es: 'Spanish',
+  en: 'English',
+  nl: 'Dutch',
+  de: 'German',
+}
+
+export const LOCALE_FLAGS: Record<Locale, string> = {
+  es: '🇵🇾',
+  en: '🇬🇧',
+  nl: '🇳🇱',
+  de: '🇩🇪',
+}
+
+/**
+ * Generate hreflang tags for a given path.
+ * 
+ * @param path - The URL path (e.g., '/blog/post-1')
+ * @param locales - Array of available locales
+ * @param baseUrl - Base URL without trailing slash (e.g., 'https://nexaparaguay.com')
+ * @returns Array of { hreflang, href } objects
+ */
+export function generateHreflang(
+  path: string,
+  locales: Locale[],
+  baseUrl: string,
+): HrefLang[] {
+  const results: HrefLang[] = []
+
+  for (const locale of locales) {
+    results.push({
+      hreflang: locale,
+      href: `${baseUrl}/${locale}${path === '/' ? '' : path}`,
+    })
+  }
+
+  // Add x-default (usually the primary locale)
+  const defaultLocale = locales[0]
+  results.push({
+    hreflang: 'x-default',
+    href: `${baseUrl}/${defaultLocale}${path === '/' ? '' : path}`,
+  })
+
+  return results
+}
+
+/**
+ * Generate hreflang HTML tags for direct insertion into <head>
+ * 
+ * @param path - The URL path
+ * @param locales - Array of available locales  
+ * @param baseUrl - Base URL
+ * @returns HTML string with all link rel="alternate" tags
+ */
+export function generateHreflangHtml(
+  path: string,
+  locales: Locale[],
+  baseUrl: string,
+): string {
+  const tags = generateHreflang(path, locales, baseUrl)
+
+  return tags
+    .map(
+      (tag) =>
+        `<link rel="alternate" hreflang="${tag.hreflang}" href="${tag.href}" />`,
+    )
+    .join('\n')
+}
+
+/**
+ * Get locale from path prefix
+ * 
+ * @param segments - URL segments
+ * @returns Locale or null
+ */
+export function getLocaleFromPath(segments: string[]): Locale | null {
+  const first = segments[0]?.toLowerCase()
+  if (first && first in LOCALES) {
+    return first as Locale
+  }
+  return null
+}
+
+/**
+ * Get path without locale prefix
+ * 
+ * @param segments - URL segments
+ * @returns Path without locale prefix
+ */
+export function getPathWithoutLocale(segments: string[]): string {
+  const first = segments[0]?.toLowerCase()
+  if (first && first in LOCALES) {
+    return '/' + segments.slice(1).join('/')
+  }
+  return '/' + segments.join('/')
+}
+
+export default {
+  generateHreflang,
+  generateHreflangHtml,
+  getLocaleFromPath,
+  getPathWithoutLocale,
+  LOCALES,
+  LOCALE_NAMES,
+  LOCALE_FLAGS,
+}

--- a/web/lib/stores/wishlist-store.ts
+++ b/web/lib/stores/wishlist-store.ts
@@ -1,0 +1,94 @@
+'use client'
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface WishlistItem {
+  id: string
+  productId: string
+  variantId: string | null
+  createdAt: string
+}
+
+interface WishlistStoreState {
+  siteSlug: string | null
+  items: WishlistItem[]
+  status: 'idle' | 'syncing' | 'error'
+  error: string | null
+}
+
+interface WishlistStoreActions {
+  hydrate(siteSlug: string, items: WishlistItem[]): void
+  refresh(siteSlug: string): Promise<void>
+  add(siteSlug: string, productId: string, variantId?: string): Promise<void>
+  remove(siteSlug: string, itemId: string): Promise<void>
+  reset(): void
+}
+
+type WishlistStore = WishlistStoreState & WishlistStoreActions
+
+async function apiCall<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+    credentials: 'same-origin',
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.error ?? `http_${res.status}`)
+  }
+  return res.json() as Promise<T>
+}
+
+export const useWishlistStore = create<WishlistStore>()(
+  persist(
+    (set, get) => ({
+      siteSlug: null,
+      items: [],
+      status: 'idle',
+      error: null,
+
+      hydrate: (siteSlug, items) => set({ siteSlug, items, status: 'idle', error: null }),
+
+      refresh: async (siteSlug) => {
+        set({ status: 'syncing', error: null })
+        try {
+          const { items } = await apiCall<{ items: WishlistItem[] }>(`/api/storefront/${siteSlug}/wishlist`)
+          set({ items, status: 'idle' })
+        } catch (e) {
+          set({ error: (e as Error).message, status: 'error' })
+        }
+      },
+
+      add: async (siteSlug, productId, variantId) => {
+        set({ status: 'syncing', error: null })
+        try {
+          await apiCall(`/api/storefront/${siteSlug}/wishlist`, {
+            method: 'POST',
+            body: JSON.stringify({ productId, variantId }),
+          })
+          await get().refresh(siteSlug)
+        } catch (e) {
+          set({ error: (e as Error).message, status: 'error' })
+        }
+      },
+
+      remove: async (siteSlug, itemId) => {
+        set({ status: 'syncing', error: null })
+        try {
+          await apiCall(`/api/storefront/${siteSlug}/wishlist`, {
+            method: 'DELETE',
+            body: JSON.stringify({ wishlistItemId: itemId }),
+          })
+          const { items } = get()
+          set({ items: items.filter(i => i.id !== itemId), status: 'idle' })
+        } catch (e) {
+          set({ error: (e as Error).message, status: 'error' })
+        }
+      },
+
+      reset: () => set({ siteSlug: null, items: [], status: 'idle', error: null }),
+    }),
+    { name: 'f4m-wishlist' }
+  )
+)


### PR DESCRIPTION
## Summary

Another batch of recovered stash work. Pure additions, zero conflicts, typecheck passes.

### New reusable sections (4-locale typed)
- `blog-section.tsx` — blog index with category filter + search
- `success-stories.tsx` — testimonials with metrics + before/after
- `trust-badges.tsx` — alternative trust-badges layout (coexists with existing `trust-badges-section.tsx`)

### New utilities
- `web/lib/seo/hreflang.tsx` — multi-language SEO helper
- `web/lib/data/py-dnit-resolutions.ts` — DNIT (ex-SET) resolutions 2020-2026 reference
- `web/lib/stores/wishlist-store.ts` — zustand client-side wishlist store

### Content + docs
- `src/content/blog-seeds/contador/precios-transferencia-etpt-paraguay.md`
- `docs/GRANJA_CABRAL_COMPLETE_ANALYSIS.md` — audit from the #309 analysis
- `docs/GRANJA_CABRAL_QUICK_CHECKLIST.md` — launch checklist
- `docs/supabase-setup-for-claude.md`

### Not included

Stashed files depending on missing modules (`@/lib/supabase/server-client`, `@/types/database`) are excluded:
- `web/lib/commerce/wishlist.ts`
- `web/lib/commerce/referral.ts`
- `web/app/api/storefront/[site]/wishlist/`

These need the missing supabase helpers before they can compile.

### Type fixes

Original stash had `{ es: string; en: string }` — updated to `LocalizedString = Partial<Record<'es'|'en'|'nl'|'de', string>>` so the sections typecheck against all 4 project locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)