### PR TITLE
fix(stoicfinch): nav + CTAs route to actual subpages

### DIFF
--- a/sites/stoicfinch/content/en.json
+++ b/sites/stoicfinch/content/en.json
@@ -17,14 +17,16 @@
   },
   "navigation": {
     "businessName": "Stoic Finch",
-    "items": [
-      { "label": "About", "href": "#about" },
-      { "label": "Benefits", "href": "#benefits" },
-      { "label": "Services", "href": "#services" },
-      { "label": "Get Started", "href": "#contact" }
+    "navItems": [
+      { "label": "About", "href": "/s/en/stoicfinch/about" },
+      { "label": "Services", "href": "/s/en/stoicfinch/pricing" },
+      { "label": "Industries", "href": "/s/en/stoicfinch/industries" },
+      { "label": "Case Studies", "href": "/s/en/stoicfinch/case-studies" },
+      { "label": "Resources", "href": "/s/en/stoicfinch/resources" },
+      { "label": "FAQ", "href": "/s/en/stoicfinch/faq" }
     ],
     "ctaText": "Get Started",
-    "ctaHref": "#contact"
+    "ctaHref": "/s/en/stoicfinch/contact"
   },
   "home": {
     "seo": {
@@ -35,9 +37,9 @@
       "headline": "Use your data like a pro.",
       "subheadline": "The data you need to stay ahead. By experts you can trust.",
       "ctaPrimaryText": "Get Started Today",
-      "ctaPrimaryHref": "#contact",
+      "ctaPrimaryHref": "/s/en/stoicfinch/contact",
       "ctaSecondaryText": "Take the First Step",
-      "ctaSecondaryHref": "#contact",
+      "ctaSecondaryHref": "/s/en/stoicfinch/contact",
       "trustBadges": [
         "No commitments",
         "No hassle",
@@ -128,7 +130,7 @@
         { "title": "Manage Data at Scale", "description": "Architecture and operating model that grow with your organization." }
       ],
       "ctaText": "Take the First Step",
-      "ctaHref": "#contact"
+      "ctaHref": "/s/en/stoicfinch/contact"
     },
     "techStack": {
       "eyebrow": "Modern Technology",
@@ -196,7 +198,7 @@
       "headline": "About Stoic Finch",
       "subheadline": "Born in Calgary 🍁  Inspired by the Rockies 🏔  Delivered Globally 🌎",
       "ctaPrimaryText": "Get Started Today",
-      "ctaPrimaryHref": "#contact"
+      "ctaPrimaryHref": "/s/en/stoicfinch/contact"
     },
     "ourStory": {
       "eyebrow": "Our story",
@@ -233,7 +235,7 @@
       "headline": "Take the first step.",
       "subheadline": "Tell us a little about your situation and we'll be in touch within one business day. No commitments. No hassle.",
       "ctaPrimaryText": "Get Started Today",
-      "ctaPrimaryHref": "#contact"
+      "ctaPrimaryHref": "/s/en/stoicfinch/contact"
     },
     "contact": {
       "title": "Get in touch",
@@ -253,7 +255,7 @@
       "headline": "The founder",
       "subheadline": "Why Stoic Finch exists and what we're building.",
       "ctaPrimaryText": "Get in touch",
-      "ctaPrimaryHref": "#contact"
+      "ctaPrimaryHref": "/s/en/stoicfinch/contact"
     },
     "ourStory": {
       "eyebrow": "Why Stoic Finch",
@@ -276,7 +278,7 @@
       "headline": "Industries we serve",
       "subheadline": "Our consultants bring domain experience across five industries — each with distinct data patterns and regulatory contexts.",
       "ctaPrimaryText": "Start a conversation",
-      "ctaPrimaryHref": "#contact"
+      "ctaPrimaryHref": "/s/en/stoicfinch/contact"
     },
     "services": {
       "title": "Five industries. Consistent delivery.",
@@ -299,7 +301,7 @@
       "headline": "Frequently asked questions",
       "subheadline": "Answers to the questions prospects ask us most often.",
       "ctaPrimaryText": "Still curious? Get in touch",
-      "ctaPrimaryHref": "#contact"
+      "ctaPrimaryHref": "/s/en/stoicfinch/contact"
     },
     "faq": {
       "title": "Stoic Finch, in answers",
@@ -325,19 +327,19 @@
       {
         "title": "Services",
         "links": [
-          { "label": "Reports & Dashboarding", "href": "#services" },
-          { "label": "Data Analysis", "href": "#services" },
-          { "label": "Data Science", "href": "#services" },
-          { "label": "Data Engineering", "href": "#services" },
-          { "label": "Data Strategy", "href": "#services" }
+          { "label": "Reports & Dashboarding", "href": "/s/en/stoicfinch/pricing" },
+          { "label": "Data Analysis", "href": "/s/en/stoicfinch/pricing" },
+          { "label": "Data Science", "href": "/s/en/stoicfinch/pricing" },
+          { "label": "Data Engineering", "href": "/s/en/stoicfinch/pricing" },
+          { "label": "Data Strategy", "href": "/s/en/stoicfinch/pricing" }
         ]
       },
       {
         "title": "Company",
         "links": [
-          { "label": "About", "href": "#about" },
-          { "label": "Benefits", "href": "#benefits" },
-          { "label": "Get Started", "href": "#contact" }
+          { "label": "About", "href": "/s/en/stoicfinch/about" },
+          { "label": "Benefits", "href": "/s/en/stoicfinch/about" },
+          { "label": "Get Started", "href": "/s/en/stoicfinch/contact" }
         ]
       },
       {

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -31508,7 +31508,7 @@ export const CONTENT: Record<string, JsonRecord> = {
         "whatsapp": ""
       },
       "hero": {
-        "ctaPrimaryHref": "#contact",
+        "ctaPrimaryHref": "/s/en/stoicfinch/contact",
         "ctaPrimaryText": "Get Started Today",
         "headline": "About Stoic Finch",
         "subheadline": "Born in Calgary 🍁  Inspired by the Rockies 🏔  Delivered Globally 🌎"
@@ -31564,7 +31564,7 @@ export const CONTENT: Record<string, JsonRecord> = {
         "title": "Get in touch"
       },
       "hero": {
-        "ctaPrimaryHref": "#contact",
+        "ctaPrimaryHref": "/s/en/stoicfinch/contact",
         "ctaPrimaryText": "Get Started Today",
         "headline": "Take the first step.",
         "subheadline": "Tell us a little about your situation and we'll be in touch within one business day. No commitments. No hassle."
@@ -31606,7 +31606,7 @@ export const CONTENT: Record<string, JsonRecord> = {
         "title": "Stoic Finch, in answers"
       },
       "hero": {
-        "ctaPrimaryHref": "#contact",
+        "ctaPrimaryHref": "/s/en/stoicfinch/contact",
         "ctaPrimaryText": "Still curious? Get in touch",
         "headline": "Frequently asked questions",
         "subheadline": "Answers to the questions prospects ask us most often."
@@ -31623,23 +31623,23 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "links": [
             {
-              "href": "#services",
+              "href": "/s/en/stoicfinch/pricing",
               "label": "Reports & Dashboarding"
             },
             {
-              "href": "#services",
+              "href": "/s/en/stoicfinch/pricing",
               "label": "Data Analysis"
             },
             {
-              "href": "#services",
+              "href": "/s/en/stoicfinch/pricing",
               "label": "Data Science"
             },
             {
-              "href": "#services",
+              "href": "/s/en/stoicfinch/pricing",
               "label": "Data Engineering"
             },
             {
-              "href": "#services",
+              "href": "/s/en/stoicfinch/pricing",
               "label": "Data Strategy"
             }
           ],
@@ -31648,15 +31648,15 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "links": [
             {
-              "href": "#about",
+              "href": "/s/en/stoicfinch/about",
               "label": "About"
             },
             {
-              "href": "#benefits",
+              "href": "/s/en/stoicfinch/about",
               "label": "Benefits"
             },
             {
-              "href": "#contact",
+              "href": "/s/en/stoicfinch/contact",
               "label": "Get Started"
             }
           ],
@@ -31678,7 +31678,7 @@ export const CONTENT: Record<string, JsonRecord> = {
     },
     "founderPage": {
       "hero": {
-        "ctaPrimaryHref": "#contact",
+        "ctaPrimaryHref": "/s/en/stoicfinch/contact",
         "ctaPrimaryText": "Get in touch",
         "headline": "The founder",
         "subheadline": "Why Stoic Finch exists and what we're building."
@@ -31774,9 +31774,9 @@ export const CONTENT: Record<string, JsonRecord> = {
         "title": "Take the first step. Level up your data."
       },
       "hero": {
-        "ctaPrimaryHref": "#contact",
+        "ctaPrimaryHref": "/s/en/stoicfinch/contact",
         "ctaPrimaryText": "Get Started Today",
-        "ctaSecondaryHref": "#contact",
+        "ctaSecondaryHref": "/s/en/stoicfinch/contact",
         "ctaSecondaryText": "Take the First Step",
         "headline": "Use your data like a pro.",
         "subheadline": "The data you need to stay ahead. By experts you can trust.",
@@ -31792,7 +31792,7 @@ export const CONTENT: Record<string, JsonRecord> = {
         "title": "Stoic Finch Corporation — Use your data like a pro"
       },
       "seriousCta": {
-        "ctaHref": "#contact",
+        "ctaHref": "/s/en/stoicfinch/contact",
         "ctaText": "Take the First Step",
         "eyebrow": "Where it gets serious",
         "highlights": [
@@ -31984,7 +31984,7 @@ export const CONTENT: Record<string, JsonRecord> = {
     },
     "industriesIndexPage": {
       "hero": {
-        "ctaPrimaryHref": "#contact",
+        "ctaPrimaryHref": "/s/en/stoicfinch/contact",
         "ctaPrimaryText": "Start a conversation",
         "headline": "Industries we serve",
         "subheadline": "Our consultants bring domain experience across five industries — each with distinct data patterns and regulatory contexts."
@@ -32031,24 +32031,32 @@ export const CONTENT: Record<string, JsonRecord> = {
     },
     "navigation": {
       "businessName": "Stoic Finch",
-      "ctaHref": "#contact",
+      "ctaHref": "/s/en/stoicfinch/contact",
       "ctaText": "Get Started",
-      "items": [
+      "navItems": [
         {
-          "href": "#about",
+          "href": "/s/en/stoicfinch/about",
           "label": "About"
         },
         {
-          "href": "#benefits",
-          "label": "Benefits"
-        },
-        {
-          "href": "#services",
+          "href": "/s/en/stoicfinch/pricing",
           "label": "Services"
         },
         {
-          "href": "#contact",
-          "label": "Get Started"
+          "href": "/s/en/stoicfinch/industries",
+          "label": "Industries"
+        },
+        {
+          "href": "/s/en/stoicfinch/case-studies",
+          "label": "Case Studies"
+        },
+        {
+          "href": "/s/en/stoicfinch/resources",
+          "label": "Resources"
+        },
+        {
+          "href": "/s/en/stoicfinch/faq",
+          "label": "FAQ"
         }
       ]
     },


### PR DESCRIPTION
User report: stoicfinch nav kept them on the home page instead of going to About/Services/etc. Cause: nav items used #about/#contact hash anchors (meant for same-page scroll); stoicfinch has 30+ dedicated subpages so these went nowhere.

Fix: replaced all hash anchors with real `/s/en/stoicfinch/*` paths (nav, hero CTAs, seriousCta, footer columns). Verified rendered HTML has 8 real routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)