### PR TITLE
feat(commerce): Tier 0 — theme on every tenant route + middleware age-gate + commerce chrome

### DIFF
--- a/web/app/s/[locale]/[site]/carrito/page.tsx
+++ b/web/app/s/[locale]/[site]/carrito/page.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link'
 import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
+import { CommerceChrome } from '@/components/commerce/commerce-chrome'
+import type { Locale } from '@/lib/i18n/config'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { CheckoutProgressIndicator } from '@/components/commerce/checkout-progress-indicator'
 import { CartPageClient } from '@/components/commerce/cart-page-client'
@@ -40,6 +42,7 @@ export default async function CartPage({ params }: { params: Promise<{ site: str
           </Link>
         </div>
       </main>
+      <CommerceChrome siteSlug={site} locale={locale as Locale} />
     </div>
   )
 }

--- a/web/app/s/[locale]/[site]/checkout/page.tsx
+++ b/web/app/s/[locale]/[site]/checkout/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from 'next/navigation'
 import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
+import { CommerceChrome } from '@/components/commerce/commerce-chrome'
+import type { Locale } from '@/lib/i18n/config'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { CheckoutForm } from '@/components/commerce/checkout-form'
 import { CheckoutProgressIndicator } from '@/components/commerce/checkout-progress-indicator'
@@ -40,6 +42,7 @@ export default async function CheckoutPage({ params }: { params: Promise<{ site:
         <CheckoutForm siteSlug={site} locale={locale} />
         <CheckoutTracker />
       </main>
+      <CommerceChrome siteSlug={site} locale={locale as Locale} />
     </div>
   )
 }

--- a/web/app/s/[locale]/[site]/layout.tsx
+++ b/web/app/s/[locale]/[site]/layout.tsx
@@ -1,16 +1,54 @@
 import { ExitIntentMount } from './exit-intent-mount'
 import { SiteSearch } from '@/components/search/site-search'
 import { LiveChatLoader } from '@/components/analytics/live-chat-loader'
+import { loadSite } from '@/lib/engine/site-loader'
+import { resolveSiteTokens } from '@/lib/engine/resolve-site-tokens'
+import { logger } from '@/lib/logger'
 
 interface Props {
   children: React.ReactNode
   params: Promise<{ locale: string; site: string }>
 }
 
+/**
+ * Tenant-wide layout. Hoists theme CSS vars + Google Fonts to EVERY route
+ * under `/s/<locale>/<site>/*` so storefront / PDP / cart / checkout /
+ * sub-pages get the brand palette, not just `[[...page]]`-composed pages.
+ *
+ * Before this, `/s/es/fun4me` rendered in the Fun4Me magenta/pink palette
+ * but `/s/es/fun4me/tienda` rendered in the grayscale fallback (#111)
+ * because theme injection lived in the page.tsx of the catch-all route
+ * only. See PR A (Tier 0) of the fun4me storefront audit.
+ */
 export default async function TenantLayout({ children, params }: Props) {
   const { locale, site } = await params
+
+  let cssString = ''
+  let googleFontsUrl = ''
+  try {
+    const siteDef = loadSite(site)
+    const tokens = resolveSiteTokens(siteDef.vertical, site)
+    cssString = tokens.cssString
+    googleFontsUrl = tokens.googleFontsUrl
+  } catch (error) {
+    // Unknown slug (e.g. /s/es/doesnt-exist) — don't crash the layout.
+    // The inner page will 404; we just skip theme injection.
+    logger.warn('TenantLayout: resolveSiteTokens failed — rendering without theme', {
+      action: 'tenantLayout',
+      site,
+      locale,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
   return (
     <>
+      {cssString ? (
+        <style dangerouslySetInnerHTML={{ __html: cssString }} />
+      ) : null}
+      {googleFontsUrl ? (
+        <link rel="stylesheet" href={googleFontsUrl} precedence="default" />
+      ) : null}
       {children}
       <ExitIntentMount locale={locale} site={site} />
       <LiveChatLoader websiteId={process.env.NEXT_PUBLIC_CRISP_WEBSITE_ID} />

--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
 import { getProductBySlug, listRelatedProducts } from '@/lib/commerce/products'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
+import { CommerceChrome } from '@/components/commerce/commerce-chrome'
+import type { Locale } from '@/lib/i18n/config'
 import { ProductImage } from '@/components/commerce/product-image'
 import { getSessionToken } from '@/lib/commerce/session'
 import { getCartBySessionToken } from '@/lib/commerce/cart'
@@ -321,6 +323,7 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
         inventoryPolicy={product.inventoryPolicy}
         imageUrl={cover?.url ?? null}
       />
+      <CommerceChrome siteSlug={site} locale={locale as Locale} />
     </div>
   )
 }

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -16,6 +16,8 @@ import { recordSearchEvent, listTopSearches } from '@/lib/commerce/search-events
 import { getReviewAggregatesByBusiness } from '@/lib/commerce/reviews'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
+import { CommerceChrome } from '@/components/commerce/commerce-chrome'
+import type { Locale } from '@/lib/i18n/config'
 import { ProductCard } from '@/components/commerce/product-card'
 import { getSessionToken } from '@/lib/commerce/session'
 import { getCartBySessionToken } from '@/lib/commerce/cart'
@@ -323,6 +325,7 @@ export default async function StorePage({
 
         <RecentlyViewedRail siteSlug={site} locale={locale} />
       </main>
+      <CommerceChrome siteSlug={site} locale={locale as Locale} />
     </div>
   )
 }

--- a/web/components/commerce/commerce-chrome.tsx
+++ b/web/components/commerce/commerce-chrome.tsx
@@ -1,0 +1,56 @@
+/**
+ * Shared footer + WhatsApp float + compliance disclaimer for commerce
+ * sub-routes (tienda, producto, carrito, checkout, favoritos).
+ *
+ * The tenant catch-all route ([[...page]]) renders footer + whatsapp-float +
+ * compliance-disclaimer via page.json section composition — so those pages
+ * get chrome automatically. Commerce sub-routes render their own JSX tree
+ * though, and were shipping without any of it (no footer, no support
+ * number, no 18+ disclaimer). This mounts the same three elements driven by
+ * the tenant's content JSON, so every surface reads like the same shop.
+ */
+import { loadSiteContent, loadSite } from '@/lib/engine/site-loader'
+import type { Locale } from '@/lib/i18n/config'
+import { FooterSection } from '@/components/sections/footer-section'
+import { WhatsAppFloat } from '@/components/sections/whatsapp-float'
+import { ComplianceDisclaimerFooterSection } from '@/components/sections/compliance-disclaimer-footer-section'
+
+interface Props {
+  siteSlug: string
+  locale: Locale
+}
+
+export async function CommerceChrome({ siteSlug, locale }: Props) {
+  let content: Record<string, unknown> = {}
+  let site: Record<string, unknown> = {}
+  try {
+    content = loadSiteContent(siteSlug, locale) as Record<string, unknown>
+    site = loadSite(siteSlug) as unknown as Record<string, unknown>
+  } catch {
+    return null
+  }
+
+  const footerProps = (content.footer as Record<string, unknown> | undefined) ?? {}
+  const whatsappProps = (content.whatsapp as Record<string, unknown> | undefined) ?? {}
+  const complianceProps =
+    (content.compliance as Record<string, unknown> | undefined) ??
+    (content.complianceDisclaimer as Record<string, unknown> | undefined) ??
+    {}
+
+  const features = (site.features as Record<string, boolean> | undefined) ?? {}
+
+  return (
+    <>
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+      <FooterSection {...(footerProps as any)} />
+      {Object.keys(complianceProps).length > 0 ? (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        <ComplianceDisclaimerFooterSection {...(complianceProps as any)} />
+      ) : null}
+      {features.whatsappFloat !== false && whatsappProps.phone ? (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        <WhatsAppFloat {...(whatsappProps as any)} />
+      ) : null}
+    </>
+  )
+}

--- a/web/components/sections/age-gate-section.tsx
+++ b/web/components/sections/age-gate-section.tsx
@@ -79,7 +79,34 @@ export function AgeGateSection({
     } catch {
       /* private mode or quota — still hide on this tab */
     }
+    // Mirror the localStorage flag into a server-visible cookie so the
+    // middleware gate (web/middleware.ts) stops redirecting on subsequent
+    // navigations. Derive the cookie name from the storage key: the
+    // middleware uses `age_gated_<siteSlug>`; the caller passes the same
+    // slug as the storageKey suffix (or defaults to the universal key).
+    const cookieMatch = /age[_-]?gat[e]?[_-]?(.+)$/i.exec(storageKey)
+    const cookieName = cookieMatch
+      ? `age_gated_${cookieMatch[1]}`
+      : storageKey
+    // cookieDays=30 matches site.json.settings.ageGate.cookieDays default.
+    const maxAge = 30 * 24 * 60 * 60
+    try {
+      document.cookie = `${cookieName}=yes; path=/; max-age=${maxAge}; SameSite=Lax`
+    } catch {
+      /* cookie write failed — middleware will re-gate next navigation */
+    }
     setDismissed(true)
+    // If the middleware redirected the user here with ?age_gate=1&return=<path>,
+    // send them back where they tried to go (e.g. /tienda, /producto/X, etc.).
+    try {
+      const params = new URLSearchParams(window.location.search)
+      const returnTo = params.get('return')
+      if (params.get('age_gate') === '1' && returnTo) {
+        window.location.replace(decodeURIComponent(returnTo))
+      }
+    } catch {
+      /* ignore */
+    }
   }
 
   return (

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -73,6 +73,55 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     return NextResponse.next()
   }
 
+  // Age-gate enforcement for adult-content tenants (fun4me, etc.).
+  //
+  // The old age-gate-section.tsx used localStorage and only rendered when
+  // mounted in a page.json — meaning a direct link to /s/es/fun4me/tienda
+  // (which doesn't mount the age-gate section) showed adult products to
+  // anyone. Middleware fixes that: we check a cookie here, before any
+  // page render, on every /s/<locale>/<site>/* path where the site has
+  // features.ageGate.enabled. The age-gate component now also writes that
+  // cookie so the localStorage + server cookie stay in sync.
+  const siteMatch = /^\/s\/([^/]+)\/([^/]+)(?:\/|$)/.exec(path)
+  if (siteMatch) {
+    const [, , siteSlug] = siteMatch
+    // Don't gate the age-gate page itself — that creates a redirect loop.
+    // The query param `?age_gate=1` signals we're already on the gate;
+    // check the search string on nextUrl, not the pathname (path variable
+    // doesn't carry query).
+    const searchStr = request.nextUrl.search || ''
+    const isAgeGatePage =
+      path.endsWith('/age-gate') ||
+      searchStr.includes('age_gate=1')
+    if (!isAgeGatePage) {
+      try {
+        const { loadSite } = await import('@/lib/engine/site-loader')
+        const site = loadSite(siteSlug) as {
+          settings?: { ageGate?: { enabled?: boolean; minAge?: number } }
+        }
+        const ageGateCfg = site?.settings?.ageGate
+        if (ageGateCfg?.enabled) {
+          const cookieName = `age_gated_${siteSlug}`
+          const gated = request.cookies.get(cookieName)?.value === 'yes'
+          if (!gated) {
+            // Redirect to the tenant home with ?age_gate=<return-path>.
+            // The home page already mounts the age-gate modal via its
+            // page.json; that modal now also writes the server cookie
+            // and then rewrites the URL back to `return`.
+            const locale = siteMatch[1]
+            const returnTo = encodeURIComponent(path + request.nextUrl.search)
+            const url = request.nextUrl.clone()
+            url.pathname = `/s/${locale}/${siteSlug}`
+            url.search = `?age_gate=1&return=${returnTo}`
+            return NextResponse.redirect(url, 307)
+          }
+        }
+      } catch {
+        // Unknown site slug — fall through; the inner route will 404.
+      }
+    }
+  }
+
   // Add request ID and pathname headers. Overwrite upstream correlation
   // headers with the canonical ones we just resolved so every downstream
   // hop sees the same traceId — even when the upstream sent a malformed


### PR DESCRIPTION
**PR A** of the fun4me/tienda storefront audit — 3 ship-blockers.

### 1. Theme on every tenant route
Before: `/s/es/fun4me/tienda` rendered in grayscale because CSS vars were only injected by the `[[...page]]` catch-all. After: `layout.tsx` calls `resolveSiteTokens()` once for every route.

### 2. Middleware age-gate enforcement
Before: direct link to `/s/es/fun4me/tienda` bypassed the 18+ gate (only mounted on home.json). Legal + Pagopar TOS issue. After: middleware redirects to `?age_gate=1&return=<path>` if `age_gated_<site>` cookie missing. Age-gate component mirrors localStorage → cookie on confirm, reads `?return=` to bounce back.

### 3. Commerce chrome on sub-routes
Before: tienda/producto/carrito/checkout shipped without footer, WhatsApp float, or compliance disclaimer. After: new `CommerceChrome` component mounted at end of each commerce route.

### Verified
- tienda no-cookie → 307 ✅
- home ?age_gate=1 → 200 (no loop) ✅
- home cookied → 200, --primary var present ✅
- granja-cabral / nexa-paraguay / stoicfinch (no ageGate config) → 200 unaffected ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)