### PR TITLE
feat(commerce): Tier 1+2 — trust ubicuo (tienda/PDP/cart) + ProductCard redesign

### DIFF
--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { getProductBySlug, listRelatedProducts } from '@/lib/commerce/products'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { CommerceChrome } from '@/components/commerce/commerce-chrome'
+import { TrustStrip } from '@/components/commerce/trust-strip'
 import type { Locale } from '@/lib/i18n/config'
 import { ProductImage } from '@/components/commerce/product-image'
 import { getSessionToken } from '@/lib/commerce/session'
@@ -245,6 +246,17 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
           <div id="pdp-main-add-to-cart" className="mt-6">
             <ProductDetailActions siteSlug={site} productId={product.id} inventoryQty={product.inventoryQty} inventoryPolicy={product.inventoryPolicy} />
           </div>
+
+          <TrustStrip
+            variant="compact"
+            className="mt-4"
+            items={[
+              { icon: '📦', title: 'Envío discreto', description: 'Empaque neutro sin logos.' },
+              { icon: '🔒', title: 'Pago seguro', description: 'Tarjeta aparece como "F4M Comercial".' },
+              { icon: '⚡', title: 'Entrega 24-48h', description: 'Asunción y GBA.' },
+              { icon: '↩️', title: 'Cambios 7 días', description: 'Sin abrir, por talle o defecto.' },
+            ]}
+          />
 
           {product.inventoryPolicy === 'deny' && product.inventoryQty === 0 ? (
             <div className="mt-4">

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -17,6 +17,7 @@ import { getReviewAggregatesByBusiness } from '@/lib/commerce/reviews'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { CommerceChrome } from '@/components/commerce/commerce-chrome'
+import { TrustStrip } from '@/components/commerce/trust-strip'
 import type { Locale } from '@/lib/i18n/config'
 import { ProductCard } from '@/components/commerce/product-card'
 import { getSessionToken } from '@/lib/commerce/session'
@@ -225,6 +226,8 @@ export default async function StorePage({
 
       <main className="mx-auto max-w-6xl px-4 py-8">
         <h1 className="mb-6 text-3xl font-bold text-[color:var(--text,#111)]">Nuestra tienda</h1>
+
+        <TrustStrip variant="prominent" />
 
         <TiendaQuickFilters />
         {!search && popularQueries.length > 0 ? (

--- a/web/components/commerce/cart-drawer.tsx
+++ b/web/components/commerce/cart-drawer.tsx
@@ -159,6 +159,13 @@ export function CartDrawer({ siteSlug, locale, open, onClose }: Props) {
             <p className="mt-2 text-center text-xs text-[color:var(--text-muted,#6b7280)]">
               Envío y totales se calculan en el siguiente paso
             </p>
+            <div className="mt-3 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-center text-[11px] text-[color:var(--text-muted,#6b7280)]">
+              <span>📦 Empaque discreto</span>
+              <span aria-hidden>·</span>
+              <span>🔒 Pago seguro</span>
+              <span aria-hidden>·</span>
+              <span>↩️ Cambios 7 días</span>
+            </div>
           </footer>
         ) : null}
       </aside>

--- a/web/components/commerce/product-card.tsx
+++ b/web/components/commerce/product-card.tsx
@@ -62,10 +62,16 @@ export function ProductCard({ siteSlug, product, priority, rates, locale = 'es',
     product.compareAtPriceCents && product.compareAtPriceCents > product.priceCents
       ? Math.round(((product.compareAtPriceCents - product.priceCents) / product.compareAtPriceCents) * 100)
       : null
-  // "Nuevo" badge for anything created in the last 14 days. Parsed lazily to
-  // avoid a `new Date()` during SSR hydration mismatch — createdAt is ISO from
-  // the DB so Date parsing is deterministic.
+  // "Nuevo" badge requires EITHER an explicit flag from the DB or a fresh
+  // createdAt AND `isSeed=false`. Prevents every seed-imported product from
+  // advertising itself as new (fun4me shipped with 12/12 products flagged
+  // "NUEVO" simply because the seed dump was within 14 days — making the
+  // badge pure noise).
   const isNew = (() => {
+    if (product.isSeed) return false
+    const explicit = (product as { isNew?: boolean }).isNew
+    if (explicit === true) return true
+    if (explicit === false) return false
     if (!product.createdAt) return false
     const t = Date.parse(product.createdAt)
     if (!Number.isFinite(t)) return false
@@ -146,9 +152,13 @@ export function ProductCard({ siteSlug, product, priority, rates, locale = 'es',
               setQuickViewOpen(true)
             }}
             aria-label={`Vista rápida de ${product.name}`}
-            className="absolute bottom-2 left-2 rounded-full bg-white/90 px-3 py-1.5 text-xs font-medium text-[color:var(--text,#111)] shadow opacity-100 hover:bg-white focus:outline-none focus:ring-2 focus:ring-[color:var(--primary,#111)] sm:opacity-0 sm:group-hover:opacity-100"
+            className="absolute bottom-2 left-2 inline-flex items-center gap-1 rounded-full bg-white/95 px-3 py-1.5 text-xs font-medium text-[color:var(--text,#111)] shadow opacity-100 hover:bg-white focus:outline-none focus:ring-2 focus:ring-[color:var(--primary,#111)] sm:opacity-0 sm:group-hover:opacity-100"
           >
-            👁️ Vista rápida
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+            Vista rápida
           </button>
 
           {/* Wishlist heart — absolute so clicks bypass the PDP Link. */}
@@ -157,38 +167,45 @@ export function ProductCard({ siteSlug, product, priority, rates, locale = 'es',
             onClick={toggleWishlist}
             aria-pressed={saved}
             aria-label={saved ? `Quitar ${product.name} de favoritos` : `Guardar ${product.name} en favoritos`}
-            className="absolute right-2 bottom-2 rounded-full bg-white/90 p-2 text-base shadow hover:bg-white focus:outline-none focus:ring-2 focus:ring-[color:var(--primary,#111)]"
+            className="absolute right-2 bottom-2 rounded-full bg-white/95 p-2 shadow hover:bg-white focus:outline-none focus:ring-2 focus:ring-[color:var(--primary,#111)]"
           >
-            <span aria-hidden="true" className={saved ? 'text-red-500' : 'text-[color:var(--text-muted,#6b7280)]'}>
-              {saved ? '♥' : '♡'}
-            </span>
+            <svg
+              aria-hidden="true"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill={saved ? 'currentColor' : 'none'}
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className={saved ? 'text-[color:var(--primary,#111)]' : 'text-[color:var(--text-muted,#6b7280)]'}
+            >
+              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+            </svg>
           </button>
 
+          {/* Top-left badge — one at a time. Priority: discount > new. */}
           {discount ? (
             <span className="absolute left-2 top-2 rounded bg-red-600 px-2 py-0.5 text-xs font-semibold text-white" aria-label={`Descuento del ${discount} por ciento`}>
               −{discount}%
             </span>
-          ) : null}
-          {isNew && !discount ? (
+          ) : isNew ? (
             <span className="absolute left-2 top-2 rounded bg-emerald-600 px-2 py-0.5 text-xs font-semibold text-white">
               NUEVO
             </span>
           ) : null}
-          {isNew && discount ? (
-            <span className="absolute left-2 top-9 rounded bg-emerald-600 px-2 py-0.5 text-xs font-semibold text-white">
-              NUEVO
-            </span>
-          ) : null}
-          {lowStock ? (
-            <span className="absolute right-2 top-2 inline-flex items-center gap-1 rounded bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white">
-              <span aria-hidden="true">⚠</span>
-              ¡Últimas {product.inventoryQty}!
-            </span>
-          ) : null}
+
+          {/* Top-right badge — one at a time. Priority: out-of-stock > low-stock. */}
           {outOfStock ? (
             <span className="absolute right-2 top-2 inline-flex items-center gap-1 rounded bg-gray-700 px-2 py-0.5 text-xs font-semibold text-white">
-              <span aria-hidden="true">✕</span>
+              <svg aria-hidden="true" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round"><path d="M6 6l12 12M6 18L18 6"/></svg>
               Agotado
+            </span>
+          ) : lowStock ? (
+            <span className="absolute right-2 top-2 inline-flex items-center gap-1 rounded bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white">
+              <svg aria-hidden="true" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2L2 20h20L12 2z"/><path d="M12 9v4M12 17h.01"/></svg>
+              ¡Últimas {product.inventoryQty}!
             </span>
           ) : null}
         </div>
@@ -222,10 +239,20 @@ export function ProductCard({ siteSlug, product, priority, rates, locale = 'es',
           type="button"
           onClick={handleAdd}
           disabled={outOfStock || adding}
-          className="mt-3 w-full rounded-md border border-[color:var(--primary,#111)] px-3 py-2 text-sm font-medium text-[color:var(--primary,#111)] hover:bg-[color:var(--primary,#111)] hover:text-[color:var(--primary-foreground,#fff)] disabled:cursor-not-allowed disabled:opacity-50"
+          className="mt-3 w-full rounded-md bg-[color:var(--primary,#111)] px-3 py-2.5 text-sm font-semibold text-[color:var(--primary-foreground,#fff)] shadow-sm transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)] disabled:cursor-not-allowed disabled:opacity-50"
         >
           {outOfStock ? 'Agotado' : adding ? 'Agregando…' : 'Agregar al carrito'}
         </button>
+
+        {/* Per-card mini trust ribbon — keeps discretion visible at browse
+            time, not just at checkout. Hidden on out-of-stock since the
+            user can't buy anyway and we don't want to waste vertical
+            space on a disabled card. */}
+        {!outOfStock ? (
+          <p className="mt-2 text-center text-[11px] text-[color:var(--text-muted,#6b7280)]">
+            📦 Envío discreto · 🔒 Pago seguro
+          </p>
+        ) : null}
       </div>
 
       <QuickViewModal

--- a/web/components/commerce/trust-strip.tsx
+++ b/web/components/commerce/trust-strip.tsx
@@ -1,0 +1,85 @@
+/**
+ * Reusable trust strip. Reinforces "discreet shipping / secure payment /
+ * returns" across every commerce surface — storefront grid, PDP, cart
+ * drawer, checkout. Props accept 3-4 items so a tenant can tune copy per
+ * surface without shipping another component.
+ *
+ * Server-rendered — no JS, no state, no client boundary.
+ */
+
+export interface TrustItem {
+  icon: string // emoji; keep dependency-free
+  title: string
+  description: string
+}
+
+export interface TrustStripProps {
+  items?: TrustItem[]
+  /** Visual variant — tight for in-page, prominent for above-grid or PDP. */
+  variant?: 'compact' | 'prominent'
+  className?: string
+  /** Optional eyebrow line shown above the items. */
+  eyebrow?: string
+}
+
+export const DEFAULT_TRUST_ITEMS: TrustItem[] = [
+  {
+    icon: '📦',
+    title: 'Envío 100% discreto',
+    description: 'Caja neutra sin logos ni referencias al contenido.',
+  },
+  {
+    icon: '🔒',
+    title: 'Pago seguro',
+    description: 'Procesado por Pagopar. Facturación discreta.',
+  },
+  {
+    icon: '⚡',
+    title: 'Entrega rápida',
+    description: 'Asunción y GBA en 24-48 horas.',
+  },
+  {
+    icon: '↩️',
+    title: 'Cambios y devoluciones',
+    description: 'Sin abrir, 7 días. Cambio por talle o defecto.',
+  },
+]
+
+export function TrustStrip({
+  items = DEFAULT_TRUST_ITEMS,
+  variant = 'compact',
+  className,
+  eyebrow,
+}: TrustStripProps) {
+  const prominent = variant === 'prominent'
+  const base =
+    'grid grid-cols-2 gap-3 rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-4 text-sm sm:grid-cols-4'
+  const spacing = prominent ? 'my-6 sm:p-5' : 'mb-4'
+  return (
+    <aside
+      aria-label="Nuestras promesas"
+      className={[base, spacing, className].filter(Boolean).join(' ')}
+    >
+      {eyebrow ? (
+        <p className="col-span-2 -mb-1 text-xs font-semibold uppercase tracking-wider text-[color:var(--text-muted,#6b7280)] sm:col-span-4">
+          {eyebrow}
+        </p>
+      ) : null}
+      {items.map((item, i) => (
+        <div key={i} className="flex items-start gap-2">
+          <span aria-hidden="true" className={prominent ? 'text-2xl' : 'text-lg'}>
+            {item.icon}
+          </span>
+          <div>
+            <p className="font-semibold text-[color:var(--text,#111)]">
+              {item.title}
+            </p>
+            <p className="text-xs text-[color:var(--text-muted,#6b7280)]">
+              {item.description}
+            </p>
+          </div>
+        </div>
+      ))}
+    </aside>
+  )
+}


### PR DESCRIPTION
PR B of fun4me/tienda audit. Makes discretion visible on every surface + gives the card a confident look.

### Trust ubicuo
- New `TrustStrip` component (compact + prominent variants)
- Mounted `prominent` above /tienda grid
- Mounted `compact` on PDP below CTA (PDP-specific copy)
- Mini trust ribbon in cart-drawer footer

### ProductCard
- CTA filled primary (was ghost-outline)
- Unicode glyphs → inline SVG (cross-OS consistency)
- Badge priority: one top-left (discount>new), one top-right (OOS>lowstock)
- `isNew` now requires !isSeed (fixed 12/12 NUEVO)
- Mini ribbon below CTA: 📦 Envío discreto · 🔒 Pago seguro

🤖 Generated with [Claude Code](https://claude.com/claude-code)