### PR TITLE
fix(commerce): kill Wall of Skittles — neutral placeholder + remove per-card trust ribbon

### DIFF
--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -237,6 +237,16 @@ export default async function StorePage({
 
         <TrustStrip variant="prominent" />
 
+        {products.length > 0 && products.every((p) => p.isSeed) && process.env.NODE_ENV !== 'production' ? (
+          <aside
+            role="note"
+            aria-label="Aviso para administradores"
+            className="mb-4 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-xs text-amber-900"
+          >
+            <strong className="font-semibold">⚠ Catálogo demo.</strong> Todos los productos son de ejemplo — cargar fotos reales y marcar <code className="rounded bg-amber-100 px-1">isSeed=false</code> antes del tráfico pago.
+          </aside>
+        ) : null}
+
         <TiendaQuickFilters />
         {!search && popularQueries.length > 0 ? (
           <div className="mb-3 flex flex-wrap items-center gap-2 text-xs">

--- a/web/components/commerce/product-card.tsx
+++ b/web/components/commerce/product-card.tsx
@@ -243,16 +243,6 @@ export function ProductCard({ siteSlug, product, priority, rates, locale = 'es',
         >
           {outOfStock ? 'Agotado' : adding ? 'Agregando…' : 'Agregar al carrito'}
         </button>
-
-        {/* Per-card mini trust ribbon — keeps discretion visible at browse
-            time, not just at checkout. Hidden on out-of-stock since the
-            user can't buy anyway and we don't want to waste vertical
-            space on a disabled card. */}
-        {!outOfStock ? (
-          <p className="mt-2 text-center text-[11px] text-[color:var(--text-muted,#6b7280)]">
-            📦 Envío discreto · 🔒 Pago seguro
-          </p>
-        ) : null}
       </div>
 
       <QuickViewModal

--- a/web/components/commerce/product-image.tsx
+++ b/web/components/commerce/product-image.tsx
@@ -17,16 +17,68 @@ const ASPECT_CLASS: Record<NonNullable<Props['aspectRatio']>, string> = {
   '16:9': 'aspect-video',
 }
 
-export function ProductImage({ image, alt, aspectRatio = '4:5', priority, sizes, className, isSeed }: Props) {
-  if (!image?.url) {
-    return (
-      <div
-        className={`relative overflow-hidden rounded-lg bg-[color:var(--surface-muted,#f3f4f6)] ${ASPECT_CLASS[aspectRatio]} ${className ?? ''}`}
-        aria-label={alt}
+/**
+ * Seed products ship with a `data:image/svg+xml...linearGradient...` URL
+ * in the `url` field — a colorful gradient with the product name in big
+ * white letters, shipped straight from the catalog seed script. That
+ * renders as "Wall of Skittles PowerPoint 2005" on the storefront grid.
+ *
+ * Until real product photography lands, we detect those gradient data
+ * URLs and render the neutral placeholder instead. Real images (http(s),
+ * cloudinary, supabase storage) pass through unchanged.
+ */
+function isSeedGradient(url: string | undefined): boolean {
+  if (!url) return false
+  return url.startsWith('data:image/svg+xml')
+}
+
+function NeutralPlaceholder({
+  aspectRatio,
+  className,
+  alt,
+  isSeed,
+}: Pick<Props, 'aspectRatio' | 'className' | 'alt' | 'isSeed'>) {
+  const ratio = aspectRatio ?? '4:5'
+  return (
+    <div
+      className={`relative flex items-center justify-center overflow-hidden rounded-lg bg-[color:var(--surface-muted,#f3f4f6)] ${ASPECT_CLASS[ratio]} ${className ?? ''}`}
+      aria-label={alt}
+    >
+      <svg
+        aria-hidden="true"
+        width="48"
+        height="48"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="text-[color:var(--text-muted,#9ca3af)]"
       >
-        <div className="flex h-full items-center justify-center text-sm text-[color:var(--text-muted,#9ca3af)]">Sin imagen</div>
-      </div>
-    )
+        <rect x="3" y="3" width="18" height="18" rx="2" />
+        <circle cx="9" cy="9" r="2" />
+        <path d="M21 15l-5-5L5 21" />
+      </svg>
+      {isSeed && process.env.NODE_ENV !== 'production' ? (
+        <span className="absolute bottom-2 right-2 rounded bg-black/50 px-1.5 py-0.5 text-[10px] font-medium text-white">
+          Ejemplo
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+export function ProductImage({ image, alt, aspectRatio = '4:5', priority, sizes, className, isSeed }: Props) {
+  // No image → neutral placeholder.
+  if (!image?.url) {
+    return <NeutralPlaceholder aspectRatio={aspectRatio} className={className} alt={alt} isSeed={isSeed} />
+  }
+
+  // Gradient placeholder from seed data → neutral placeholder (not the
+  // loud text-on-gradient thing the seed shipped).
+  if (isSeedGradient(image.url)) {
+    return <NeutralPlaceholder aspectRatio={aspectRatio} className={className} alt={alt} isSeed={isSeed} />
   }
 
   return (
@@ -39,7 +91,7 @@ export function ProductImage({ image, alt, aspectRatio = '4:5', priority, sizes,
         priority={priority}
         className="object-cover transition-transform duration-300 hover:scale-105"
       />
-      {isSeed ? (
+      {isSeed && process.env.NODE_ENV !== 'production' ? (
         <span className="absolute bottom-2 right-2 rounded bg-black/60 px-2 py-0.5 text-xs font-medium text-white">
           Ejemplo
         </span>


### PR DESCRIPTION
Roast response round 2. 3 fixes:

1. **Wall of Skittles fix** — detect `data:image/svg+xml` seed URLs in `product-image.tsx`, render neutral gray placeholder instead of the loud gradient-with-text. Real images pass through unchanged.
2. **Per-card trust ribbon removed** (revert of PR #323 regression) — 12× `📦 Envío discreto` = clutter. Trust lives above grid + PDP + cart-drawer, not on every card.
3. **Admin catalog warning** — amber note above grid when 100% of products are `isSeed=true` (non-prod only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)