### PR TITLE
feat(commerce): category tiles at top + tag filters grouped into 5 buckets

### DIFF
--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -18,6 +18,7 @@ import { isCommerceEnabled } from '@/lib/commerce/capability'
 import { CommerceHeader } from '@/components/commerce/commerce-header'
 import { CommerceChrome } from '@/components/commerce/commerce-chrome'
 import { TrustStrip } from '@/components/commerce/trust-strip'
+import { TiendaCategoryTiles } from '@/components/commerce/tienda-category-tiles'
 import type { Locale } from '@/lib/i18n/config'
 import { ProductCard } from '@/components/commerce/product-card'
 import { getSessionToken } from '@/lib/commerce/session'
@@ -236,6 +237,13 @@ export default async function StorePage({
         </div>
 
         <TrustStrip variant="prominent" />
+
+        <TiendaCategoryTiles
+          siteSlug={site}
+          locale={locale}
+          availableCategories={availableCategories}
+          categoryCounts={categoryCounts}
+        />
 
         {products.length > 0 && products.every((p) => p.isSeed) && process.env.NODE_ENV !== 'production' ? (
           <aside

--- a/web/components/commerce/tienda-category-tiles.tsx
+++ b/web/components/commerce/tienda-category-tiles.tsx
@@ -1,0 +1,111 @@
+/**
+ * 4 big category tiles for the top of the /tienda grid. Replaces "click
+ * through a wall of lowercase chips" as the primary entry into the
+ * catalog. Icons are inline SVG so no lucide import bloat — each tile
+ * links to /tienda?category=<slug> so the existing filter logic handles
+ * selection.
+ *
+ * Display rule: a tile is only rendered if the underlying category has
+ * at least one product (checked via categoryCounts). If fewer than 3
+ * tiles would render, the whole block collapses — the tenant isn't at
+ * scale yet and the chips below are enough.
+ */
+import Link from 'next/link'
+
+interface Props {
+  siteSlug: string
+  locale: string
+  availableCategories: string[]
+  categoryCounts?: Record<string, number>
+}
+
+interface Tile {
+  category: string
+  label: string
+  description: string
+  icon: React.ReactNode
+  /** Gradient bg for the tile — deliberately muted so the category
+   * wordmark stays dominant. */
+  accent: string
+}
+
+const TILES: Tile[] = [
+  {
+    category: 'parejas',
+    label: 'Parejas',
+    description: 'Para compartir',
+    icon: (
+      <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+      </svg>
+    ),
+    accent: 'from-pink-50 to-rose-50',
+  },
+  {
+    category: 'vibradores',
+    label: 'Para ella',
+    description: 'Placer femenino',
+    icon: (
+      <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 2C9 2 7 4 7 7v10a5 5 0 0 0 10 0V7c0-3-2-5-5-5z" />
+      </svg>
+    ),
+    accent: 'from-purple-50 to-fuchsia-50',
+  },
+  {
+    category: 'dildos',
+    label: 'Para él',
+    description: 'Placer masculino',
+    icon: (
+      <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="9" />
+        <path d="M12 7v10M7 12h10" />
+      </svg>
+    ),
+    accent: 'from-blue-50 to-indigo-50',
+  },
+  {
+    category: 'lubricantes',
+    label: 'Lubricantes',
+    description: 'Bienestar íntimo',
+    icon: (
+      <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 2s6 7 6 12a6 6 0 0 1-12 0c0-5 6-12 6-12z" />
+      </svg>
+    ),
+    accent: 'from-amber-50 to-orange-50',
+  },
+]
+
+export function TiendaCategoryTiles({ siteSlug, locale, availableCategories, categoryCounts }: Props) {
+  // Only render tiles for categories that have at least one product
+  // available in the current shop. Keeps the row honest.
+  const available = TILES.filter((t) => availableCategories.includes(t.category))
+  if (available.length < 3) return null
+
+  return (
+    <nav aria-label="Categorías principales" className="mb-6">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {available.map((tile) => {
+          const count = categoryCounts?.[tile.category] ?? 0
+          return (
+            <Link
+              key={tile.category}
+              href={`/s/${locale}/${siteSlug}/tienda?category=${encodeURIComponent(tile.category)}`}
+              className={`group flex flex-col items-start gap-1 rounded-xl border border-[color:var(--border,#e5e7eb)] bg-gradient-to-br ${tile.accent} p-4 transition-all hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)]`}
+            >
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-white/80 text-[color:var(--primary,#111)] shadow-sm group-hover:bg-white">
+                {tile.icon}
+              </span>
+              <p className="mt-2 text-base font-semibold text-[color:var(--text,#111)]">{tile.label}</p>
+              <p className="text-xs text-[color:var(--text-muted,#6b7280)]">
+                {tile.description}
+                {count > 0 ? ` · ${count}` : ''}
+              </p>
+            </Link>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}

--- a/web/components/commerce/tienda-toolbar.tsx
+++ b/web/components/commerce/tienda-toolbar.tsx
@@ -37,6 +37,58 @@ interface Props {
 
 const PER_PAGE_OPTIONS = [12, 24, 48, 96]
 
+/**
+ * Tag buckets for the filter toolbar. Flat wall of 20+ chips (which is
+ * what this shop actually ships) is unnavigable; grouping them by
+ * intent lets the shopper scan "what kind of filter is this" fast.
+ *
+ * Curated for the adult-retail niche — feel free to grow or rebalance.
+ * Tags not in any bucket fall back to an "Otros" group.
+ */
+const TAG_GROUPS: Array<{ id: string; label: string; tags: string[] }> = [
+  {
+    id: 'material',
+    label: 'Material',
+    tags: [
+      'silicona',
+      'base-agua',
+      'base-silicona',
+      'tela',
+      'apto-latex',
+      'apto-piel',
+      'encaje',
+    ],
+  },
+  {
+    id: 'caracteristicas',
+    label: 'Características',
+    tags: [
+      'silencioso',
+      'recargable',
+      'impermeable',
+      'larga-duracion',
+      'progresivo',
+      'sensible',
+      'estimulador',
+    ],
+  },
+  {
+    id: 'experiencia',
+    label: 'Nivel de experiencia',
+    tags: ['principiantes', 'clasico', 'sensorial', 'realista'],
+  },
+  {
+    id: 'contexto',
+    label: 'Pensado para',
+    tags: ['parejas', 'regalo', 'roleplay', 'corporal', 'kit'],
+  },
+  {
+    id: 'estilo',
+    label: 'Estilo',
+    tags: ['elegante'],
+  },
+]
+
 const SORT_OPTIONS: Array<{ value: ProductSort; label: string }> = [
   { value: 'newest', label: 'Más nuevos' },
   { value: 'popularity', label: 'Más vendidos' },
@@ -317,38 +369,43 @@ export function TiendaToolbar({
 
       {/* Advanced filters: always visible on md+, collapsible on mobile. */}
       <div className={cn('flex flex-col gap-3', advancedOpen ? 'block' : 'hidden', 'md:flex')}>
-      {/* Category pills */}
+      {/* Category pills — Capitalize + only show counts ≥ 2 (1-item categories
+          look like a stale catalog). "Todo" only visible when at least one
+          category is active, so the default view isn't dominated by a loud
+          "Todo is selected" chip. */}
       {availableCategories.length > 0 ? (
         <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={() => pushParams({ category: null })}
-            aria-pressed={initialCategories.length === 0}
-            className={`rounded-full border px-3 py-1 text-xs ${
-              initialCategories.length === 0
-                ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
-                : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
-            }`}
-          >
-            Todo
-          </button>
+          {initialCategories.length > 0 ? (
+            <button
+              type="button"
+              onClick={() => pushParams({ category: null })}
+              className="rounded-full border border-[color:var(--border,#e5e7eb)] px-3 py-1 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+            >
+              ← Todas
+            </button>
+          ) : null}
           {availableCategories.map((cat) => {
             const count = categoryCounts?.[cat]
             const active = initialCategories.includes(cat)
+            // Capitalize first letter; BDSM stays uppercase.
+            const label =
+              cat.toLowerCase() === 'bdsm'
+                ? 'BDSM'
+                : cat.charAt(0).toUpperCase() + cat.slice(1)
             return (
               <button
                 key={cat}
                 type="button"
                 onClick={() => toggleCategory(cat)}
                 aria-pressed={active}
-                className={`rounded-full border px-3 py-1 text-xs capitalize ${
+                className={`rounded-full border px-3 py-1 text-xs ${
                   active
                     ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
                     : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
                 }`}
               >
-                {cat}
-                {typeof count === 'number' ? (
+                {label}
+                {typeof count === 'number' && count >= 2 ? (
                   <span className="ml-1 opacity-70">({count})</span>
                 ) : null}
               </button>
@@ -382,28 +439,107 @@ export function TiendaToolbar({
         </div>
       ) : null}
 
-      {/* Tag filter */}
+      {/* Tag filter — grouped into themed buckets so 20+ tags don't render
+          as a flat "bowl of alphabet soup" wall. Each group is a <details>
+          element (native, accessible, keyboard-friendly) collapsed by
+          default; opens when it has an active selection. Tags that don't
+          fit any bucket fall back to "Otros". */}
       {availableTags.length > 0 ? (
-        <div className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="text-[color:var(--text-muted,#6b7280)]">Características:</span>
-          {availableTags.map((t) => {
-            const active = initialTags.includes(t)
+        <div className="flex flex-col gap-2">
+          {TAG_GROUPS.map((group) => {
+            const tagsInGroup = availableTags.filter((t) => group.tags.includes(t))
+            if (tagsInGroup.length === 0) return null
+            const activeCount = tagsInGroup.filter((t) => initialTags.includes(t)).length
             return (
-              <button
-                key={t}
-                type="button"
-                onClick={() => toggleTag(t)}
-                aria-pressed={active}
-                className={`rounded-full border px-2.5 py-0.5 ${
-                  active
-                    ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
-                    : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
-                }`}
+              <details
+                key={group.id}
+                open={activeCount > 0}
+                className="group rounded-md border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-3 py-2"
               >
-                #{t}
-              </button>
+                <summary className="flex cursor-pointer items-center justify-between text-xs font-medium text-[color:var(--text,#111)] marker:hidden [&::-webkit-details-marker]:hidden">
+                  <span className="flex items-center gap-2">
+                    <span>{group.label}</span>
+                    {activeCount > 0 ? (
+                      <span className="rounded-full bg-[color:var(--primary,#111)] px-1.5 text-[10px] font-semibold text-[color:var(--primary-foreground,#fff)]">
+                        {activeCount}
+                      </span>
+                    ) : null}
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    className="text-[color:var(--text-muted,#9ca3af)] transition-transform group-open:rotate-180"
+                  >
+                    ▾
+                  </span>
+                </summary>
+                <div className="mt-2 flex flex-wrap gap-1.5 pt-1">
+                  {tagsInGroup.map((t) => {
+                    const active = initialTags.includes(t)
+                    return (
+                      <button
+                        key={t}
+                        type="button"
+                        onClick={() => toggleTag(t)}
+                        aria-pressed={active}
+                        className={`rounded-full border px-2.5 py-0.5 text-xs ${
+                          active
+                            ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
+                            : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
+                        }`}
+                      >
+                        {t.replace(/-/g, ' ')}
+                      </button>
+                    )
+                  })}
+                </div>
+              </details>
             )
           })}
+          {/* Otros — any tag not matched to a group */}
+          {(() => {
+            const grouped = new Set(TAG_GROUPS.flatMap((g) => g.tags))
+            const others = availableTags.filter((t) => !grouped.has(t))
+            if (others.length === 0) return null
+            const activeCount = others.filter((t) => initialTags.includes(t)).length
+            return (
+              <details
+                open={activeCount > 0}
+                className="group rounded-md border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-3 py-2"
+              >
+                <summary className="flex cursor-pointer items-center justify-between text-xs font-medium text-[color:var(--text,#111)] marker:hidden [&::-webkit-details-marker]:hidden">
+                  <span className="flex items-center gap-2">
+                    <span>Otros</span>
+                    {activeCount > 0 ? (
+                      <span className="rounded-full bg-[color:var(--primary,#111)] px-1.5 text-[10px] font-semibold text-[color:var(--primary-foreground,#fff)]">
+                        {activeCount}
+                      </span>
+                    ) : null}
+                  </span>
+                  <span aria-hidden="true" className="text-[color:var(--text-muted,#9ca3af)] transition-transform group-open:rotate-180">▾</span>
+                </summary>
+                <div className="mt-2 flex flex-wrap gap-1.5 pt-1">
+                  {others.map((t) => {
+                    const active = initialTags.includes(t)
+                    return (
+                      <button
+                        key={t}
+                        type="button"
+                        onClick={() => toggleTag(t)}
+                        aria-pressed={active}
+                        className={`rounded-full border px-2.5 py-0.5 text-xs ${
+                          active
+                            ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
+                            : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
+                        }`}
+                      >
+                        {t.replace(/-/g, ' ')}
+                      </button>
+                    )
+                  })}
+                </div>
+              </details>
+            )
+          })()}
         </div>
       ) : null}
 


### PR DESCRIPTION
PR 2 of fun4me/tienda rebuild. Kills the 'alphabet soup' tag wall.

1. **4 big category tiles** (Parejas/Ella/Él/Lubricantes) above grid with icons + gradient tints + count
2. **Tag groups** — 20+ flat chips → 5 collapsible `<details>` buckets (Material/Características/Experiencia/Pensado para/Estilo) + Otros
3. **Polish** — no # prefix, spaces not dashes, "Todo" only when active, Capitalize labels, counts ≥ 2 only

🤖 Generated with [Claude Code](https://claude.com/claude-code)