### PR TITLE
feat(fun4me): populate footer — kills the dead purple band

### DIFF
--- a/sites/fun4me/content/es.json
+++ b/sites/fun4me/content/es.json
@@ -762,13 +762,36 @@
     }
   },
   "footer": {
+    "businessName": "Fun4Me",
+    "city": "Asunción, Paraguay",
+    "address": "Herrera 875",
+    "phone": "+595976569739",
+    "whatsapp": "+595976569739",
+    "email": "hola@fun4me.com.py",
+    "instagram": "@fun4me_store",
+    "facebook": "FUN4MEStore",
+    "navLinks": [
+      { "label": "Tienda", "href": "/s/es/fun4me/tienda" },
+      { "label": "Ayudame a elegir", "href": "/s/es/fun4me/quiz" },
+      { "label": "Suscripciones", "href": "/s/es/fun4me/suscripciones" },
+      { "label": "Bundles y kits", "href": "/s/es/fun4me/bundles" },
+      { "label": "Gift cards", "href": "/s/es/fun4me/gift-cards" },
+      { "label": "Placer Plus", "href": "/s/es/fun4me/placer-plus" },
+      { "label": "Quiénes somos", "href": "/s/es/fun4me/quienes-somos" },
+      { "label": "Blog", "href": "/s/es/fun4me/blog" },
+      { "label": "Reserva en tienda", "href": "/s/es/fun4me/reserva-en-tienda" },
+      { "label": "Guía de talles", "href": "/s/es/fun4me/size-guide" },
+      { "label": "Preguntas frecuentes", "href": "/s/es/fun4me/legal#faq" },
+      { "label": "Privacidad", "href": "/s/es/fun4me/legal" },
+      { "label": "Términos", "href": "/s/es/fun4me/legal" }
+    ],
     "rights": "Todos los derechos reservados.",
-    "privacy": "Politica de Privacidad",
-    "privacyHref": "/fun4me/legal",
-    "terms": "Terminos y Condiciones",
-    "termsHref": "/fun4me/legal",
-    "legalText": "Solo mayores de 18 anos.",
-    "legalHref": "/fun4me/legal"
+    "privacy": "Política de Privacidad",
+    "privacyHref": "/s/es/fun4me/legal",
+    "terms": "Términos y Condiciones",
+    "termsHref": "/s/es/fun4me/legal",
+    "legalText": "Solo mayores de 18 años. Empaque y facturación discretos. Datos cifrados.",
+    "legalHref": "/s/es/fun4me/legal"
   },
   "whatsapp": {
     "message": "Hola! Quiero consultar sobre un producto.",

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -19777,13 +19777,75 @@ export const CONTENT: Record<string, JsonRecord> = {
       }
     },
     "footer": {
-      "legalHref": "/fun4me/legal",
-      "legalText": "Solo mayores de 18 anos.",
-      "privacy": "Politica de Privacidad",
-      "privacyHref": "/fun4me/legal",
+      "address": "Herrera 875",
+      "businessName": "Fun4Me",
+      "city": "Asunción, Paraguay",
+      "email": "hola@fun4me.com.py",
+      "facebook": "FUN4MEStore",
+      "instagram": "@fun4me_store",
+      "legalHref": "/s/es/fun4me/legal",
+      "legalText": "Solo mayores de 18 años. Empaque y facturación discretos. Datos cifrados.",
+      "navLinks": [
+        {
+          "href": "/s/es/fun4me/tienda",
+          "label": "Tienda"
+        },
+        {
+          "href": "/s/es/fun4me/quiz",
+          "label": "Ayudame a elegir"
+        },
+        {
+          "href": "/s/es/fun4me/suscripciones",
+          "label": "Suscripciones"
+        },
+        {
+          "href": "/s/es/fun4me/bundles",
+          "label": "Bundles y kits"
+        },
+        {
+          "href": "/s/es/fun4me/gift-cards",
+          "label": "Gift cards"
+        },
+        {
+          "href": "/s/es/fun4me/placer-plus",
+          "label": "Placer Plus"
+        },
+        {
+          "href": "/s/es/fun4me/quienes-somos",
+          "label": "Quiénes somos"
+        },
+        {
+          "href": "/s/es/fun4me/blog",
+          "label": "Blog"
+        },
+        {
+          "href": "/s/es/fun4me/reserva-en-tienda",
+          "label": "Reserva en tienda"
+        },
+        {
+          "href": "/s/es/fun4me/size-guide",
+          "label": "Guía de talles"
+        },
+        {
+          "href": "/s/es/fun4me/legal#faq",
+          "label": "Preguntas frecuentes"
+        },
+        {
+          "href": "/s/es/fun4me/legal",
+          "label": "Privacidad"
+        },
+        {
+          "href": "/s/es/fun4me/legal",
+          "label": "Términos"
+        }
+      ],
+      "phone": "+595976569739",
+      "privacy": "Política de Privacidad",
+      "privacyHref": "/s/es/fun4me/legal",
       "rights": "Todos los derechos reservados.",
-      "terms": "Terminos y Condiciones",
-      "termsHref": "/fun4me/legal"
+      "terms": "Términos y Condiciones",
+      "termsHref": "/s/es/fun4me/legal",
+      "whatsapp": "+595976569739"
     },
     "giftCards": {
       "cta": {


### PR DESCRIPTION
PR 4 of tienda rebuild. Footer component already supports 4 columns (About/Links/Contact/Social); fun4me content was just missing the fields.

Added: businessName, address, phone, whatsapp, email, instagram, facebook + 13 navLinks (Tienda/Quiz/Suscripciones/Bundles/Gift cards/Placer Plus/Sobre/Blog/Reserva/Talles/FAQ/Privacidad/Términos). Accent fixes. legalText now mentions discreet packaging + billing.

Content-only change, no component touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)