### PR TITLE
feat(fun4me): voseo copy + quick wins on /tienda toolbar

### DIFF
--- a/sites/fun4me/content/bundles.json
+++ b/sites/fun4me/content/bundles.json
@@ -9,7 +9,7 @@
       "name": "Para la Primera Vez",
       "category": "parejas",
       "audience": "beginner",
-      "headline": "Todo lo que necesitas para empezar, sin complicaciones.",
+      "headline": "Todo lo que necesitás para empezar, sin complicaciones.",
       "description": "Kit curado para quienes exploran juguetes por primera vez. Productos suaves, fáciles de usar, con guía de inicio incluida.",
       "composition": [
         { "sku": "SAT-PRO2", "name": "Vibrador Satisfyer Pro 2 (beginner-friendly)", "individualPrice": 420000 },

--- a/sites/fun4me/content/checkout.json
+++ b/sites/fun4me/content/checkout.json
@@ -95,13 +95,13 @@
   },
   "emptyCart": {
     "title": "Tu carrito esta vacio",
-    "text": "Explora nuestras categorias y agrega productos.",
+    "text": "Explorá nuestras categorías y agregá productos.",
     "ctaText": "Ir a la Tienda",
     "ctaHref": "/fun4me/tienda"
   },
   "errors": {
     "payment_declined": "El pago fue rechazado. Probá con otro metodo o contactanos por WhatsApp.",
-    "age_not_verified": "Debes confirmar que sos mayor de 18 anos antes de finalizar la compra.",
+    "age_not_verified": "Tenés que confirmar que sos mayor de 18 años antes de finalizar la compra.",
     "out_of_stock": "Este producto ya no esta disponible. Lo removemos de tu carrito.",
     "delivery_unavailable": "No hacemos delivery a esta zona todavia. Podes elegir retiro en tienda o contactarnos."
   }

--- a/sites/fun4me/content/es.json
+++ b/sites/fun4me/content/es.json
@@ -69,7 +69,7 @@
     },
     "ageGate": {
       "title": "Verificacion de Edad",
-      "message": "Este sitio contiene contenido para adultos. Debes ser mayor de 18 anos para continuar.",
+      "message": "Este sitio contiene contenido para adultos. Tenés que ser mayor de 18 años para continuar.",
       "confirmText": "Soy mayor de 18",
       "denyText": "Salir",
       "denyHref": "https://google.com"
@@ -139,7 +139,7 @@
     },
     "categories": {
       "title": "Categorias Destacadas",
-      "subtitle": "Todo lo que necesitas para disfrutar",
+      "subtitle": "Todo lo que necesitás para disfrutar",
       "items": [
         {
           "id": "vibradores",
@@ -159,7 +159,7 @@
           "id": "anal",
           "name": "Juguetes Anales",
           "icon": "arrow-uturn-down",
-          "description": "Explora nuevos territorios de placer",
+          "description": "Explorá nuevos territorios de placer",
           "href": "/fun4me/tienda/categoria/anal"
         },
         {
@@ -630,7 +630,7 @@
     },
     "hero": {
       "headline": "Politicas y Legal",
-      "subheadline": "Todo lo que necesitas saber sobre tus derechos al comprar en Fun4Me.",
+      "subheadline": "Todo lo que necesitás saber sobre tus derechos al comprar en Fun4Me.",
       "ctaPrimaryText": "Contactar legal@fun4me.com.py",
       "ctaPrimaryHref": "mailto:legal@fun4me.com.py"
     },
@@ -801,11 +801,11 @@
   "store": {
     "seo": {
       "title": "Tienda Fun4Me | Catalogo online con envio discreto",
-      "description": "Explora todo el catalogo de Fun4Me. Vibradores, lenceria, lubricantes, BDSM y mas. Envio 100% discreto a todo Paraguay."
+      "description": "Explorá todo el catalogo de Fun4Me. Vibradores, lenceria, lubricantes, BDSM y mas. Envio 100% discreto a todo Paraguay."
     },
     "hero": {
       "headline": "Tu Placer, Nuestra Prioridad",
-      "subheadline": "Encuentra productos de calidad con envio discreto a todo Paraguay. Envio gratis en compras mayores a 200.000 Gs."
+      "subheadline": "Encontrá productos de calidad con envio discreto a todo Paraguay. Envio gratis en compras mayores a 200.000 Gs."
     },
     "bundlesPreview": {
       "title": "Kits Curados",
@@ -936,7 +936,7 @@
     },
     "hero": {
       "headline": "Regala Placer",
-      "subheadline": "El regalo perfecto cuando no sabes que elegir. Sin talles, sin preferencias, sin errores."
+      "subheadline": "El regalo perfecto cuando no sabés qué elegir. Sin talles, sin preferencias, sin errores."
     },
     "denominations": {
       "title": "Elegi el monto",
@@ -1488,7 +1488,7 @@
         },
         {
           "q": "Plus size / curvy",
-          "a": "Empieza en XL (= L/M de marcas regulares). Verifica la tabla especifica del producto."
+          "a": "Empezá en XL (= L/M de marcas regulares). Verificá la tabla especifica del producto."
         },
         {
           "q": "One size",
@@ -1561,11 +1561,11 @@
       "subheadline": "Guias, educacion y consejos. Aprendé sin juicios."
     },
     "categories": {
-      "title": "Explora por categoria",
+      "title": "Explorá por categoria",
       "items": [
         {
           "name": "Guias para principiantes",
-          "description": "Lo basico que deberias saber antes de comprar tu primer producto."
+          "description": "Lo básico que deberías saber antes de comprar tu primer producto."
         },
         {
           "name": "Seguridad y cuidado",

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -242,9 +242,10 @@ export default async function StorePage({
           <aside
             role="note"
             aria-label="Aviso para administradores"
-            className="mb-4 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-xs text-amber-900"
+            className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-amber-300 bg-amber-50 px-3 py-1 text-xs text-amber-900"
           >
-            <strong className="font-semibold">⚠ Catálogo demo.</strong> Todos los productos son de ejemplo — cargar fotos reales y marcar <code className="rounded bg-amber-100 px-1">isSeed=false</code> antes del tráfico pago.
+            <span aria-hidden="true">⚠</span>
+            <span>Catálogo demo — <code className="rounded bg-amber-100 px-1">isSeed</code> sin reemplazar.</span>
           </aside>
         ) : null}
 

--- a/web/components/commerce/tienda-quick-filters.tsx
+++ b/web/components/commerce/tienda-quick-filters.tsx
@@ -87,7 +87,7 @@ export function TiendaQuickFilters() {
             disabled={pending}
             aria-pressed={active}
             className={cn(
-              'rounded-full border px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50',
+              'rounded-full border px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)] disabled:opacity-50',
               active
                 ? 'border-[color:var(--secondary,#b8860b)] bg-[color:var(--secondary,#b8860b)] text-white'
                 : 'border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] hover:bg-[color:var(--surface-muted,#f3f4f6)]',

--- a/web/components/commerce/tienda-toolbar.tsx
+++ b/web/components/commerce/tienda-toolbar.tsx
@@ -35,8 +35,6 @@ interface Props {
   initialPerPage: number
 }
 
-const PER_PAGE_OPTIONS = [12, 24, 48, 96]
-
 /**
  * Tag buckets for the filter toolbar. Flat wall of 20+ chips (which is
  * what this shop actually ships) is unnavigable; grouping them by
@@ -134,7 +132,7 @@ export function TiendaToolbar({
   initialMaxPrice,
   initialInStockOnly,
   initialOnSaleOnly,
-  initialPerPage,
+  initialPerPage: _initialPerPage,
   initialBrands,
   availableBrands,
   initialTags,
@@ -290,14 +288,14 @@ export function TiendaToolbar({
               type="search"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="Buscar por nombre, descripción o SKU…"
+              placeholder="¿Qué buscás? (lubricante, vibrador, lencería…)"
               className="w-full bg-transparent text-sm outline-none placeholder:text-[color:var(--text-muted,#9ca3af)]"
             />
           </label>
           <button
             type="submit"
             disabled={pending}
-            className="rounded bg-[color:var(--primary,#111)] px-3 py-2 text-sm font-medium text-[color:var(--primary-foreground,#fff)] disabled:opacity-50"
+            className="rounded bg-[color:var(--primary,#111)] px-3 py-2 text-sm font-medium text-[color:var(--primary-foreground,#fff)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)] disabled:opacity-50"
           >
             Buscar
           </button>
@@ -309,25 +307,11 @@ export function TiendaToolbar({
             <select
               value={initialSort}
               onChange={(e) => pushParams({ sort: e.target.value === 'newest' ? null : e.target.value })}
-              className="rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-2 py-1 text-sm"
+              className="rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-[color:var(--primary,#111)]"
             >
               {SORT_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>
                   {opt.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="flex items-center gap-2">
-            <span className="text-xs text-[color:var(--text-muted,#6b7280)]">Por página:</span>
-            <select
-              value={initialPerPage}
-              onChange={(e) => pushParams({ per_page: e.target.value === '12' ? null : e.target.value })}
-              className="rounded border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-2 py-1 text-sm"
-            >
-              {PER_PAGE_OPTIONS.map((n) => (
-                <option key={n} value={n}>
-                  {n}
                 </option>
               ))}
             </select>
@@ -341,7 +325,7 @@ export function TiendaToolbar({
         type="button"
         onClick={() => setAdvancedOpen((v) => !v)}
         aria-expanded={advancedOpen}
-        className="flex items-center justify-between rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm md:hidden"
+        className="flex items-center justify-between rounded border border-[color:var(--border,#e5e7eb)] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[color:var(--primary,#111)] md:hidden"
       >
         <span className="flex items-center gap-2">
           <svg aria-hidden="true" className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -374,12 +358,13 @@ export function TiendaToolbar({
           category is active, so the default view isn't dominated by a loud
           "Todo is selected" chip. */}
       {availableCategories.length > 0 ? (
-        <div className="flex flex-wrap gap-2">
+        <fieldset className="flex flex-wrap gap-2">
+          <legend className="sr-only">Categoría</legend>
           {initialCategories.length > 0 ? (
             <button
               type="button"
               onClick={() => pushParams({ category: null })}
-              className="rounded-full border border-[color:var(--border,#e5e7eb)] px-3 py-1 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+              className="rounded-full border border-[color:var(--border,#e5e7eb)] px-3 py-1 text-xs hover:bg-[color:var(--surface-muted,#f3f4f6)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)]"
             >
               ← Todas
             </button>
@@ -398,7 +383,7 @@ export function TiendaToolbar({
                 type="button"
                 onClick={() => toggleCategory(cat)}
                 aria-pressed={active}
-                className={`rounded-full border px-3 py-1 text-xs ${
+                className={`rounded-full border px-3 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)] ${
                   active
                     ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
                     : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
@@ -411,13 +396,15 @@ export function TiendaToolbar({
               </button>
             )
           })}
-        </div>
+        </fieldset>
       ) : null}
 
-      {/* Brand filter */}
-      {availableBrands.length > 0 ? (
-        <div className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="text-[color:var(--text-muted,#6b7280)]">Marca:</span>
+      {/* Brand filter — only render when there are at least 2 brands.
+          With a single brand, the filter is purely decorative and wastes
+          vertical space. */}
+      {availableBrands.length >= 2 ? (
+        <fieldset className="flex flex-wrap items-center gap-2 text-xs">
+          <legend className="float-left mr-2 text-[color:var(--text-muted,#6b7280)]">Marca:</legend>
           {availableBrands.map((b) => {
             const active = initialBrands.includes(b)
             return (
@@ -426,7 +413,7 @@ export function TiendaToolbar({
                 type="button"
                 onClick={() => toggleBrand(b)}
                 aria-pressed={active}
-                className={`rounded-full border px-3 py-1 ${
+                className={`rounded-full border px-3 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)] ${
                   active
                     ? 'border-[color:var(--secondary,#b8860b)] bg-[color:var(--secondary,#b8860b)] text-white'
                     : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
@@ -436,7 +423,7 @@ export function TiendaToolbar({
               </button>
             )
           })}
-        </div>
+        </fieldset>
       ) : null}
 
       {/* Tag filter — grouped into themed buckets so 20+ tags don't render
@@ -481,7 +468,7 @@ export function TiendaToolbar({
                         type="button"
                         onClick={() => toggleTag(t)}
                         aria-pressed={active}
-                        className={`rounded-full border px-2.5 py-0.5 text-xs ${
+                        className={`rounded-full border px-2.5 py-0.5 text-xs focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)] ${
                           active
                             ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
                             : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
@@ -526,7 +513,7 @@ export function TiendaToolbar({
                         type="button"
                         onClick={() => toggleTag(t)}
                         aria-pressed={active}
-                        className={`rounded-full border px-2.5 py-0.5 text-xs ${
+                        className={`rounded-full border px-2.5 py-0.5 text-xs focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)] ${
                           active
                             ? 'border-[color:var(--primary,#111)] bg-[color:var(--primary,#111)] text-[color:var(--primary-foreground,#fff)]'
                             : 'border-[color:var(--border,#e5e7eb)] hover:bg-[color:var(--surface-muted,#f3f4f6)]'
@@ -546,30 +533,32 @@ export function TiendaToolbar({
       {/* Price range + toggles */}
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <form onSubmit={onPriceSubmit} className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="text-[color:var(--text-muted,#6b7280)]">Precio (Gs):</span>
-          <input
-            type="text"
-            inputMode="numeric"
-            value={minPrice}
-            onChange={(e) => setMinPrice(e.target.value)}
-            placeholder="Mín"
-            className="w-24 rounded border border-[color:var(--border,#e5e7eb)] px-2 py-1"
-            aria-label="Precio mínimo"
-          />
-          <span aria-hidden="true">–</span>
-          <input
-            type="text"
-            inputMode="numeric"
-            value={maxPrice}
-            onChange={(e) => setMaxPrice(e.target.value)}
-            placeholder="Máx"
-            className="w-24 rounded border border-[color:var(--border,#e5e7eb)] px-2 py-1"
-            aria-label="Precio máximo"
-          />
+          <fieldset className="flex flex-wrap items-center gap-2">
+            <legend className="float-left mr-2 text-[color:var(--text-muted,#6b7280)]">Precio (Gs):</legend>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={minPrice}
+              onChange={(e) => setMinPrice(e.target.value)}
+              placeholder="Mín"
+              className="w-24 rounded border border-[color:var(--border,#e5e7eb)] px-2 py-1 focus:outline-none focus:ring-2 focus:ring-[color:var(--primary,#111)]"
+              aria-label="Precio mínimo"
+            />
+            <span aria-hidden="true">–</span>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={maxPrice}
+              onChange={(e) => setMaxPrice(e.target.value)}
+              placeholder="Máx"
+              className="w-24 rounded border border-[color:var(--border,#e5e7eb)] px-2 py-1 focus:outline-none focus:ring-2 focus:ring-[color:var(--primary,#111)]"
+              aria-label="Precio máximo"
+            />
+          </fieldset>
           <button
             type="submit"
             disabled={pending}
-            className="rounded border border-[color:var(--border,#e5e7eb)] px-2 py-1 hover:bg-[color:var(--surface-muted,#f3f4f6)] disabled:opacity-50"
+            className="rounded border border-[color:var(--border,#e5e7eb)] px-2 py-1 hover:bg-[color:var(--surface-muted,#f3f4f6)] focus:outline-none focus:ring-2 focus:ring-[color:var(--primary,#111)] disabled:opacity-50"
           >
             Aplicar
           </button>
@@ -605,15 +594,21 @@ export function TiendaToolbar({
             key={f.key}
             type="button"
             onClick={f.clear}
-            className="inline-flex items-center gap-1 rounded-full bg-[color:var(--surface-muted,#f3f4f6)] px-2 py-0.5 hover:bg-[color:var(--border,#e5e7eb)]"
+            className="inline-flex min-h-[28px] items-center gap-1.5 rounded-full bg-[color:var(--surface-muted,#f3f4f6)] py-1 pl-2.5 pr-1.5 transition-colors hover:bg-[color:var(--border,#e5e7eb)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)]"
             aria-label={`Quitar filtro: ${f.label}`}
           >
             <span>{f.label}</span>
-            <span aria-hidden="true">✕</span>
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M6 6l12 12M6 18L18 6" />
+            </svg>
           </button>
         ))}
         {activeFilters.length > 0 ? (
-          <button type="button" onClick={clearAll} className="text-[color:var(--primary,#111)] underline">
+          <button
+            type="button"
+            onClick={clearAll}
+            className="text-[color:var(--primary,#111)] underline hover:no-underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)]"
+          >
             Limpiar todo
           </button>
         ) : null}


### PR DESCRIPTION
## Summary

PR 1 of a 4-PR fun4me storefront polish sweep. Fixes the "copy from Madrid" tell (tú/tienes → vos/tenés) plus a handful of small UX papercuts in the tienda toolbar.

## Voseo paraguayo

Customer-facing copy across `sites/fun4me/content/*.json`:
- `necesitas` → `necesitás`
- `Explora` → `Explorá` / `Encuentra` → `Encontrá`
- `no sabes que elegir` → `no sabés qué elegir`
- `Verifica` / `Empieza` → `Verificá` / `Empezá`
- `Debes ser mayor` → `Tenés que ser mayor`
- `agrega productos` → `agregá productos`

## Toolbar (/tienda)

- Remove per-page selector (12/24/48/96) — noise, no-one changed it. URL param `per_page` still works.
- Search placeholder: `Buscar por nombre, descripción o SKU…` → `¿Qué buscás? (lubricante, vibrador, lencería…)`
- Hide brand filter when store has < 2 brands (was rendering 1-option decoration).
- Active filter chip: Unicode `✕` → inline SVG, 28px tap target, visible focus ring.
- `<fieldset>`/`<legend>` around Category, Brand, Price groups for screen-reader semantics.
- Unify focus rings across search submit, sort select, filter toggle, category pills, brand pills, tag chips, price inputs, "Aplicar", "Limpiar todo".

## Admin banner

- Verbose `⚠ Catálogo demo...` paragraph → compact inline amber pill. Dev-env only.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] eslint clean (two pre-existing warnings unchanged)
- [ ] visual: `/s/es/fun4me/tienda` — search placeholder, no per-page dropdown, new filter-chip X icon, focus rings on tab
- [ ] screen-reader: fieldset/legend groups announce correctly
- [ ] mobile: "Filtros" toggle still works, focus ring visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)