### PR TITLE
feat(fun4me): free-shipping progress bar + PDP care/shipping guide

### DIFF
--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -25,6 +25,7 @@ import { ReviewList } from '@/components/commerce/review-list'
 import { ReviewForm } from '@/components/commerce/review-form'
 import { ReviewStars } from '@/components/commerce/review-stars'
 import { PdpStickyMobileCta } from '@/components/commerce/pdp-sticky-mobile-cta'
+import { PdpCareGuide } from '@/components/commerce/pdp-care-guide'
 import { Breadcrumbs } from '@/components/commerce/breadcrumbs'
 import { PdpViewTracker } from '@/components/commerce/pdp-view-tracker'
 import {
@@ -280,11 +281,10 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
 
           <ProductShare productName={product.name} productUrl={`${env.APP_URL}/s/${locale}/${site}/producto/${product.slug}`} />
 
-          <div className="mt-8 rounded-lg bg-[color:var(--surface,#fff)] p-4 text-sm text-[color:var(--text-muted,#6b7280)]">
-            <p>✓ Pago seguro</p>
-            <p>✓ Envío a todo el Paraguay</p>
-            <p>✓ Atención por WhatsApp</p>
-          </div>
+          {/* Care / sizing / shipping guide — three collapsible panels that
+              answer the questions a first-time buyer asks before adding to
+              cart. Adult-retail specific copy for sex_shop tenants. */}
+          <PdpCareGuide vertical={business.type === 'sex_shop' ? 'adult-retail' : 'generic'} />
         </div>
       </main>
 

--- a/web/components/commerce/cart-drawer.tsx
+++ b/web/components/commerce/cart-drawer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { useCartStore, cartSubtotalCents } from '@/lib/stores/cart-store'
 import { formatCents } from '@/lib/commerce/compute-totals'
+import { getFreeShippingThresholdCents } from '@/lib/commerce/shipping-threshold'
 
 interface Props {
   siteSlug: string
@@ -146,6 +147,41 @@ export function CartDrawer({ siteSlug, locale, open, onClose }: Props) {
 
         {items.length > 0 ? (
           <footer className="border-t border-[color:var(--border,#e5e7eb)] px-6 py-4">
+            {(() => {
+              // Progress bar toward free-shipping threshold. Hidden when
+              // the tenant has no threshold configured, or when the cart
+              // currency doesn't match the tenant's threshold currency
+              // (both PYG for PY tenants today). Converts the "Gs 200.000"
+              // marketing promise into a concrete "faltan Gs X" nudge the
+              // moment the shopper opens the drawer.
+              const threshold = getFreeShippingThresholdCents(siteSlug)
+              if (threshold <= 0 || currency !== 'PYG') return null
+              const pct = Math.min(100, Math.round((subtotal / threshold) * 100))
+              const reached = subtotal >= threshold
+              return (
+                <div className="mb-3" aria-live="polite">
+                  <div className="mb-1 flex items-center justify-between text-xs">
+                    <span className={reached ? 'font-medium text-emerald-700' : 'text-[color:var(--text-muted,#6b7280)]'}>
+                      {reached
+                        ? '🎉 ¡Ya tenés envío gratis!'
+                        : `Te faltan ${formatCents(threshold - subtotal, 'PYG')} para envío gratis`}
+                    </span>
+                  </div>
+                  <div
+                    role="progressbar"
+                    aria-valuenow={pct}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    className="h-1.5 overflow-hidden rounded-full bg-[color:var(--surface-muted,#f3f4f6)]"
+                  >
+                    <div
+                      className={`h-full transition-all duration-300 ${reached ? 'bg-emerald-600' : 'bg-[color:var(--primary,#111)]'}`}
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </div>
+              )
+            })()}
             <div className="mb-3 flex items-center justify-between text-sm">
               <span className="text-[color:var(--text-muted,#6b7280)]">Subtotal</span>
               <span className="text-lg font-semibold">{formatCents(subtotal, currency)}</span>

--- a/web/components/commerce/pdp-care-guide.tsx
+++ b/web/components/commerce/pdp-care-guide.tsx
@@ -1,0 +1,89 @@
+/**
+ * Three collapsible `<details>` panels on the PDP with vocabulary-light
+ * answers to the questions every first-time buyer in this vertical asks
+ * before they add to cart:
+ *   - "How do I keep this clean / not break it?"
+ *   - "What size do I order if I don't know my size?"
+ *   - "When does it arrive, how discreetly, and can I return it?"
+ *
+ * Content is intentionally hard-coded here (not pulled from the
+ * per-tenant `content/es.json`) because every fun4me PDP asks the same
+ * three questions with the same answers — pushing it into tenant copy
+ * would multiply content-entry work without adding flexibility.
+ *
+ * `<details>` is native, keyboard-accessible, and ships zero JS.
+ */
+
+interface Props {
+  /** When true, render category-specific guidance. Opt-out default keeps
+   *  the copy generic so it's still useful on non-adult stores if the
+   *  component ever gets reused. */
+  vertical?: 'adult-retail' | 'generic'
+}
+
+const PANELS_ADULT: Array<{ title: string; body: string }> = [
+  {
+    title: 'Cómo cuidar y limpiar',
+    body:
+      'Agua tibia + jabón neutro, o limpiador específico para juguetes. ' +
+      'Silicona y acero: hasta 10 minutos en agua hirviendo. ' +
+      'Baterías recargables: usá el cable original y no dejés cargando más de 4 horas. ' +
+      'Siempre secar al aire antes de guardar.',
+  },
+  {
+    title: 'Cómo elegir el talle (lencería)',
+    body:
+      'Si dudás, andá una talla arriba — las marcas Leg Avenue, Dreamgirl y similares tallan más chico que la ropa regular. ' +
+      'Plus size empieza en XL. Cada producto tiene la tabla específica en su descripción. ' +
+      'Si el talle no te queda, tenés cambio dentro de los 7 días (sin abrir, sin usar).',
+  },
+  {
+    title: 'Envío, privacidad y cambios',
+    body:
+      'Asunción y GBA: 24-72hs hábiles. Interior: 3-5 días hábiles. ' +
+      'Empaque 100% discreto, sin logos ni nombre del rubro en el remito. ' +
+      'Pago con tarjeta aparece en el resumen como "F4M Comercial". ' +
+      'Envío gratis en compras mayores a Gs 200.000. ' +
+      'Cambios dentro de 7 días si viene sin abrir o con defecto.',
+  },
+]
+
+const PANELS_GENERIC: Array<{ title: string; body: string }> = [
+  {
+    title: 'Cuidado y mantenimiento',
+    body: 'Seguí las indicaciones específicas de la etiqueta del producto.',
+  },
+  {
+    title: 'Envío y cambios',
+    body:
+      'Despachamos dentro de las 24hs hábiles. ' +
+      'Tenés 7 días para cambios si viene sin uso o con defecto.',
+  },
+]
+
+export function PdpCareGuide({ vertical = 'adult-retail' }: Props) {
+  const panels = vertical === 'adult-retail' ? PANELS_ADULT : PANELS_GENERIC
+  return (
+    <section aria-label="Guías del producto" className="mt-8 space-y-2">
+      {panels.map((p) => (
+        <details
+          key={p.title}
+          className="group rounded-lg border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] open:shadow-sm"
+        >
+          <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-medium text-[color:var(--text,#111)] marker:hidden [&::-webkit-details-marker]:hidden">
+            <span>{p.title}</span>
+            <span
+              aria-hidden="true"
+              className="text-[color:var(--text-muted,#9ca3af)] transition-transform group-open:rotate-180"
+            >
+              ▾
+            </span>
+          </summary>
+          <p className="px-4 pb-4 text-sm leading-relaxed text-[color:var(--text-muted,#4b5563)]">
+            {p.body}
+          </p>
+        </details>
+      ))}
+    </section>
+  )
+}

--- a/web/lib/commerce/shipping-threshold.ts
+++ b/web/lib/commerce/shipping-threshold.ts
@@ -1,0 +1,19 @@
+/**
+ * Per-site free-shipping threshold in cents. Returns 0 when no threshold
+ * is configured (i.e. the cart drawer hides the progress bar entirely).
+ *
+ * Lives outside the Supabase/business record on purpose — this is a
+ * copy + marketing concern, not a billing rule. The hero and FAQ pages
+ * advertise the threshold, and we want the cart UI to match that story
+ * without adding a migration + admin UI for one number.
+ *
+ * Values are in cents of the site's base currency (PYG for PY tenants).
+ * Gs. 200.000 = 20_000_000 cents.
+ */
+const THRESHOLDS: Readonly<Record<string, number>> = {
+  fun4me: 20_000_000,
+}
+
+export function getFreeShippingThresholdCents(siteSlug: string): number {
+  return THRESHOLDS[siteSlug] ?? 0
+}


### PR DESCRIPTION
## Summary

PR 2 of the fun4me storefront polish. Two user-facing improvements:

### Free-shipping progress bar in CartDrawer

fun4me has advertised "Envío gratis en compras mayores a Gs 200.000" in hero + FAQ, but the cart UI never made that concrete. Now every CartDrawer shows \"Te faltan Gs X para envío gratis\" + a filling progress bar, flipping to \"🎉 ¡Ya tenés envío gratis!\" on threshold cross.

Threshold per-site in `lib/commerce/shipping-threshold.ts` (fun4me → 20_000_000 cents). Hidden for tenants without a threshold, and for non-PYG carts.

### PDP care/shipping guide

Three native `<details>` panels on the PDP, vocabulary-light:
- Cómo cuidar y limpiar
- Cómo elegir el talle (lencería)
- Envío, privacidad y cambios

Gated on `business.type === 'sex_shop'`; generic variant for other tenants. Replaces the duplicated bottom-of-PDP trust list (TrustStrip renders the same info 50px above).

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Add one Gs 50.000 item → drawer shows \"Te faltan Gs 150.000\"
- [ ] Add enough to cross 200k → drawer flips to green \"Ya tenés envío gratis\"
- [ ] Drawer on non-fun4me tenant → no progress bar
- [ ] Currency toggle to USD → progress bar hidden (PYG-only)
- [ ] PDP on fun4me → three panels render collapsed, expand on click
- [ ] PDP on non-sex_shop tenant → generic 2-panel variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)