### PR TITLE
feat(commerce): WhatsApp pay-by-chat secondary CTA on cart + drawer

### DIFF
--- a/web/app/s/[locale]/[site]/buscar-orden/page.tsx
+++ b/web/app/s/[locale]/[site]/buscar-orden/page.tsx
@@ -33,7 +33,7 @@ export default async function OrderLookupPage({
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
-      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} whatsappNumber={business.whatsappNumber} />
       <main className="mx-auto max-w-md px-4 py-10">
         <h1 className="mb-2 text-2xl font-bold text-[color:var(--text,#111)]">Buscar mi orden</h1>
         <p className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">

--- a/web/app/s/[locale]/[site]/carrito/page.tsx
+++ b/web/app/s/[locale]/[site]/carrito/page.tsx
@@ -31,11 +31,16 @@ export default async function CartPage({ params }: { params: Promise<{ site: str
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
-      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} whatsappNumber={business.whatsappNumber} />
       <main className="mx-auto max-w-4xl px-4 py-8">
         <CheckoutProgressIndicator current="cart" />
         <h1 className="mb-6 text-2xl font-bold">Tu carrito</h1>
-        <CartPageClient siteSlug={site} locale={locale} />
+        <CartPageClient
+          siteSlug={site}
+          locale={locale}
+          whatsappNumber={business.whatsappNumber}
+          businessName={business.name}
+        />
         <div className="mt-6">
           <Link href={`/s/${locale}/${site}/tienda`} className="text-sm text-[color:var(--primary,#111)] underline">
             ← Seguir comprando

--- a/web/app/s/[locale]/[site]/checkout/page.tsx
+++ b/web/app/s/[locale]/[site]/checkout/page.tsx
@@ -34,7 +34,7 @@ export default async function CheckoutPage({ params }: { params: Promise<{ site:
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
-      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} whatsappNumber={business.whatsappNumber} />
       <main className="mx-auto max-w-5xl px-4 py-8">
         <CheckoutProgressIndicator current="checkout" />
         <h1 className="mb-6 text-2xl font-bold">Finalizar compra</h1>

--- a/web/app/s/[locale]/[site]/favoritos/page.tsx
+++ b/web/app/s/[locale]/[site]/favoritos/page.tsx
@@ -33,7 +33,7 @@ export default async function WishlistPage({
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
-      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} whatsappNumber={business.whatsappNumber} />
       <main className="mx-auto max-w-5xl px-4 py-8">
         <h1 className="mb-2 text-2xl font-bold text-[color:var(--text,#111)]">Mis favoritos</h1>
         <p className="mb-6 text-sm text-[color:var(--text-muted,#6b7280)]">

--- a/web/app/s/[locale]/[site]/orden/[id]/page.tsx
+++ b/web/app/s/[locale]/[site]/orden/[id]/page.tsx
@@ -34,7 +34,7 @@ export default async function OrderPage({
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)] print:bg-white">
       <div className="print:hidden">
-        <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+        <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} whatsappNumber={business.whatsappNumber} />
       </div>
       <OrderConfirmation siteSlug={site} locale={locale} businessName={business.name} initialOrder={order} initialStatus={initial} />
       <PurchaseTracker order={order} />

--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -161,7 +161,7 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
-      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} whatsappNumber={business.whatsappNumber} />
 
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
       <PdpViewTracker

--- a/web/app/s/[locale]/[site]/quiz/page.tsx
+++ b/web/app/s/[locale]/[site]/quiz/page.tsx
@@ -34,7 +34,7 @@ export default async function QuizPage({
 
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
-      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} whatsappNumber={business.whatsappNumber} />
       <main className="mx-auto max-w-3xl px-4 py-10">
         <header className="mb-8 text-center">
           <h1 className="text-3xl font-bold text-[color:var(--text,#111)]">

--- a/web/app/s/[locale]/[site]/tienda/categoria/[category]/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/categoria/[category]/page.tsx
@@ -129,7 +129,7 @@ export default async function CategoryPage({
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
-      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} whatsappNumber={business.whatsappNumber} />
 
       <Breadcrumbs
         absoluteBaseUrl={env.APP_URL}

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -215,7 +215,7 @@ export default async function StorePage({
   return (
     <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
       <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
-      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} whatsappNumber={business.whatsappNumber} />
 
       <Breadcrumbs
         absoluteBaseUrl={env.APP_URL}

--- a/web/components/commerce/cart-drawer.tsx
+++ b/web/components/commerce/cart-drawer.tsx
@@ -5,17 +5,23 @@ import Link from 'next/link'
 import { useCartStore, cartSubtotalCents } from '@/lib/stores/cart-store'
 import { formatCents } from '@/lib/commerce/compute-totals'
 import { getFreeShippingThresholdCents } from '@/lib/commerce/shipping-threshold'
+import { buildWhatsAppCartUrl } from '@/lib/commerce/whatsapp-cart-link'
 
 interface Props {
   siteSlug: string
   locale: string
   open: boolean
   onClose: () => void
+  /** Optional tenant WhatsApp number. When set, adds a "Pedir por
+   *  WhatsApp" secondary CTA below the primary pay button. */
+  whatsappNumber?: string
+  /** Business display name for the pre-filled WA message. */
+  businessName?: string
 }
 
 const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
 
-export function CartDrawer({ siteSlug, locale, open, onClose }: Props) {
+export function CartDrawer({ siteSlug, locale, open, onClose, whatsappNumber, businessName }: Props) {
   const cart = useCartStore((s) => s.cart)
   const status = useCartStore((s) => s.status)
   const updateItem = useCartStore((s) => s.updateItem)
@@ -188,10 +194,36 @@ export function CartDrawer({ siteSlug, locale, open, onClose }: Props) {
             </div>
             <Link
               href={`/s/${locale}/${siteSlug}/checkout`}
-              className="block w-full rounded-lg bg-[color:var(--primary,#111)] px-4 py-3 text-center font-semibold text-[color:var(--primary-foreground,#fff)] hover:opacity-90"
+              className="block w-full rounded-lg bg-[color:var(--primary,#111)] px-4 py-3 text-center font-semibold text-[color:var(--primary-foreground,#fff)] hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)]"
             >
               {status === 'syncing' ? 'Actualizando…' : 'Pagar ahora'}
             </Link>
+            {whatsappNumber ? (() => {
+              const waUrl = buildWhatsAppCartUrl({
+                whatsappNumber,
+                businessName: businessName ?? 'Tienda',
+                currency,
+                items: items.map((i) => ({
+                  productName: i.productName,
+                  quantity: i.quantity,
+                  unitPriceCents: i.unitPriceCents,
+                })),
+                subtotalCents: subtotal,
+              })
+              return (
+                <a
+                  href={waUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-2 flex w-full items-center justify-center gap-2 rounded-lg border border-[#25D366] bg-white px-4 py-2.5 text-center text-sm font-semibold text-[#128C7E] hover:bg-[#25D36610] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#25D366]"
+                >
+                  <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+                  </svg>
+                  Pedir por WhatsApp
+                </a>
+              )
+            })() : null}
             <p className="mt-2 text-center text-xs text-[color:var(--text-muted,#6b7280)]">
               Envío y totales se calculan en el siguiente paso
             </p>

--- a/web/components/commerce/cart-page-client.tsx
+++ b/web/components/commerce/cart-page-client.tsx
@@ -4,8 +4,20 @@ import { useEffect } from 'react'
 import Link from 'next/link'
 import { useCartStore, cartSubtotalCents } from '@/lib/stores/cart-store'
 import { formatCents } from '@/lib/commerce/compute-totals'
+import { buildWhatsAppCartUrl } from '@/lib/commerce/whatsapp-cart-link'
 
-export function CartPageClient({ siteSlug, locale = 'es' }: { siteSlug: string; locale?: string }) {
+interface Props {
+  siteSlug: string
+  locale?: string
+  /** E.164-ish WhatsApp number from the tenant record. When set, a
+   *  secondary "Pedir por WhatsApp" CTA shows under the primary checkout
+   *  button. Digits-only is also accepted. */
+  whatsappNumber?: string
+  /** Business name used to open the pre-filled WA message. */
+  businessName?: string
+}
+
+export function CartPageClient({ siteSlug, locale = 'es', whatsappNumber, businessName }: Props) {
   const cart = useCartStore((s) => s.cart)
   const status = useCartStore((s) => s.status)
   const refresh = useCartStore((s) => s.refresh)
@@ -88,10 +100,46 @@ export function CartPageClient({ siteSlug, locale = 'es' }: { siteSlug: string; 
         <p className="mt-1 text-xs text-[color:var(--text-muted,#6b7280)]">El envío se calcula al confirmar la dirección.</p>
         <Link
           href={`/s/${locale}/${siteSlug}/checkout`}
-          className="mt-4 block w-full rounded-lg bg-[color:var(--primary,#111)] px-4 py-3 text-center font-semibold text-[color:var(--primary-foreground,#fff)] hover:opacity-90"
+          className="mt-4 block w-full rounded-lg bg-[color:var(--primary,#111)] px-4 py-3 text-center font-semibold text-[color:var(--primary-foreground,#fff)] hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[color:var(--primary,#111)]"
         >
           {status === 'syncing' ? 'Actualizando…' : 'Finalizar compra'}
         </Link>
+        {whatsappNumber ? (() => {
+          const waUrl = buildWhatsAppCartUrl({
+            whatsappNumber,
+            businessName: businessName ?? 'Tienda',
+            currency: cart.currency,
+            items: cart.items.map((i) => ({
+              productName: i.productName,
+              quantity: i.quantity,
+              unitPriceCents: i.unitPriceCents,
+            })),
+            subtotalCents: subtotal,
+          })
+          return (
+            <>
+              <div className="my-3 flex items-center gap-3 text-xs text-[color:var(--text-muted,#6b7280)]">
+                <span className="h-px flex-1 bg-[color:var(--border,#e5e7eb)]" />
+                <span>o</span>
+                <span className="h-px flex-1 bg-[color:var(--border,#e5e7eb)]" />
+              </div>
+              <a
+                href={waUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-[#25D366] bg-white px-4 py-3 text-center font-semibold text-[#128C7E] transition-colors hover:bg-[#25D36610] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#25D366]"
+              >
+                <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+                </svg>
+                Pedir por WhatsApp
+              </a>
+              <p className="mt-2 text-center text-[11px] text-[color:var(--text-muted,#6b7280)]">
+                Pagás por transferencia o en efectivo al recibir. Confirmamos stock antes.
+              </p>
+            </>
+          )
+        })() : null}
       </aside>
     </div>
   )

--- a/web/components/commerce/commerce-header.tsx
+++ b/web/components/commerce/commerce-header.tsx
@@ -15,9 +15,12 @@ interface Props {
   /** Active locale slug from the URL — threaded through to cart links so
    * `/s/pt/...` sites don't get sent back to `/s/es/...`. */
   locale?: string
+  /** Optional tenant WhatsApp number. Passed through to CartDrawer to
+   *  power the "Pedir por WhatsApp" secondary CTA. */
+  whatsappNumber?: string
 }
 
-export function CommerceHeader({ siteSlug, businessName, locale = 'es' }: Props) {
+export function CommerceHeader({ siteSlug, businessName, locale = 'es', whatsappNumber }: Props) {
   const [open, setOpen] = useState(false)
   return (
     <>
@@ -44,7 +47,14 @@ export function CommerceHeader({ siteSlug, businessName, locale = 'es' }: Props)
           </nav>
         </div>
       </header>
-      <CartDrawer siteSlug={siteSlug} locale={locale} open={open} onClose={() => setOpen(false)} />
+      <CartDrawer
+        siteSlug={siteSlug}
+        locale={locale}
+        open={open}
+        onClose={() => setOpen(false)}
+        whatsappNumber={whatsappNumber}
+        businessName={businessName}
+      />
     </>
   )
 }

--- a/web/lib/commerce/whatsapp-cart-link.ts
+++ b/web/lib/commerce/whatsapp-cart-link.ts
@@ -1,0 +1,59 @@
+import { formatCents } from './compute-totals'
+
+interface CartItemLite {
+  productName: string | null | undefined
+  quantity: number
+  unitPriceCents: number
+}
+
+interface Options {
+  /** E.164-ish phone; digits only after normalization. */
+  whatsappNumber: string
+  /** Store name to open the message with. */
+  businessName: string
+  /** Cart currency, for display in line items. */
+  currency: string
+  /** Line items in the cart. */
+  items: CartItemLite[]
+  /** Subtotal cents for the whole cart. */
+  subtotalCents: number
+  /** PDP URL back to the shop (useful for support). Optional. */
+  shopUrl?: string
+}
+
+/**
+ * Builds a `https://wa.me/<digits>?text=<pre-filled>` URL that drops the
+ * shopper into a WhatsApp chat with the store, preloaded with the cart
+ * contents, subtotal, and a polite request to confirm availability and
+ * payment method.
+ *
+ * This is the LATAM checkout's escape hatch: not every shopper trusts
+ * card-not-present on a new store, and the conversion rate on
+ * "Terminar por WhatsApp" is consistently higher than forcing them
+ * through a Pagopar tokenization flow. The cart state is in the URL
+ * only — no PII persisted anywhere.
+ */
+export function buildWhatsAppCartUrl(opts: Options): string {
+  const phone = opts.whatsappNumber.replace(/\D/g, '')
+  if (!phone) return ''
+
+  const lines: string[] = []
+  lines.push(`Hola ${opts.businessName}, quiero confirmar este pedido:`)
+  lines.push('')
+  for (const it of opts.items) {
+    const name = it.productName ?? 'Producto'
+    const lineTotal = formatCents(it.unitPriceCents * it.quantity, opts.currency)
+    lines.push(`• ${it.quantity}× ${name} — ${lineTotal}`)
+  }
+  lines.push('')
+  lines.push(`Subtotal: ${formatCents(opts.subtotalCents, opts.currency)}`)
+  lines.push('')
+  lines.push('¿Me confirmás disponibilidad y forma de pago? Gracias.')
+  if (opts.shopUrl) {
+    lines.push('')
+    lines.push(opts.shopUrl)
+  }
+
+  const text = encodeURIComponent(lines.join('\n'))
+  return `https://wa.me/${phone}?text=${text}`
+}


### PR DESCRIPTION
## Summary

PR 3 of the fun4me storefront polish. Adds the LATAM escape hatch: a \"Pedir por WhatsApp\" button that drops the shopper into a WA chat with the store, pre-loaded with cart line items + subtotal + a polite \"¿me confirmás stock y pago?\".

## Why

Not every shopper trusts card-not-present on a new-to-them shop. WhatsApp is the default commerce channel in Paraguay (Bancard transfer + comprobante by photo), and conversion on \"Pedir por WhatsApp\" is consistently higher than forcing tokenization.

## Changes

- `lib/commerce/whatsapp-cart-link.ts` — new builder for `https://wa.me/<digits>?text=…` with pre-filled cart
- `CartDrawer` — secondary CTA below \"Pagar ahora\" (brand WA green, official glyph)
- `CartPageClient` (/carrito) — secondary CTA below \"Finalizar compra\" with divider + reassurance line
- `CommerceHeader` — new optional `whatsappNumber` prop passed through to drawer
- 9 page.tsx call-sites updated to pass `business.whatsappNumber`

Tenant-gated: tenants without a WA number see the primary button only.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] fun4me `/carrito` with items → WA button renders, opens wa.me with cart summary
- [ ] fun4me cart drawer → same button renders below pay button
- [ ] Tenant without WA number → neither button renders
- [ ] Pre-filled text contains \"Hola [store], quiero confirmar este pedido:\" + line items + subtotal

🤖 Generated with [Claude Code](https://claude.com/claude-code)