### PR TITLE
feat(seo): nested indexable /tienda/categoria/[cat]/[tag]/ routes

### DIFF
--- a/web/app/s/[locale]/[site]/tienda/categoria/[category]/[tag]/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/categoria/[category]/[tag]/page.tsx
@@ -1,0 +1,264 @@
+import { notFound, redirect } from 'next/navigation'
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { resolveBusinessBySlug } from '@/lib/commerce/resolve-business'
+import {
+  countActiveProducts,
+  listActiveProducts,
+  listDistinctCategories,
+  listTagsForCategory,
+  type ProductSort,
+} from '@/lib/commerce/products'
+import { isCommerceEnabled } from '@/lib/commerce/capability'
+import { CommerceHeader } from '@/components/commerce/commerce-header'
+import { CommerceChrome } from '@/components/commerce/commerce-chrome'
+import { Breadcrumbs } from '@/components/commerce/breadcrumbs'
+import { env } from '@/lib/env'
+import type { Locale } from '@/lib/i18n/config'
+import { ProductCard } from '@/components/commerce/product-card'
+import { getSessionToken } from '@/lib/commerce/session'
+import { getCartBySessionToken } from '@/lib/commerce/cart'
+import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
+import { TiendaPagination } from '@/components/commerce/tienda-pagination'
+import { loadPygRates } from '@/lib/commerce/currency-server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const PAGE_SIZE = 24
+
+function parsePositiveInt(raw: string | undefined): number {
+  if (!raw) return 0
+  const n = parseInt(raw, 10)
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+function pretty(s: string): string {
+  const decoded = decodeURIComponent(s).replace(/-/g, ' ')
+  return decoded.charAt(0).toUpperCase() + decoded.slice(1)
+}
+
+export async function generateMetadata({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ site: string; locale: string; category: string; tag: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}): Promise<Metadata> {
+  const { site, locale, category, tag } = await params
+  const sp = await searchParams
+  const business = await resolveBusinessBySlug(site)
+  if (!business) return {}
+  const prettyCat = pretty(category)
+  const prettyTag = pretty(tag)
+  const canonical = `${env.APP_URL}/s/${locale}/${site}/tienda/categoria/${category}/${tag}`
+  const decodedCat = decodeURIComponent(category)
+  const decodedTag = decodeURIComponent(tag)
+  const count = await countActiveProducts(business.id, {
+    category: decodedCat,
+    tags: [decodedTag],
+  }).catch(() => 0)
+  // Transactional-intent title: "Comprar [Tag] [Category] en Paraguay | Store".
+  // Peer analysis: luden.store uses the same "Comprar X en Y" pattern and
+  // ranks consistently on Paraguay-specific long-tail terms.
+  const title = `Comprar ${prettyTag} ${prettyCat} en Paraguay | ${business.name}`
+  const description = count > 0
+    ? `${prettyTag} · ${prettyCat} en ${business.name}: ${count} producto${count === 1 ? '' : 's'} con envío discreto a todo Paraguay. Pagá por transferencia, tarjeta o WhatsApp.`
+    : `${prettyTag} · ${prettyCat} en ${business.name}. Envío discreto a todo Paraguay.`
+  // noindex if any filter param set — the clean nested URL is the one
+  // that should rank, permutations of it are duplicates.
+  const hasFilterParam = ['q', 'min', 'max', 'sort', 'page', 'in_stock', 'on_sale']
+    .some((k) => {
+      const v = sp[k]
+      return typeof v === 'string' ? v.length > 0 : Array.isArray(v) ? v.length > 0 : false
+    })
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: { url: canonical, title, description },
+    robots: count > 0 && !hasFilterParam
+      ? { index: true, follow: true }
+      : { index: false, follow: true },
+  }
+}
+
+/**
+ * Nested category+tag route: `/tienda/categoria/[cat]/[tag]/`.
+ *
+ * Peer analysis: luden.store surfaces URLs like `/dildos/dildos-realistas/`
+ * that rank on specific long-tail search — a pattern we'd missed by
+ * only indexing the flat /tienda and single-level /tienda/categoria/<cat>.
+ * This route produces one indexable page per (category, tag) pair that
+ * has ≥ 2 products in the catalog; the parent category page links in
+ * (see ./[category]/page.tsx) so Google can discover them via internal
+ * links without a sitemap change.
+ *
+ * 404 on unknown (category, tag) combo — we don't want to generate
+ * thin-content pages for every typo in the URL.
+ */
+export default async function CategoryTagPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ site: string; locale: string; category: string; tag: string }>
+  searchParams: Promise<{
+    q?: string
+    sort?: string
+    min?: string
+    max?: string
+    in_stock?: string
+    on_sale?: string
+    page?: string
+  }>
+}) {
+  const { site, locale, category: rawCat, tag: rawTag } = await params
+  const sp = await searchParams
+  const business = await resolveBusinessBySlug(site)
+  if (!business || !(await isCommerceEnabled(business.type))) notFound()
+
+  const categorySlug = decodeURIComponent(rawCat).trim()
+  const tagSlug = decodeURIComponent(rawTag).trim()
+  if (!categorySlug || !tagSlug) redirect(`/s/${locale}/${site}/tienda`)
+
+  const availableCats = await listDistinctCategories(business.id)
+  const matchCat = availableCats.find((c) => c.toLowerCase() === categorySlug.toLowerCase())
+  if (!matchCat) {
+    redirect(`/s/${locale}/${site}/tienda?category=${encodeURIComponent(categorySlug)}`)
+  }
+
+  // Validate the tag belongs to this category with ≥1 product so we
+  // don't generate thin-content pages for arbitrary tag typos.
+  const tagsInCat = await listTagsForCategory(business.id, matchCat)
+  const matchTag = tagsInCat.find((t) => t.tag.toLowerCase() === tagSlug.toLowerCase())
+  if (!matchTag) notFound()
+
+  const search = (sp.q ?? '').trim()
+  const minPriceCents = parsePositiveInt(sp.min)
+  const maxPriceCents = parsePositiveInt(sp.max)
+  const inStockOnly = sp.in_stock === '1' || sp.in_stock === 'true'
+  const onSaleOnly = sp.on_sale === '1' || sp.on_sale === 'true'
+  const sortKey: ProductSort = (sp.sort as ProductSort) || 'newest'
+  const page = Math.max(1, parsePositiveInt(sp.page) || 1)
+  const offset = (page - 1) * PAGE_SIZE
+
+  const filterOpts = {
+    category: matchCat,
+    tags: [matchTag.tag],
+    search,
+    minPriceCents: minPriceCents || undefined,
+    maxPriceCents: maxPriceCents || undefined,
+    inStockOnly,
+    onSaleOnly,
+  }
+
+  const [products, totalCount, rates] = await Promise.all([
+    listActiveProducts(business.id, { ...filterOpts, limit: PAGE_SIZE, offset, sort: sortKey }),
+    countActiveProducts(business.id, filterOpts),
+    loadPygRates(),
+  ])
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
+
+  const sessionToken = await getSessionToken()
+  const initialCart = sessionToken
+    ? await getCartBySessionToken(business.id, sessionToken).catch(() => null)
+    : null
+
+  const prettyCat = matchCat.charAt(0).toUpperCase() + matchCat.slice(1)
+  const prettyTag = matchTag.tag.replace(/-/g, ' ')
+  const prettyTagTitle = prettyTag.charAt(0).toUpperCase() + prettyTag.slice(1)
+
+  return (
+    <div className="min-h-screen bg-[color:var(--surface-muted,#f9fafb)]">
+      <CartStoreHydrator siteSlug={site} initialCart={initialCart} />
+      <CommerceHeader siteSlug={site} businessName={business.name} locale={locale} whatsappNumber={business.whatsappNumber} />
+
+      <Breadcrumbs
+        absoluteBaseUrl={env.APP_URL}
+        items={[
+          { label: business.name, href: `/s/${locale}/${site}` },
+          { label: 'Tienda', href: `/s/${locale}/${site}/tienda` },
+          { label: prettyCat, href: `/s/${locale}/${site}/tienda/categoria/${encodeURIComponent(matchCat)}` },
+          { label: prettyTagTitle },
+        ]}
+      />
+
+      <main className="mx-auto max-w-6xl px-4 py-8">
+        <div className="mb-6 rounded-lg bg-[color:var(--primary,#111)] p-6 text-[color:var(--primary-foreground,#fff)] sm:p-8">
+          <h1 className="text-3xl font-bold">
+            {prettyTagTitle} · <span className="opacity-80">{prettyCat}</span>
+          </h1>
+          <p className="mt-1 text-sm opacity-90">
+            {totalCount} {totalCount === 1 ? 'producto' : 'productos'} de {prettyTagTitle.toLowerCase()} en {prettyCat.toLowerCase()} con envío discreto a todo Paraguay.
+          </p>
+        </div>
+
+        {products.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] p-12 text-center">
+            <p className="text-[color:var(--text-muted,#6b7280)]">
+              No hay productos en <strong>{prettyTag}</strong> dentro de {prettyCat}.
+            </p>
+            <Link
+              href={`/s/${locale}/${site}/tienda/categoria/${encodeURIComponent(matchCat)}`}
+              className="mt-4 inline-block rounded-md bg-[color:var(--primary,#111)] px-4 py-2 text-sm font-semibold text-[color:var(--primary-foreground,#fff)]"
+            >
+              Ver toda la categoría {prettyCat}
+            </Link>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 gap-4 min-[420px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 lg:gap-6">
+              {products.map((product, idx) => (
+                <ProductCard
+                  key={product.id}
+                  siteSlug={site}
+                  product={product}
+                  priority={idx < 4}
+                  rates={rates}
+                  locale={locale}
+                />
+              ))}
+            </div>
+
+            {totalPages > 1 ? (
+              <div className="mt-10">
+                <TiendaPagination currentPage={page} totalPages={totalPages} />
+              </div>
+            ) : null}
+          </>
+        )}
+
+        {/* Sibling tag links inside the same category — internal linking
+            so Google finds adjacent subcategory pages without a sitemap. */}
+        {tagsInCat.length > 1 ? (
+          <nav
+            aria-label="Otras subcategorías"
+            className="mt-10 border-t border-[color:var(--border,#e5e7eb)] pt-6"
+          >
+            <p className="mb-3 text-sm font-medium text-[color:var(--text,#111)]">
+              Otras subcategorías en {prettyCat}
+            </p>
+            <ul className="flex flex-wrap gap-2 text-xs">
+              {tagsInCat
+                .filter((t) => t.tag !== matchTag.tag)
+                .slice(0, 12)
+                .map((t) => (
+                  <li key={t.tag}>
+                    <Link
+                      href={`/s/${locale}/${site}/tienda/categoria/${encodeURIComponent(matchCat)}/${encodeURIComponent(t.tag)}`}
+                      className="rounded-full border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-3 py-1 capitalize hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+                    >
+                      {t.tag.replace(/-/g, ' ')}{' '}
+                      <span className="opacity-60">({t.count})</span>
+                    </Link>
+                  </li>
+                ))}
+            </ul>
+          </nav>
+        ) : null}
+      </main>
+
+      <CommerceChrome siteSlug={site} locale={locale as Locale} />
+    </div>
+  )
+}

--- a/web/app/s/[locale]/[site]/tienda/categoria/[category]/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/categoria/[category]/page.tsx
@@ -6,6 +6,7 @@ import {
   countActiveProducts,
   listActiveProducts,
   listDistinctCategories,
+  listTagsForCategory,
   type ProductSort,
 } from '@/lib/commerce/products'
 import { isCommerceEnabled } from '@/lib/commerce/capability'
@@ -48,11 +49,15 @@ export async function generateMetadata({
       const v = sp[k]
       return typeof v === 'string' ? v.length > 0 : Array.isArray(v) ? v.length > 0 : false
     })
+  // Transactional-intent title: "Comprar [Category] en Paraguay | Store".
+  // Peer analysis (luden.store) ranks consistently on this pattern for
+  // Paraguay-specific long-tail.
+  const title = `Comprar ${pretty} en Paraguay | ${business.name}`
   return {
-    title: `${pretty} — ${business.name}`,
+    title,
     description,
     alternates: { canonical },
-    openGraph: { url: canonical, title: `${pretty} — ${business.name}`, description },
+    openGraph: { url: canonical, title, description },
     robots: hasFilterParam
       ? { index: false, follow: true }
       : { index: true, follow: true },
@@ -131,10 +136,11 @@ export default async function CategoryPage({
     onSaleOnly,
   }
 
-  const [products, totalCount, rates] = await Promise.all([
+  const [products, totalCount, rates, tagsInCat] = await Promise.all([
     listActiveProducts(business.id, { ...filterOpts, limit: PAGE_SIZE, offset, sort: sortKey }),
     countActiveProducts(business.id, filterOpts),
     loadPygRates(),
+    listTagsForCategory(business.id, match),
   ])
 
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
@@ -166,6 +172,28 @@ export default async function CategoryPage({
             {totalCount} {totalCount === 1 ? 'producto disponible' : 'productos disponibles'} en {match}.
           </p>
         </div>
+
+        {/* Subcategory shortcuts — indexable nested URLs per (category, tag).
+            Placed high on the page so Google crawls the internal links on
+            the first pass. Peer analysis: luden.store surfaces these as
+            the primary merchandising hook on the category page. */}
+        {tagsInCat.length >= 2 ? (
+          <nav aria-label="Subcategorías" className="mb-5">
+            <ul className="flex flex-wrap gap-2 text-xs">
+              {tagsInCat.slice(0, 10).map((t) => (
+                <li key={t.tag}>
+                  <Link
+                    href={`/s/${locale}/${site}/tienda/categoria/${encodeURIComponent(match)}/${encodeURIComponent(t.tag)}`}
+                    className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--border,#e5e7eb)] bg-[color:var(--surface,#fff)] px-3 py-1.5 font-medium capitalize hover:border-[color:var(--primary,#111)] hover:bg-[color:var(--surface-muted,#f3f4f6)]"
+                  >
+                    {t.tag.replace(/-/g, ' ')}
+                    <span className="text-[color:var(--text-muted,#9ca3af)]">({t.count})</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        ) : null}
 
         <TiendaToolbar
           initialQuery={search}

--- a/web/lib/commerce/products.ts
+++ b/web/lib/commerce/products.ts
@@ -271,6 +271,40 @@ export async function listDistinctTags(businessId: string): Promise<string[]> {
 }
 
 /**
+ * Tags ranked by count among active products in a given category. Powers
+ * the internal-linking block on the category page (Luden-style "Comprar
+ * [Tag] [Category]" nested URLs) — we only want to link to tag pages
+ * that actually have inventory, and we want the most-populated tags
+ * surfaced first so Google spiders the pages that matter.
+ *
+ * Returns `[{ tag, count }]` sorted by count desc. Tags with count < 2
+ * are filtered out (a 1-product "category" is thin content).
+ */
+export async function listTagsForCategory(
+  businessId: string,
+  category: string,
+): Promise<Array<{ tag: string; count: number }>> {
+  const supabase = await createAdminClient()
+  const { data } = await supabase
+    .from('products')
+    .select('tags')
+    .eq('business_id', businessId)
+    .eq('status', 'active')
+    .eq('category', category)
+  const counts = new Map<string, number>()
+  for (const row of (Array.isArray(data) ? data : []) as Array<{ tags: string[] | null }>) {
+    for (const t of row.tags ?? []) {
+      if (!t) continue
+      counts.set(t, (counts.get(t) ?? 0) + 1)
+    }
+  }
+  return Array.from(counts.entries())
+    .filter(([, count]) => count >= 2)
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag, 'es'))
+}
+
+/**
  * Category counts for faceted filtering. Pulls every active product's
  * category in one query and aggregates client-side — cheap enough for the
  * product counts we care about (<5k active per tenant).


### PR DESCRIPTION
## Summary

PR B of the luden.store-inspired polish. Closes the biggest SEO gap: every (category, tag) pair with ≥ 2 products gets its own indexable landing page with a transactional-intent title, product count, and internal linking from the parent category.

### Why

luden.store ranks on `/dildos/dildos-realistas/` style long-tail URLs. Our current `/tienda?category=dildos&tag=realistas` is `noindex` (PR #332) — invisible to Google. New nested route fixes the \"no target URL to rank\" problem.

### New route

`web/app/s/[locale]/[site]/tienda/categoria/[category]/[tag]/page.tsx`

- Title: \"Comprar [Tag] [Category] en Paraguay | [Business]\"
- Product-count-aware meta description + self-canonical
- BreadcrumbList JSON-LD (via existing `<Breadcrumbs>`)
- `noindex` when filter params set (only clean URL ranks)
- 404 on unknown (cat, tag) combos — no thin-content pages for typos

### Internal linking

- Parent `/tienda/categoria/[cat]/` now renders a top-10 tag nav above the grid, linking to nested URLs with product counts
- Nested page has sibling-tag rail at bottom

### Supporting

- `listTagsForCategory(businessId, category)` — new helper, filters `count < 2` server-side
- Parent category title changed from \"[Cat] — Fun4Me\" to \"Comprar [Cat] en Paraguay | Fun4Me\" (transactional-intent)

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] `/tienda/categoria/vibradores/` → tag nav renders with counts
- [ ] `/tienda/categoria/vibradores/silicona/` (assuming the tag exists) → indexable page, correct title, breadcrumbs show 4 levels
- [ ] `/tienda/categoria/vibradores/nonexistent-tag/` → 404
- [ ] `/tienda/categoria/vibradores/silicona/?sort=price-asc` → robots: noindex, follow (filtered view)
- [ ] Click sibling-tag link → navigates correctly
- [ ] View page source on nested page: `<title>Comprar Silicona Vibradores en Paraguay | Fun4Me</title>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)