### PR TITLE
fix(i18n): stop Spanish leaks on /s/en tenant pages

### DIFF
--- a/web/components/sections/portfolio-section.tsx
+++ b/web/components/sections/portfolio-section.tsx
@@ -20,14 +20,26 @@ interface PortfolioSectionProps {
   subtitle?: string
   items: PortfolioItem[]
   categories?: string[]
+  __locale?: string
+}
+
+const PORTFOLIO_LABELS: Record<string, { title: string; all: string }> = {
+  en: { title: 'Our Portfolio', all: 'All' },
+  es: { title: 'Nuestro Portafolio', all: 'Todos' },
+  de: { title: 'Unser Portfolio', all: 'Alle' },
+  pt: { title: 'Nosso Portfólio', all: 'Todos' },
+  nl: { title: 'Ons Portfolio', all: 'Alle' },
 }
 
 export function PortfolioSection({
-  title = 'Nuestro Portafolio',
+  title,
   subtitle,
   items,
-  categories = []
+  categories = [],
+  __locale = 'es',
 }: PortfolioSectionProps) {
+  const labels = PORTFOLIO_LABELS[__locale] ?? PORTFOLIO_LABELS.es
+  const resolvedTitle = title ?? labels.title
   const [selectedCategory, setSelectedCategory] = useState<string>('all')
 
   const filteredItems = selectedCategory === 'all'
@@ -47,7 +59,7 @@ export function PortfolioSection({
       <div className="mx-auto max-w-6xl px-4">
         <div className="text-center mb-12">
           <Heading level={2} className="text-3xl font-bold text-[var(--text)]" style={{ fontFamily: 'var(--font-heading)' }}>
-            {title}
+            {resolvedTitle}
           </Heading>
           {subtitle && (
             <p className="mt-2 text-[var(--text-muted)]">{subtitle}</p>
@@ -64,7 +76,7 @@ export function PortfolioSection({
                   : 'bg-[var(--surface-light)] text-[var(--text)] hover:bg-[var(--primary)] hover:text-white'
               }`}
             >
-              Todos
+              {labels.all}
             </button>
             {uniqueCategories.map(cat => (
               <button

--- a/web/components/sections/process-section.tsx
+++ b/web/components/sections/process-section.tsx
@@ -27,15 +27,33 @@ const STEP_LABELS: Record<string, string> = {
   nl: 'Stap',
 }
 
+const TITLE_DEFAULTS: Record<string, string> = {
+  en: 'Our Process',
+  es: 'Nuestro Proceso',
+  de: 'Unser Prozess',
+  pt: 'Nosso Processo',
+  nl: 'Ons Proces',
+}
+
+const CTA_DEFAULTS: Record<string, string> = {
+  en: 'Start my process',
+  es: 'Iniciar mi proceso',
+  de: 'Prozess starten',
+  pt: 'Iniciar meu processo',
+  nl: 'Start mijn proces',
+}
+
 export function ProcessSection({
-  title = 'Nuestro Proceso',
+  title,
   subtitle,
   steps = [],
-  ctaText = 'Iniciar mi proceso',
+  ctaText,
   ctaLink = '#contact',
   __locale = 'es',
 }: ProcessSectionProps) {
   const stepLabel = STEP_LABELS[__locale] || 'Paso'
+  const resolvedTitle = title ?? TITLE_DEFAULTS[__locale] ?? TITLE_DEFAULTS.es
+  const resolvedCtaText = ctaText ?? CTA_DEFAULTS[__locale] ?? CTA_DEFAULTS.es
   const [activeStep, setActiveStep] = useState<number | null>(null)
 
   if (!steps.length) {
@@ -45,9 +63,9 @@ export function ProcessSection({
   return (
     <section className="py-16 md:py-24">
       <div className="mx-auto max-w-6xl px-4">
-        {title && (
+        {resolvedTitle && (
           <Heading level={2} className="mb-4 text-3xl font-bold md:text-4xl" style={{ color: 'var(--primary)' }}>
-            {title}
+            {resolvedTitle}
           </Heading>
         )}
         {subtitle && (
@@ -121,7 +139,7 @@ export function ProcessSection({
           </div>
         </div>
 
-        {ctaText && (
+        {resolvedCtaText && (
           <div className="mt-12 text-center">
             <a
               href={ctaLink}
@@ -131,7 +149,7 @@ export function ProcessSection({
                 color: 'var(--primary-foreground)',
               }}
             >
-              {ctaText}
+              {resolvedCtaText}
             </a>
           </div>
         )}

--- a/web/components/sections/product-catalog-section.tsx
+++ b/web/components/sections/product-catalog-section.tsx
@@ -29,6 +29,64 @@ export interface ProductCatalogSectionProps {
   orderButtonText?: string
   orderMessageTemplate?: string
   emailAddress?: string
+  __locale?: string
+}
+
+const CATALOG_LABELS: Record<
+  string,
+  {
+    all: string
+    orderButton: string
+    orderTemplate: string
+    emailSubject: (name: string) => string
+    emailBody: (name: string, price?: string) => string
+  }
+> = {
+  en: {
+    all: 'All',
+    orderButton: 'Ask via WhatsApp',
+    orderTemplate:
+      "Hi! I'm interested in: {{productName}} (${{productPrice}}). Could you tell me more?",
+    emailSubject: (name) => `Inquiry: ${name}`,
+    emailBody: (name, price) =>
+      `Hi! I'm interested in "${name}"${price ? ` ($${price})` : ''}. Could you send more info?`,
+  },
+  es: {
+    all: 'Todos',
+    orderButton: 'Consultar por WhatsApp',
+    orderTemplate:
+      'Hola! Me interesa el diseno: {{productName}} (${{productPrice}}). Quisiera mas informacion.',
+    emailSubject: (name) => `Consulta: ${name}`,
+    emailBody: (name, price) =>
+      `Hola! Me interesa el diseno "${name}"${price ? ` ($${price})` : ''}. Quisiera mas informacion.`,
+  },
+  de: {
+    all: 'Alle',
+    orderButton: 'Über WhatsApp anfragen',
+    orderTemplate:
+      'Hallo! Ich interessiere mich für: {{productName}} (${{productPrice}}). Können Sie mir mehr Informationen geben?',
+    emailSubject: (name) => `Anfrage: ${name}`,
+    emailBody: (name, price) =>
+      `Hallo! Ich interessiere mich für "${name}"${price ? ` ($${price})` : ''}. Können Sie mir mehr Informationen senden?`,
+  },
+  pt: {
+    all: 'Todos',
+    orderButton: 'Consultar pelo WhatsApp',
+    orderTemplate:
+      'Olá! Tenho interesse em: {{productName}} (${{productPrice}}). Poderia me enviar mais informações?',
+    emailSubject: (name) => `Consulta: ${name}`,
+    emailBody: (name, price) =>
+      `Olá! Tenho interesse em "${name}"${price ? ` ($${price})` : ''}. Poderia me enviar mais informações?`,
+  },
+  nl: {
+    all: 'Alle',
+    orderButton: 'Vraag via WhatsApp',
+    orderTemplate:
+      'Hallo! Ik heb interesse in: {{productName}} (${{productPrice}}). Kunt u mij meer vertellen?',
+    emailSubject: (name) => `Aanvraag: ${name}`,
+    emailBody: (name, price) =>
+      `Hallo! Ik heb interesse in "${name}"${price ? ` ($${price})` : ''}. Kunt u mij meer informatie sturen?`,
+  },
 }
 
 function buildWhatsAppUrl(
@@ -43,11 +101,13 @@ function buildWhatsAppUrl(
   return `https://wa.me/${cleanPhone}?text=${encodeURIComponent(message)}`
 }
 
-function buildEmailUrl(email: string, product: ProductItem): string {
-  const subject = encodeURIComponent(`Consulta: ${product.name}`)
-  const body = encodeURIComponent(
-    `Hola! Me interesa el diseno "${product.name}"${product.price ? ` ($${product.price})` : ''}. Quisiera mas informacion.`
-  )
+function buildEmailUrl(
+  email: string,
+  product: ProductItem,
+  labels: (typeof CATALOG_LABELS)[string],
+): string {
+  const subject = encodeURIComponent(labels.emailSubject(product.name))
+  const body = encodeURIComponent(labels.emailBody(product.name, product.price))
   return `mailto:${email}?subject=${subject}&body=${body}`
 }
 
@@ -59,6 +119,8 @@ function ProductCard({
   orderMessageTemplate,
   emailAddress,
   index,
+  labels,
+  unavailableText,
 }: {
   product: ProductItem
   showPrices: boolean
@@ -67,6 +129,8 @@ function ProductCard({
   orderMessageTemplate: string
   emailAddress?: string
   index: number
+  labels: (typeof CATALOG_LABELS)[string]
+  unavailableText: string
 }) {
   const isAvailable = product.available !== false
 
@@ -92,7 +156,7 @@ function ProductCard({
 
           <div className="mt-auto flex flex-col gap-2 pt-4">
             {!isAvailable && (
-              <Badge variant="muted" className="self-start">No disponible</Badge>
+              <Badge variant="muted" className="self-start">{unavailableText}</Badge>
             )}
             {isAvailable && whatsappPhone && (
               <Button
@@ -110,7 +174,7 @@ function ProductCard({
               <Button
                 variant="primary"
                 size="sm"
-                href={buildEmailUrl(emailAddress, product)}
+                href={buildEmailUrl(emailAddress, product, labels)}
               >
                 {orderButtonText}
               </Button>
@@ -130,10 +194,15 @@ export function ProductCatalogSection({
   categories,
   showPrices = true,
   whatsappPhone,
-  orderButtonText = 'Consultar por WhatsApp',
-  orderMessageTemplate = 'Hola! Me interesa el diseno: {{productName}} (${{productPrice}}). Quisiera mas informacion.',
+  orderButtonText,
+  orderMessageTemplate,
   emailAddress,
+  __locale = 'es',
 }: ProductCatalogSectionProps) {
+  const labels = CATALOG_LABELS[__locale] ?? CATALOG_LABELS.es
+  const resolvedOrderButton = orderButtonText ?? labels.orderButton
+  const resolvedOrderTemplate = orderMessageTemplate ?? labels.orderTemplate
+  const unavailableText = __locale === 'en' ? 'Unavailable' : 'No disponible'
   const products = productsProp || items || []
 
   // Hooks must be called before any early return — conditional hook calls
@@ -174,7 +243,7 @@ export function ProductCatalogSection({
                   : 'bg-[var(--surface)] text-[var(--text-muted)] hover:bg-[var(--surface)] hover:text-[var(--text)]'
               }`}
             >
-              Todos
+              {labels.all}
             </button>
             {allCategories.map((cat) => (
               <button
@@ -200,17 +269,21 @@ export function ProductCatalogSection({
               product={product}
               showPrices={showPrices}
               whatsappPhone={whatsappPhone}
-              orderButtonText={orderButtonText}
-              orderMessageTemplate={orderMessageTemplate}
+              orderButtonText={resolvedOrderButton}
+              orderMessageTemplate={resolvedOrderTemplate}
               emailAddress={emailAddress}
               index={index}
+              labels={labels}
+              unavailableText={unavailableText}
             />
           ))}
         </div>
 
         {filteredProducts.length === 0 && (
           <p className="py-12 text-center text-[var(--text-muted)]">
-            No hay productos disponibles en esta categoria.
+            {__locale === 'en'
+              ? 'No products available in this category.'
+              : 'No hay productos disponibles en esta categoria.'}
           </p>
         )}
       </Container>

--- a/web/components/ui/skip-to-content.tsx
+++ b/web/components/ui/skip-to-content.tsx
@@ -1,10 +1,32 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+
+const LABELS: Record<string, string> = {
+  en: 'Skip to main content',
+  es: 'Saltar al contenido principal',
+  de: 'Zum Hauptinhalt springen',
+  pt: 'Ir para o conteúdo principal',
+  nl: 'Naar hoofdinhoud',
+}
+
+function localeFromPath(pathname: string | null): string {
+  if (!pathname) return 'es'
+  const parts = pathname.split('/').filter(Boolean)
+  if (parts[0] === 's' && parts[1] && LABELS[parts[1]]) return parts[1]
+  if (parts[0] === 'en' && parts[1] === 'p') return 'en'
+  return 'es'
+}
+
 export function SkipToContent({ targetId = 'main-content' }: { targetId?: string }) {
+  const pathname = usePathname()
+  const label = LABELS[localeFromPath(pathname)] ?? LABELS.es
   return (
     <a
       href={`#${targetId}`}
       className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-md focus:bg-[var(--primary)] focus:px-4 focus:py-2 focus:text-[var(--primary-foreground)] focus:shadow-lg focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-[var(--accent)]"
     >
-      Saltar al contenido principal
+      {label}
     </a>
   )
 }


### PR DESCRIPTION
## Summary

- Reported: https://paragu-ai.com/s/en/dayah-litworks had Spanish text leaking in (user described it as "German" — was actually Spanish bleeding into the English page).
- Four components had hardcoded Spanish strings or Spanish-only defaults that rendered whenever the `__locale` was `en` but content didn't explicitly override.

## Specific leaks found on /s/en/dayah-litworks

| Component | Leak | Fix |
|---|---|---|
| `skip-to-content.tsx` | "Saltar al contenido principal" hardcoded | Read locale from pathname, pick label from dict |
| `product-catalog-section.tsx` | "Todos" filter tab + "Consultar por WhatsApp" button + "No disponible" badge + Spanish email body | `__locale`-aware defaults + empty-state + email helper |
| `portfolio-section.tsx` | "Todos" filter tab + "Nuestro Portafolio" default title | `__locale`-aware defaults |
| `process-section.tsx` | "Iniciar mi proceso" CTA + "Nuestro Proceso" title defaults | Added to existing `__locale` pattern |

`__locale` was already being spread into every section's props by `compose-site.ts:154`, so no composer changes were needed.

## Test plan

- [x] TypeScript: `npx tsc --noEmit` clean on touched files
- [ ] After merge + VPS redeploy, curl `/s/en/dayah-litworks` and grep for leaked strings (`Todos`, `Saltar`, `Iniciar mi proceso`, `No disponible`, `Consultar por WhatsApp`)
- [ ] Visual check that `/s/es/dayah-litworks` still renders correctly (no English leaks)
- [ ] Spot-check one non-dayah tenant's catalog/portfolio sections (salon-maria, gymfit-py) to ensure nothing regressed