### PR TITLE
dayah: complete overhaul — en+es only, real services, T&C, bio, blog/portfolio placeholders

### DIFF
--- a/sites/dayah-litworks/content/en.json
+++ b/sites/dayah-litworks/content/en.json
@@ -9,18 +9,54 @@
   "faq": {
     "title": "Frequently Asked Questions",
     "items": [
-      { "question": "How long does a custom cover take?", "answer": "1–3 weeks depending on project complexity. Premades are delivered in 1–2 weeks." },
-      { "question": "How many revisions are included?", "answer": "Revisions within the predefined plan are included. Additional changes beyond scope may have extra cost." },
-      { "question": "What's the payment process?", "answer": "50% advance to start. Balance upon final design approval. We accept Western Union, bank transfer and cash." },
-      { "question": "What currency do you charge in?", "answer": "We charge in USD and guaraníes (₲). See our pricing table for both currencies." },
-      { "question": "Can I use the cover on Amazon KDP / Wattpad / publishers?", "answer": "Yes. Design rights belong to Dayah LitWorks until full payment. Once paid 100%, you can use the cover on any platform." },
-      { "question": "What is a 3D mockup?", "answer": "A realistic 3D render of your book. Perfect for social media promotion and marketing." },
-      { "question": "What if I cancel the project?", "answer": "If the client cancels after work has started, the advance payment is non-refundable." },
-      { "question": "Do you redesign existing covers?", "answer": "Yes, you can hire a redesign as a custom cover. Send us your current cover and new ideas." },
-      { "question": "What do I need to get started?", "answer": "Book title, synopsis, genre, visual references (ideas, fonts, colors, styles). Send references BEFORE requesting design." },
-      { "question": "What language do you design in?", "answer": "We design covers in Spanish and English. Typography adapts to your book's language." },
-      { "question": "Can I request rush delivery (48–72h)?", "answer": "Contact us on WhatsApp to check availability. Rush projects may have a surcharge." },
-      { "question": "How are final files delivered?", "answer": "High-resolution files (JPG, PDF, PNG) ready to upload to your platform. Mockups delivered as rendered images." }
+      {
+        "question": "How long does a custom cover take?",
+        "answer": "1–3 weeks depending on project complexity. Premades are delivered in 1–2 weeks."
+      },
+      {
+        "question": "How many revisions are included?",
+        "answer": "Revisions within the predefined plan are included. Additional changes beyond scope may have extra cost."
+      },
+      {
+        "question": "What's the payment process?",
+        "answer": "50% advance to start. Balance upon final design approval. We accept Western Union, bank transfer and cash."
+      },
+      {
+        "question": "What currency do you charge in?",
+        "answer": "We charge in USD and guaraníes (₲). See our pricing table for both currencies."
+      },
+      {
+        "question": "Can I use the cover on Amazon KDP / Wattpad / publishers?",
+        "answer": "Yes. Design rights belong to Dayah LitWorks until full payment. Once paid 100%, you can use the cover on any platform."
+      },
+      {
+        "question": "What is a 3D mockup?",
+        "answer": "A realistic 3D render of your book. Perfect for social media promotion and marketing."
+      },
+      {
+        "question": "What if I cancel the project?",
+        "answer": "If the client cancels after work has started, the advance payment is non-refundable."
+      },
+      {
+        "question": "Do you redesign existing covers?",
+        "answer": "Yes, you can hire a redesign as a custom cover. Send us your current cover and new ideas."
+      },
+      {
+        "question": "What do I need to get started?",
+        "answer": "Book title, synopsis, genre, visual references (ideas, fonts, colors, styles). Send references BEFORE requesting design."
+      },
+      {
+        "question": "What language do you design in?",
+        "answer": "We design covers in Spanish and English. Typography adapts to your book's language."
+      },
+      {
+        "question": "Can I request rush delivery (48–72h)?",
+        "answer": "Contact us on WhatsApp to check availability. Rush projects may have a surcharge."
+      },
+      {
+        "question": "How are final files delivered?",
+        "answer": "High-resolution files (JPG, PDF, PNG) ready to upload to your platform. Mockups delivered as rendered images."
+      }
     ]
   },
   "faqPage": {
@@ -47,13 +83,34 @@
   "navigation": {
     "businessName": "Dayah LitWorks",
     "items": [
-      { "label": "Home", "href": "/s/en/dayah-litworks" },
-      { "label": "Services", "href": "/s/en/dayah-litworks/servicios" },
-      { "label": "Catalog", "href": "/s/en/dayah-litworks/catalogo" },
-      { "label": "Portfolio", "href": "/s/en/dayah-litworks/portafolio" },
-      { "label": "Blog", "href": "/s/en/dayah-litworks/blog" },
-      { "label": "About", "href": "/s/en/dayah-litworks/sobre" },
-      { "label": "Contact", "href": "/s/en/dayah-litworks/contacto" }
+      {
+        "label": "Home",
+        "href": "/s/en/dayah-litworks"
+      },
+      {
+        "label": "Services",
+        "href": "/s/en/dayah-litworks/servicios"
+      },
+      {
+        "label": "Catalog",
+        "href": "/s/en/dayah-litworks/catalogo"
+      },
+      {
+        "label": "Portfolio",
+        "href": "/s/en/dayah-litworks/portafolio"
+      },
+      {
+        "label": "Blog",
+        "href": "/s/en/dayah-litworks/blog"
+      },
+      {
+        "label": "About",
+        "href": "/s/en/dayah-litworks/sobre"
+      },
+      {
+        "label": "Contact",
+        "href": "/s/en/dayah-litworks/contacto"
+      }
     ],
     "ctaText": "Contact",
     "ctaHref": "https://wa.me/595986868241"
@@ -74,10 +131,26 @@
     "trustBadges": {
       "title": "Why Choose Us",
       "badges": [
-        { "icon": "palette", "label": "Professional design", "description": "Covers that sell books" },
-        { "icon": "globe", "label": "Global clients", "description": "Authors in USA, Europe and LATAM" },
-        { "icon": "dollar-sign", "label": "USD & guaraníes", "description": "Payment in both currencies" },
-        { "icon": "zap", "label": "Fast delivery", "description": "1–3 weeks depending on service" }
+        {
+          "icon": "palette",
+          "label": "Professional design",
+          "description": "Covers that sell books"
+        },
+        {
+          "icon": "globe",
+          "label": "Global clients",
+          "description": "Authors in USA, Europe and LATAM"
+        },
+        {
+          "icon": "dollar-sign",
+          "label": "USD & guaraníes",
+          "description": "Payment in both currencies"
+        },
+        {
+          "icon": "zap",
+          "label": "Fast delivery",
+          "description": "1–3 weeks depending on service"
+        }
       ]
     },
     "services": {
@@ -224,54 +297,333 @@
           "price": "Per evaluation",
           "description": "Priced based on evaluation of first chapters and manuscript length"
         }
+      ],
+      "items": [
+        {
+          "name": "Custom Cover — eBook",
+          "priceUSD": "$45",
+          "pricePYG": "₲300,000",
+          "delivery": "1–2 weeks",
+          "description": "Exclusive eBook cover design",
+          "includes": [
+            "eBook cover (JPG/PDF)",
+            "Title PNG + Title page PNG",
+            "2 cover reveal banners",
+            "2 Mockups"
+          ],
+          "category": "Custom Covers"
+        },
+        {
+          "name": "Custom Cover — Paperback",
+          "priceUSD": "$80",
+          "pricePYG": "₲500,000",
+          "delivery": "1–2 weeks",
+          "description": "Full cover (front + spine + back) for print",
+          "includes": [
+            "Paperback cover (JPG/PDF)",
+            "Print-ready file (PDF)",
+            "Title PNG + Title page PNG",
+            "2 cover reveal banners",
+            "2 Mockups"
+          ],
+          "category": "Custom Covers"
+        },
+        {
+          "name": "Cover Paperback & eBook",
+          "priceUSD": "$120",
+          "pricePYG": "₲800,000",
+          "delivery": "2–3 weeks",
+          "description": "Complete combo: eBook + paperback cover",
+          "includes": [
+            "eBook cover (JPG/PDF)",
+            "Print-ready file (PDF)",
+            "Title PNG + Title page PNG",
+            "2 cover reveal banners",
+            "2 Mockups"
+          ],
+          "category": "Custom Covers"
+        },
+        {
+          "name": "Premade eBook",
+          "priceUSD": "$35",
+          "pricePYG": "₲250,000",
+          "delivery": "1–2 weeks",
+          "description": "Premade eBook cover with customization",
+          "includes": [
+            "eBook cover (JPG/PDF)",
+            "Title PNG + Title page PNG",
+            "2 cover reveal banners",
+            "2 Mockups"
+          ],
+          "scopeNote": "Includes copy and typography alterations, color changes, minor element repositioning",
+          "category": "Premade Covers"
+        },
+        {
+          "name": "Premade eBook & Paperback",
+          "priceUSD": "$80",
+          "pricePYG": "₲500,000",
+          "delivery": "1–2 weeks",
+          "description": "Premade cover with paperback version",
+          "includes": [
+            "Paperback cover (JPG/PDF)",
+            "Print-ready file (PDF)",
+            "Title PNG + Title page PNG",
+            "2 cover reveal banners",
+            "2 Mockups"
+          ],
+          "category": "Premade Covers"
+        },
+        {
+          "name": "eBook Layout",
+          "priceUSD": "$25",
+          "pricePYG": "₲160,000",
+          "delivery": "1–2 weeks",
+          "description": "Professional interior design for eBooks",
+          "includes": [
+            "Professional interior design",
+            "File per platform specs (WORD/PDF)"
+          ],
+          "category": "Interior Layout"
+        },
+        {
+          "name": "Paperback Layout",
+          "priceUSD": "$35",
+          "pricePYG": "₲250,000",
+          "delivery": "1–2 weeks",
+          "description": "Professional interior design for print",
+          "includes": [
+            "Professional interior design",
+            "File per platform specs (WORD/PDF)"
+          ],
+          "category": "Interior Layout"
+        },
+        {
+          "name": "eBook & Paperback Layout",
+          "priceUSD": "$50",
+          "pricePYG": "₲320,000",
+          "delivery": "1–2 weeks",
+          "description": "Complete interior design for both formats",
+          "includes": [
+            "Professional interior design",
+            "File per platform specs (WORD/PDF)"
+          ],
+          "category": "Interior Layout"
+        }
       ]
     },
     "products": {
       "title": "Premade Catalog",
       "subtitle": "Ready-to-use designs — customization included",
-      "categories": ["All", "Fantasy", "Romance", "Thriller", "Sci-Fi", "Horror"],
+      "categories": [
+        "All",
+        "Fantasy",
+        "Romance",
+        "Thriller",
+        "Sci-Fi",
+        "Horror"
+      ],
       "items": [
-        { "name": "Whispers of the Forest", "priceUSD": "$35", "pricePYG": "₲250,000", "description": "Premade cover — Fantasy/Romance", "category": "Fantasy", "imageUrl": "", "available": true, "format": "eBook", "includes": ["eBook cover (JPG/PDF)", "Title PNG + Title page PNG", "2 reveal banners", "2 mockups"], "ctaHref": "https://wa.me/595986868241?text=Hi!%20I'm%20interested%20in%20the%20premade%20cover%20'Whispers%20of%20the%20Forest'" },
-        { "name": "Heart of Ash", "priceUSD": "$35", "pricePYG": "₲250,000", "description": "Premade cover — Dark Romance", "category": "Romance", "imageUrl": "", "available": true, "format": "eBook", "includes": ["eBook cover (JPG/PDF)", "Title PNG + Title page PNG", "2 reveal banners", "2 mockups"], "ctaHref": "https://wa.me/595986868241?text=Hi!%20I'm%20interested%20in%20the%20premade%20cover%20'Heart%20of%20Ash'" },
-        { "name": "The Last Code", "priceUSD": "$30", "pricePYG": "₲250,000", "description": "Premade cover — Thriller/Suspense", "category": "Thriller", "imageUrl": "", "available": true, "format": "eBook", "includes": ["eBook cover (JPG/PDF)", "Title PNG + Title page PNG", "2 reveal banners", "2 mockups"], "ctaHref": "https://wa.me/595986868241?text=Hi!%20I'm%20interested%20in%20the%20premade%20cover%20'The%20Last%20Code'" },
-        { "name": "Inner Galaxy", "priceUSD": "$35", "pricePYG": "₲250,000", "description": "Premade cover — Science Fiction", "category": "Sci-Fi", "imageUrl": "", "available": true, "format": "eBook", "includes": ["eBook cover (JPG/PDF)", "Title PNG + Title page PNG", "2 reveal banners", "2 mockups"], "ctaHref": "https://wa.me/595986868241?text=Hi!%20I'm%20interested%20in%20the%20premade%20cover%20'Inner%20Galaxy'" },
-        { "name": "Shadows in the Mirror", "priceUSD": "$30", "pricePYG": "₲250,000", "description": "Premade cover — Horror", "category": "Horror", "imageUrl": "", "available": true, "format": "eBook", "includes": ["eBook cover (JPG/PDF)", "Title PNG + Title page PNG", "2 reveal banners", "2 mockups"], "ctaHref": "https://wa.me/595986868241?text=Hi!%20I'm%20interested%20in%20the%20premade%20cover%20'Shadows%20in%20the%20Mirror'" },
-        { "name": "Crystal Wings", "priceUSD": "$35", "pricePYG": "₲250,000", "description": "Premade cover — YA Fantasy", "category": "Fantasy", "imageUrl": "", "available": true, "format": "eBook", "includes": ["eBook cover (JPG/PDF)", "Title PNG + Title page PNG", "2 reveal banners", "2 mockups"], "ctaHref": "https://wa.me/595986868241?text=Hi!%20I'm%20interested%20in%20the%20premade%20cover%20'Crystal%20Wings'" }
+        {
+          "name": "Whispers of the Forest",
+          "priceUSD": "$35",
+          "pricePYG": "₲250,000",
+          "description": "Premade cover — Fantasy/Romance",
+          "category": "Fantasy",
+          "imageUrl": "",
+          "available": true,
+          "format": "eBook",
+          "includes": [
+            "eBook cover (JPG/PDF)",
+            "Title PNG + Title page PNG",
+            "2 reveal banners",
+            "2 mockups"
+          ],
+          "ctaHref": "https://wa.me/595986868241?text=Hi!%20I'm%20interested%20in%20the%20premade%20cover%20'Whispers%20of%20the%20Forest'"
+        },
+        {
+          "name": "Heart of Ash",
+          "priceUSD": "$35",
+          "pricePYG": "₲250,000",
+          "description": "Premade cover — Dark Romance",
+          "category": "Romance",
+          "imageUrl": "",
+          "available": true,
+          "format": "eBook",
+          "includes": [
+            "eBook cover (JPG/PDF)",
+            "Title PNG + Title page PNG",
+            "2 reveal banners",
+            "2 mockups"
+          ],
+          "ctaHref": "https://wa.me/595986868241?text=Hi!%20I'm%20interested%20in%20the%20premade%20cover%20'Heart%20of%20Ash'"
+        },
+        {
+          "name": "The Last Code",
+          "priceUSD": "$30",
+          "pricePYG": "₲250,000",
+          "description": "Premade cover — Thriller/Suspense",
+          "category": "Thriller",
+          "imageUrl": "",
+          "available": true,
+          "format": "eBook",
+          "includes": [
+            "eBook cover (JPG/PDF)",
+            "Title PNG + Title page PNG",
+            "2 reveal banners",
+            "2 mockups"
+          ],
+          "ctaHref": "https://wa.me/595986868241?text=Hi!%20I'm%20interested%20in%20the%20premade%20cover%20'The%20Last%20Code'"
+        },
+        {
+          "name": "Inner Galaxy",
+          "priceUSD": "$35",
+          "pricePYG": "₲250,000",
+          "description": "Premade cover — Science Fiction",
+          "category": "Sci-Fi",
+          "imageUrl": "",
+          "available": true,
+          "format": "eBook",
+          "includes": [
+            "eBook cover (JPG/PDF)",
+            "Title PNG + Title page PNG",
+            "2 reveal banners",
+            "2 mockups"
+          ],
+          "ctaHref": "https://wa.me/595986868241?text=Hi!%20I'm%20interested%20in%20the%20premade%20cover%20'Inner%20Galaxy'"
+        },
+        {
+          "name": "Shadows in the Mirror",
+          "priceUSD": "$30",
+          "pricePYG": "₲250,000",
+          "description": "Premade cover — Horror",
+          "category": "Horror",
+          "imageUrl": "",
+          "available": true,
+          "format": "eBook",
+          "includes": [
+            "eBook cover (JPG/PDF)",
+            "Title PNG + Title page PNG",
+            "2 reveal banners",
+            "2 mockups"
+          ],
+          "ctaHref": "https://wa.me/595986868241?text=Hi!%20I'm%20interested%20in%20the%20premade%20cover%20'Shadows%20in%20the%20Mirror'"
+        },
+        {
+          "name": "Crystal Wings",
+          "priceUSD": "$35",
+          "pricePYG": "₲250,000",
+          "description": "Premade cover — YA Fantasy",
+          "category": "Fantasy",
+          "imageUrl": "",
+          "available": true,
+          "format": "eBook",
+          "includes": [
+            "eBook cover (JPG/PDF)",
+            "Title PNG + Title page PNG",
+            "2 reveal banners",
+            "2 mockups"
+          ],
+          "ctaHref": "https://wa.me/595986868241?text=Hi!%20I'm%20interested%20in%20the%20premade%20cover%20'Crystal%20Wings'"
+        }
       ]
     },
     "process": {
       "title": "Our Process",
       "subtitle": "How we transform your manuscript into a cover that sells",
       "steps": [
-        { "title": "Initial Consultation", "description": "We learn about your book, audience and visual references", "duration": "Day 1" },
-        { "title": "Brief & References", "description": "We define style, mood and creative direction", "duration": "Days 1–2" },
-        { "title": "Design Proposals", "description": "We present 2–3 initial options", "duration": "Days 3–5" },
-        { "title": "Revisions", "description": "Adjustments until it's perfect", "duration": "Days 5–7" },
-        { "title": "Final Delivery", "description": "All high-resolution files ready for your platform", "duration": "Day 7" }
+        {
+          "title": "Initial Consultation",
+          "description": "We learn about your book, audience and visual references",
+          "duration": "Day 1"
+        },
+        {
+          "title": "Brief & References",
+          "description": "We define style, mood and creative direction",
+          "duration": "Days 1–2"
+        },
+        {
+          "title": "Design Proposals",
+          "description": "We present 2–3 initial options",
+          "duration": "Days 3–5"
+        },
+        {
+          "title": "Revisions",
+          "description": "Adjustments until it's perfect",
+          "duration": "Days 5–7"
+        },
+        {
+          "title": "Final Delivery",
+          "description": "All high-resolution files ready for your platform",
+          "duration": "Day 7"
+        }
       ]
     },
     "faq": {
       "title": "FAQ",
       "items": [
-        { "question": "How long does a custom cover take?", "answer": "1–3 weeks depending on project complexity. Premades are delivered in 1–2 weeks." },
-        { "question": "How many revisions are included?", "answer": "Revisions within the predefined plan are included. Additional changes beyond scope may have extra cost." },
-        { "question": "What's the payment process?", "answer": "50% advance to start. Balance upon final design approval. We accept Western Union, bank transfer and cash." },
-        { "question": "What currency do you charge in?", "answer": "We charge in USD and guaraníes (₲). See our pricing table for both currencies." },
-        { "question": "Can I use the cover on Amazon KDP / Wattpad / publishers?", "answer": "Yes. Design rights belong to Dayah LitWorks until full payment. Once paid 100%, you can use the cover on any platform." },
-        { "question": "What is a 3D mockup?", "answer": "A realistic 3D render of your book. Perfect for social media promotion and marketing." },
-        { "question": "What if I cancel the project?", "answer": "If the client cancels after work has started, the advance payment is non-refundable." },
-        { "question": "Do you redesign existing covers?", "answer": "Yes, you can hire a redesign as a custom cover. Send us your current cover and new ideas." },
-        { "question": "What do I need to get started?", "answer": "Book title, synopsis, genre, visual references (ideas, fonts, colors, styles). Send references BEFORE requesting design." },
-        { "question": "What language do you design in?", "answer": "We design covers in Spanish and English. Typography adapts to your book's language." },
-        { "question": "Can I request rush delivery (48–72h)?", "answer": "Contact us on WhatsApp to check availability. Rush projects may have a surcharge." },
-        { "question": "How are final files delivered?", "answer": "High-resolution files (JPG, PDF, PNG) ready to upload to your platform. Mockups delivered as rendered images." }
+        {
+          "question": "How long does a custom cover take?",
+          "answer": "1–3 weeks depending on project complexity. Premades are delivered in 1–2 weeks."
+        },
+        {
+          "question": "How many revisions are included?",
+          "answer": "Revisions within the predefined plan are included. Additional changes beyond scope may have extra cost."
+        },
+        {
+          "question": "What's the payment process?",
+          "answer": "50% advance to start. Balance upon final design approval. We accept Western Union, bank transfer and cash."
+        },
+        {
+          "question": "What currency do you charge in?",
+          "answer": "We charge in USD and guaraníes (₲). See our pricing table for both currencies."
+        },
+        {
+          "question": "Can I use the cover on Amazon KDP / Wattpad / publishers?",
+          "answer": "Yes. Design rights belong to Dayah LitWorks until full payment. Once paid 100%, you can use the cover on any platform."
+        },
+        {
+          "question": "What is a 3D mockup?",
+          "answer": "A realistic 3D render of your book. Perfect for social media promotion and marketing."
+        },
+        {
+          "question": "What if I cancel the project?",
+          "answer": "If the client cancels after work has started, the advance payment is non-refundable."
+        },
+        {
+          "question": "Do you redesign existing covers?",
+          "answer": "Yes, you can hire a redesign as a custom cover. Send us your current cover and new ideas."
+        },
+        {
+          "question": "What do I need to get started?",
+          "answer": "Book title, synopsis, genre, visual references (ideas, fonts, colors, styles). Send references BEFORE requesting design."
+        },
+        {
+          "question": "What language do you design in?",
+          "answer": "We design covers in Spanish and English. Typography adapts to your book's language."
+        },
+        {
+          "question": "Can I request rush delivery (48–72h)?",
+          "answer": "Contact us on WhatsApp to check availability. Rush projects may have a surcharge."
+        },
+        {
+          "question": "How are final files delivered?",
+          "answer": "High-resolution files (JPG, PDF, PNG) ready to upload to your platform. Mockups delivered as rendered images."
+        }
       ]
     },
     "testimonials": {
       "title": "Testimonials",
       "items": [
-        { "quote": "My cover is incredible! Dayah perfectly understood the essence of my book.", "author": "María G.", "rating": 5 },
-        { "quote": "Professional, creative and super fast. My premade cover was love at first sight.", "author": "Carlos R.", "rating": 5 }
+        {
+          "quote": "My cover is incredible! Dayah perfectly understood the essence of my book.",
+          "author": "María G.",
+          "rating": 5
+        },
+        {
+          "quote": "Professional, creative and super fast. My premade cover was love at first sight.",
+          "author": "Carlos R.",
+          "rating": 5
+        }
       ]
     },
     "contact": {
@@ -291,7 +643,14 @@
     },
     "title": "Portfolio",
     "subtitle": "Covers that sell books",
-    "filters": ["All", "Fantasy", "Romance", "Thriller", "Sci-Fi", "Horror"],
+    "filters": [
+      "All",
+      "Fantasy",
+      "Romance",
+      "Thriller",
+      "Sci-Fi",
+      "Horror"
+    ],
     "items": []
   },
   "blog": {
@@ -347,10 +706,37 @@
   "quoteForm": {
     "title": "Tell me about your project",
     "steps": [
-      { "id": "genre", "title": "What's your book about?", "fields": ["Genre", "Title"] },
-      { "id": "service", "title": "What do you need?", "fields": ["Service type"] },
-      { "id": "details", "title": "Details", "fields": ["Timeline", "Budget"] },
-      { "id": "contact", "title": "Your info", "fields": ["Name", "Email or WhatsApp"] }
+      {
+        "id": "genre",
+        "title": "What's your book about?",
+        "fields": [
+          "Genre",
+          "Title"
+        ]
+      },
+      {
+        "id": "service",
+        "title": "What do you need?",
+        "fields": [
+          "Service type"
+        ]
+      },
+      {
+        "id": "details",
+        "title": "Details",
+        "fields": [
+          "Timeline",
+          "Budget"
+        ]
+      },
+      {
+        "id": "contact",
+        "title": "Your info",
+        "fields": [
+          "Name",
+          "Email or WhatsApp"
+        ]
+      }
     ],
     "serviceOptions": [
       "Custom Cover — eBook ($45)",
@@ -379,13 +765,44 @@
       "short": "Book cover designer with 6+ years of experience. From Asunción, Paraguay, to authors worldwide.",
       "long": "I'm Daihana Araujo, founder of Dayah LitWorks. Since November 2019, I've been transforming manuscripts into covers that sell books.\n\nI created Dayah LitWorks with the conviction that every book deserves a professional cover, regardless of the author's budget. I work with indie authors across the Spanish and English-speaking world, designing covers that capture the essence of each story.\n\nMy approach combines a deep understanding of literary genres with a collaborative creative process. I believe the best cover comes from listening to the author, understanding their vision, and translating it into a design that's not only beautiful but works as a sales tool.",
       "founded": "Founded November 20, 2019",
-      "location": "Asunción, Paraguay"
+      "location": "Asunción, Paraguay",
+      "features": [
+        {
+          "title": "",
+          "description": "Book cover designer with 6+ years of experience. From Asunción, Paraguay, to authors worldwide."
+        },
+        {
+          "title": "",
+          "description": "I'm Daihana Araujo, founder of Dayah LitWorks. Since November 2019, I've been transforming manuscripts into covers that sell books.\n\nI created Dayah LitWorks with the conviction that every book deserves a professional cover, regardless of the author's budget. I work with indie authors across the Spanish and English-speaking world, designing covers that capture the essence of each story.\n\nMy approach combines a deep understanding of literary genres with a collaborative creative process. I believe the best cover comes from listening to the author, understanding their vision, and translating it into a design that's not only beautiful but works as a sales tool."
+        },
+        {
+          "title": "Founded",
+          "description": "Founded November 20, 2019"
+        },
+        {
+          "title": "Location",
+          "description": "Asunción, Paraguay"
+        }
+      ],
+      "title": "About Daihana"
     },
     "highlights": [
-      { "label": "6+", "description": "Years of experience" },
-      { "label": "100+", "description": "Covers designed" },
-      { "label": "Global", "description": "Clients in LATAM, USA and Europe" },
-      { "label": "Bilingual", "description": "Spanish and English" }
+      {
+        "title": "6+",
+        "description": "Years of experience"
+      },
+      {
+        "title": "100+",
+        "description": "Covers designed"
+      },
+      {
+        "title": "Global",
+        "description": "Clients in LATAM, USA and Europe"
+      },
+      {
+        "title": "Bilingual",
+        "description": "Spanish and English"
+      }
     ]
   },
   "terminos": {
@@ -397,42 +814,68 @@
     "subtitle": "Payment of the quote implies acceptance of the following conditions",
     "sections": [
       {
-        "title": "1. References first",
-        "content": "Always send references for ideas, fonts, colors or styles BEFORE requesting design — not after the finished proposal is delivered."
+        "question": "1. References first",
+        "answer": "Always send references for ideas, fonts, colors or styles BEFORE requesting design — not after the finished proposal is delivered."
       },
       {
-        "title": "2. Business days",
-        "content": "Work is done on business days (Monday through Friday), with sufficient time allocated for quality delivery."
+        "question": "2. Business days",
+        "answer": "Work is done on business days (Monday through Friday), with sufficient time allocated for quality delivery."
       },
       {
-        "title": "3. Cancellation",
-        "content": "If the client decides to terminate the contract after the project has started, the advance payment is non-refundable."
+        "question": "3. Cancellation",
+        "answer": "If the client decides to terminate the contract after the project has started, the advance payment is non-refundable."
       },
       {
-        "title": "4. Review responsibility",
-        "content": "The client is responsible for reviewing the design, text and data before any printing, reproduction and/or publication. Dayah LitWorks is not liable for errors not communicated beforehand."
+        "question": "4. Review responsibility",
+        "answer": "The client is responsible for reviewing the design, text and data before any printing, reproduction and/or publication. Dayah LitWorks is not liable for errors not communicated beforehand."
       },
       {
-        "title": "5. Scope changes",
-        "content": "This agreement does not include additional work arising from changes in direction during development by the client. If this occurs, Dayah LitWorks will inform the client and may adjust the budget."
+        "question": "5. Scope changes",
+        "answer": "This agreement does not include additional work arising from changes in direction during development by the client. If this occurs, Dayah LitWorks will inform the client and may adjust the budget."
       },
       {
-        "title": "6. Design rights",
-        "content": "Design rights remain with Dayah LitWorks until the client has made 100% payment."
+        "question": "6. Design rights",
+        "answer": "Design rights remain with Dayah LitWorks until the client has made 100% payment."
       },
       {
-        "title": "7. Portfolio usage",
-        "content": "Dayah LitWorks may display completed work in the portfolio, as well as on other digital platforms such as Instagram, Facebook, TikTok and the website."
+        "question": "7. Portfolio usage",
+        "answer": "Dayah LitWorks may display completed work in the portfolio, as well as on other digital platforms such as Instagram, Facebook, TikTok and the website."
       }
     ],
     "payment": {
       "title": "Payment Methods",
       "methods": [
-        { "name": "Western Union", "description": "For international clients" },
-        { "name": "Bank transfer", "description": "Paraguayan banks" },
-        { "name": "Cash", "description": "In-person payment in Asunción" }
+        {
+          "name": "Western Union",
+          "description": "For international clients"
+        },
+        {
+          "name": "Bank transfer",
+          "description": "Paraguayan banks"
+        },
+        {
+          "name": "Cash",
+          "description": "In-person payment in Asunción"
+        }
       ],
-      "note": "50% advance required to start the project. Remaining balance due upon final design approval."
+      "note": "50% advance required to start the project. Remaining balance due upon final design approval.",
+      "features": [
+        {
+          "title": "Western Union",
+          "description": "For international clients",
+          "icon": null
+        },
+        {
+          "title": "Bank transfer",
+          "description": "Paraguayan banks",
+          "icon": null
+        },
+        {
+          "title": "Cash",
+          "description": "In-person payment in Asunción",
+          "icon": null
+        }
+      ]
     }
   },
   "footer": {

--- a/sites/dayah-litworks/content/en.json
+++ b/sites/dayah-litworks/content/en.json
@@ -651,7 +651,18 @@
       "email": "dayahlitworks@gmail.com",
       "instagram": "@dayah.litworks",
       "facebook": "https://www.facebook.com/bookc0verdesign/",
-      "linkedin": "https://www.linkedin.com/in/daihana-araujo/"
+      "linkedin": "https://www.linkedin.com/in/daihana-araujo/",
+      "city": "Asunción, Paraguay",
+      "whatsappMessage": "Hi Dayah! I want to ask about a cover design.",
+      "hours": {
+        "Monday": "09:00 – 18:00",
+        "Tuesday": "09:00 – 18:00",
+        "Wednesday": "09:00 – 18:00",
+        "Thursday": "09:00 – 18:00",
+        "Friday": "09:00 – 18:00",
+        "Saturday": "Closed",
+        "Sunday": "Closed"
+      }
     }
   },
   "portfolio": {

--- a/sites/dayah-litworks/content/en.json
+++ b/sites/dayah-litworks/content/en.json
@@ -711,7 +711,28 @@
         "readTime": "5 min",
         "imageUrl": ""
       }
-    ]
+    ],
+    "placeholder": {
+      "title": "Blog coming soon",
+      "subtitle": "Soon you will find cover design tips, trends, and resources for indie authors. In the meantime, subscribe to the newsletter.",
+      "features": [
+        {
+          "title": "Newsletter",
+          "description": "One email a month with tips and examples of covers that sell.",
+          "href": "#newsletter"
+        },
+        {
+          "title": "Instagram @dayah.litworks",
+          "description": "Follow recent work + behind-the-scenes.",
+          "href": "https://instagram.com/dayah.litworks"
+        },
+        {
+          "title": "WhatsApp",
+          "description": "Direct questions, fast answers.",
+          "href": "https://wa.me/595986868241"
+        }
+      ]
+    }
   },
   "blogPost": {
     "como-elegir-portada-libro": {

--- a/sites/dayah-litworks/content/en.json
+++ b/sites/dayah-litworks/content/en.json
@@ -409,7 +409,25 @@
           ],
           "category": "Interior Layout"
         }
-      ]
+      ],
+      "addons_block": {
+        "title": "Additional services",
+        "subtitle": "Add-ons you can attach to any package. Quote on request.",
+        "features": [
+          {
+            "title": "Static 3D Mockup",
+            "description": "Realistic 3D render of your book (Quote)"
+          },
+          {
+            "title": "3D Video Mockup",
+            "description": "Professional animation of your cover (Quote)"
+          },
+          {
+            "title": "Copyediting & Proofreading",
+            "description": "Priced based on evaluation of first chapters and manuscript length (Per evaluation)"
+          }
+        ]
+      }
     },
     "products": {
       "title": "Premade Catalog",
@@ -651,7 +669,28 @@
       "Sci-Fi",
       "Horror"
     ],
-    "items": []
+    "items": [],
+    "placeholder": {
+      "title": "Portfolio coming soon",
+      "subtitle": "I'm curating recent work to share here. In the meantime, browse the premade catalog or DM me on WhatsApp.",
+      "features": [
+        {
+          "title": "Premade Catalog",
+          "description": "Ready-to-use designs — with typography and color customization.",
+          "href": "/s/en/dayah-litworks/catalogo"
+        },
+        {
+          "title": "Instagram @dayah.litworks",
+          "description": "Latest work + behind-the-scenes on Instagram.",
+          "href": "https://instagram.com/dayah.litworks"
+        },
+        {
+          "title": "WhatsApp",
+          "description": "Tell me what you're writing — I reply during business hours.",
+          "href": "https://wa.me/595986868241"
+        }
+      ]
+    }
   },
   "blog": {
     "seo": {

--- a/sites/dayah-litworks/content/es.json
+++ b/sites/dayah-litworks/content/es.json
@@ -403,7 +403,25 @@
           ],
           "category": "Maquetación Interior"
         }
-      ]
+      ],
+      "addons_block": {
+        "title": "Servicios adicionales",
+        "subtitle": "Extras que puedes sumar a cualquier paquete. Cotización según necesidad.",
+        "features": [
+          {
+            "title": "Mockup 3D Estático",
+            "description": "Imagen realista de tu libro en 3D (Cotizar)"
+          },
+          {
+            "title": "Video Mockup 3D",
+            "description": "Animación profesional de tu portada (Cotizar)"
+          },
+          {
+            "title": "Corrección ortotipográfica y de estilo",
+            "description": "Se cotiza según evaluación de primeros capítulos y extensión del manuscrito (Según evaluación)"
+          }
+        ]
+      }
     },
     "products": {
       "title": "Catálogo Premade",
@@ -645,7 +663,28 @@
       "Ciencia Ficción",
       "Terror"
     ],
-    "items": []
+    "items": [],
+    "placeholder": {
+      "title": "Portafolio en preparación",
+      "subtitle": "Estoy curando los trabajos recientes para compartirlos acá. Mientras tanto, mirá el catálogo de premades o escribime por WhatsApp.",
+      "features": [
+        {
+          "title": "Catálogo Premade",
+          "description": "Diseños listos para usar — con personalización de tipografía y color.",
+          "href": "/s/es/dayah-litworks/catalogo"
+        },
+        {
+          "title": "Instagram @dayah.litworks",
+          "description": "Últimos trabajos + proceso en Instagram.",
+          "href": "https://instagram.com/dayah.litworks"
+        },
+        {
+          "title": "WhatsApp",
+          "description": "Contame qué estás escribiendo — respondo en horario de oficina.",
+          "href": "https://wa.me/595986868241"
+        }
+      ]
+    }
   },
   "blog": {
     "seo": {

--- a/sites/dayah-litworks/content/es.json
+++ b/sites/dayah-litworks/content/es.json
@@ -645,7 +645,18 @@
       "email": "dayahlitworks@gmail.com",
       "instagram": "@dayah.litworks",
       "facebook": "https://www.facebook.com/bookc0verdesign/",
-      "linkedin": "https://www.linkedin.com/in/daihana-araujo/"
+      "linkedin": "https://www.linkedin.com/in/daihana-araujo/",
+      "city": "Asunción, Paraguay",
+      "whatsappMessage": "Hola Dayah! Quiero consultar por una portada.",
+      "hours": {
+        "Lunes": "09:00 – 18:00",
+        "Martes": "09:00 – 18:00",
+        "Miércoles": "09:00 – 18:00",
+        "Jueves": "09:00 – 18:00",
+        "Viernes": "09:00 – 18:00",
+        "Sábado": "Cerrado",
+        "Domingo": "Cerrado"
+      }
     }
   },
   "portfolio": {

--- a/sites/dayah-litworks/content/es.json
+++ b/sites/dayah-litworks/content/es.json
@@ -705,7 +705,28 @@
         "readTime": "5 min",
         "imageUrl": ""
       }
-    ]
+    ],
+    "placeholder": {
+      "title": "Blog en preparación",
+      "subtitle": "Pronto vas a encontrar acá tips de diseño, tendencias de portadas y recursos para autores indie. Mientras tanto suscribite al newsletter.",
+      "features": [
+        {
+          "title": "Newsletter",
+          "description": "Un email al mes con tips y ejemplos de portadas que venden.",
+          "href": "#newsletter"
+        },
+        {
+          "title": "Instagram @dayah.litworks",
+          "description": "Seguimiento de trabajos recientes + proceso.",
+          "href": "https://instagram.com/dayah.litworks"
+        },
+        {
+          "title": "WhatsApp",
+          "description": "Preguntas directas, respuestas rápidas.",
+          "href": "https://wa.me/595986868241"
+        }
+      ]
+    }
   },
   "blogPost": {
     "como-elegir-portada-libro": {

--- a/sites/dayah-litworks/content/es.json
+++ b/sites/dayah-litworks/content/es.json
@@ -6,21 +6,57 @@
   },
   "siteName": "Dayah LitWorks",
   "tagline": "Diseño de tapas de libros — del manuscrito a la portada que vende",
-"faq": {
+  "faq": {
     "title": "Preguntas Frecuentes",
     "items": [
-      { "question": "¿Cuánto tarda una portada personalizada?", "answer": "Entre 1 y 3 semanas dependiendo de la complejidad del proyecto. Las premades se entregan en 1–2 semanas." },
-      { "question": "¿Cuántas revisiones incluye?", "answer": "Las revisiones están incluidas dentro del plan predefinido. Cambios adicionales fuera del scope pueden tener costo extra." },
-      { "question": "¿Cómo es el proceso de pago?", "answer": "Se requiere un anticipo del 50% para comenzar. El resto al aprobar el diseño final. Aceptamos Western Union, transferencia bancaria y efectivo." },
-      { "question": "¿En qué moneda cobran?", "answer": "Cobramos en USD y en guaraníes (₲). Los precios en guaraníes están en nuestra tabla de servicios." },
-      { "question": "¿Puedo usar la portada en Amazon KDP / Wattpad / editorial?", "answer": "Sí. Los derechos del diseño pertenecen a Dayah LitWorks hasta el pago completo. Una vez pago al 100%, podés usar la portada en la plataforma que elijas." },
-      { "question": "¿Qué es un mockup 3D?", "answer": "Es una imagen realista de tu libro renderizada en 3D. Ideal para promocionar en redes sociales y marketing." },
-      { "question": "¿Qué pasa si cancelo el proyecto?", "answer": "Si el cliente decide rescindir el contrato una vez iniciado el proyecto, el anticipo no es reembolsable." },
-      { "question": "¿Hacés rediseños de portadas existentes?", "answer": "Sí, podés contratar un rediseño como portada personalizada. Envianos la portada actual y tus nuevas ideas." },
-      { "question": "¿Qué necesito enviar para empezar?", "answer": "Título del libro, sinopsis, género, referencias visuales (ideas, tipografías, colores, estilos). Es importante enviar las referencias ANTES de solicitar el diseño." },
-      { "question": "¿En qué idioma diseñás?", "answer": "Diseñamos portadas en español e inglés. Los textos tipográficos se adaptan al idioma de tu libro." },
-      { "question": "¿Puedo contratar urgente (48–72h)?", "answer": "Contáctanos por WhatsApp para verificar disponibilidad. Los proyectos urgentes pueden tener un recargo." },
-      { "question": "¿Cómo se entregados los archivos finales?", "answer": "Archivos en alta resolución (JPG, PDF, PNG) listos para subir a tu plataforma. Los mockups se entrega como imágenes renderizadas." }
+      {
+        "question": "¿Cuánto tarda una portada personalizada?",
+        "answer": "Entre 1 y 3 semanas dependiendo de la complejidad del proyecto. Las premades se entregan en 1–2 semanas."
+      },
+      {
+        "question": "¿Cuántas revisiones incluye?",
+        "answer": "Las revisiones están incluidas dentro del plan predefinido. Cambios adicionales fuera del scope pueden tener costo extra."
+      },
+      {
+        "question": "¿Cómo es el proceso de pago?",
+        "answer": "Se requiere un anticipo del 50% para comenzar. El resto al aprobar el diseño final. Aceptamos Western Union, transferencia bancaria y efectivo."
+      },
+      {
+        "question": "¿En qué moneda cobran?",
+        "answer": "Cobramos en USD y en guaraníes (₲). Los precios en guaraníes están en nuestra tabla de servicios."
+      },
+      {
+        "question": "¿Puedo usar la portada en Amazon KDP / Wattpad / editorial?",
+        "answer": "Sí. Los derechos del diseño pertenecen a Dayah LitWorks hasta el pago completo. Una vez pago al 100%, podés usar la portada en la plataforma que elijas."
+      },
+      {
+        "question": "¿Qué es un mockup 3D?",
+        "answer": "Es una imagen realista de tu libro renderizada en 3D. Ideal para promocionar en redes sociales y marketing."
+      },
+      {
+        "question": "¿Qué pasa si cancelo el proyecto?",
+        "answer": "Si el cliente decide rescindir el contrato una vez iniciado el proyecto, el anticipo no es reembolsable."
+      },
+      {
+        "question": "¿Hacés rediseños de portadas existentes?",
+        "answer": "Sí, podés contratar un rediseño como portada personalizada. Envianos la portada actual y tus nuevas ideas."
+      },
+      {
+        "question": "¿Qué necesito enviar para empezar?",
+        "answer": "Título del libro, sinopsis, género, referencias visuales (ideas, tipografías, colores, estilos). Es importante enviar las referencias ANTES de solicitar el diseño."
+      },
+      {
+        "question": "¿En qué idioma diseñás?",
+        "answer": "Diseñamos portadas en español e inglés. Los textos tipográficos se adaptan al idioma de tu libro."
+      },
+      {
+        "question": "¿Puedo contratar urgente (48–72h)?",
+        "answer": "Contáctanos por WhatsApp para verificar disponibilidad. Los proyectos urgentes pueden tener un recargo."
+      },
+      {
+        "question": "¿Cómo se entregados los archivos finales?",
+        "answer": "Archivos en alta resolución (JPG, PDF, PNG) listos para subir a tu plataforma. Los mockups se entrega como imágenes renderizadas."
+      }
     ]
   },
   "faqPage": {
@@ -41,13 +77,34 @@
   "navigation": {
     "businessName": "Dayah LitWorks",
     "items": [
-      { "label": "Inicio", "href": "/s/es/dayah-litworks" },
-      { "label": "Servicios", "href": "/s/es/dayah-litworks/servicios" },
-      { "label": "Catálogo", "href": "/s/es/dayah-litworks/catalogo" },
-      { "label": "Portafolio", "href": "/s/es/dayah-litworks/portafolio" },
-      { "label": "Blog", "href": "/s/es/dayah-litworks/blog" },
-      { "label": "Sobre", "href": "/s/es/dayah-litworks/sobre" },
-      { "label": "Contacto", "href": "/s/es/dayah-litworks/contacto" }
+      {
+        "label": "Inicio",
+        "href": "/s/es/dayah-litworks"
+      },
+      {
+        "label": "Servicios",
+        "href": "/s/es/dayah-litworks/servicios"
+      },
+      {
+        "label": "Catálogo",
+        "href": "/s/es/dayah-litworks/catalogo"
+      },
+      {
+        "label": "Portafolio",
+        "href": "/s/es/dayah-litworks/portafolio"
+      },
+      {
+        "label": "Blog",
+        "href": "/s/es/dayah-litworks/blog"
+      },
+      {
+        "label": "Sobre",
+        "href": "/s/es/dayah-litworks/sobre"
+      },
+      {
+        "label": "Contacto",
+        "href": "/s/es/dayah-litworks/contacto"
+      }
     ],
     "ctaText": "Contactanos",
     "ctaHref": "https://wa.me/595986868241"
@@ -68,10 +125,26 @@
     "trustBadges": {
       "title": "¿Por qué elegirnos?",
       "badges": [
-        { "icon": "palette", "label": "Diseño profesional", "description": "Portadas que venden libros" },
-        { "icon": "globe", "label": "Clientes globales", "description": "Autores en USA, Europa y LATAM" },
-        { "icon": "dollar-sign", "label": "USD y guaraníes", "description": "Cobro en ambas monedas" },
-        { "icon": "zap", "label": "Entrega rápida", "description": "1–3 semanas según servicio" }
+        {
+          "icon": "palette",
+          "label": "Diseño profesional",
+          "description": "Portadas que venden libros"
+        },
+        {
+          "icon": "globe",
+          "label": "Clientes globales",
+          "description": "Autores en USA, Europa y LATAM"
+        },
+        {
+          "icon": "dollar-sign",
+          "label": "USD y guaraníes",
+          "description": "Cobro en ambas monedas"
+        },
+        {
+          "icon": "zap",
+          "label": "Entrega rápida",
+          "description": "1–3 semanas según servicio"
+        }
       ]
     },
     "services": {
@@ -218,54 +291,333 @@
           "price": "Según evaluación",
           "description": "Se cotiza según evaluación de primeros capítulos y extensión del manuscrito"
         }
+      ],
+      "items": [
+        {
+          "name": "Portada Personalizada — eBook",
+          "priceUSD": "$45",
+          "pricePYG": "₲300.000",
+          "delivery": "1–2 semanas",
+          "description": "Portada de libro electrónica exclusiva",
+          "includes": [
+            "Portada de libro electrónico (JPG/PDF)",
+            "Título en formato PNG y Portadilla PNG",
+            "2 banners de revelación de portada",
+            "2 Mockups"
+          ],
+          "category": "Portadas Personalizadas"
+        },
+        {
+          "name": "Portada Personalizada — Tapa Blanda",
+          "priceUSD": "$80",
+          "pricePYG": "₲500.000",
+          "delivery": "1–2 semanas",
+          "description": "Portada completa (frente, lomo y contra) para impresión",
+          "includes": [
+            "Portada de libro tapa blanda (JPG/PDF)",
+            "Archivo imprimible (PDF)",
+            "Título en formato PNG y Portadilla PNG",
+            "2 banners de revelación de portada",
+            "2 Mockups"
+          ],
+          "category": "Portadas Personalizadas"
+        },
+        {
+          "name": "Portada Paperback & eBook",
+          "priceUSD": "$120",
+          "pricePYG": "₲800.000",
+          "delivery": "2–3 semanas",
+          "description": "Combo completo: portada eBook + tapa blanda",
+          "includes": [
+            "Portada de libro electrónico (JPG/PDF)",
+            "Archivo imprimible (PDF)",
+            "Título en formato PNG y Portadilla PNG",
+            "2 banners de revelación de portada",
+            "2 Mockups"
+          ],
+          "category": "Portadas Personalizadas"
+        },
+        {
+          "name": "Premade eBook",
+          "priceUSD": "$35",
+          "pricePYG": "₲250.000",
+          "delivery": "1–2 semanas",
+          "description": "Portada premade para eBook con personalización",
+          "includes": [
+            "Portada de libro electrónico (JPG/PDF)",
+            "Título en formato PNG y Portadilla PNG",
+            "2 banners de revelación de portada",
+            "2 Mockups"
+          ],
+          "scopeNote": "Incluye alteraciones en redacción y tipografía, cambios de color, cambios menores en posición de elementos",
+          "category": "Portadas Premade"
+        },
+        {
+          "name": "Premade eBook & Paperback",
+          "priceUSD": "$80",
+          "pricePYG": "₲500.000",
+          "delivery": "1–2 semanas",
+          "description": "Portada premade completa con versión tapa blanda",
+          "includes": [
+            "Portada de libro tapa blanda (JPG/PDF)",
+            "Archivo imprimible (PDF)",
+            "Título en formato PNG y Portadilla PNG",
+            "2 banners de revelación de portada",
+            "2 Mockups"
+          ],
+          "category": "Portadas Premade"
+        },
+        {
+          "name": "Maquetación eBook",
+          "priceUSD": "$25",
+          "pricePYG": "₲160.000",
+          "delivery": "1–2 semanas",
+          "description": "Diseño interior para libro electrónico",
+          "includes": [
+            "Diseño interior profesional",
+            "Entrega del archivo según especificaciones de la plataforma (WORD/PDF)"
+          ],
+          "category": "Maquetación Interior"
+        },
+        {
+          "name": "Maquetación Paperback",
+          "priceUSD": "$35",
+          "pricePYG": "₲250.000",
+          "delivery": "1–2 semanas",
+          "description": "Diseño interior para libro impreso",
+          "includes": [
+            "Diseño interior profesional",
+            "Entrega del archivo según especificaciones de la plataforma (WORD/PDF)"
+          ],
+          "category": "Maquetación Interior"
+        },
+        {
+          "name": "Maquetación eBook & Paperback",
+          "priceUSD": "$50",
+          "pricePYG": "₲320.000",
+          "delivery": "1–2 semanas",
+          "description": "Diseño interior completo para ambas versiones",
+          "includes": [
+            "Diseño interior profesional",
+            "Entrega del archivo según especificaciones de la plataforma (WORD/PDF)"
+          ],
+          "category": "Maquetación Interior"
+        }
       ]
     },
     "products": {
       "title": "Catálogo Premade",
       "subtitle": "Diseños listos para usar — personalización incluida",
-      "categories": ["Todos", "Fantasía", "Romance", "Thriller", "Ciencia Ficción", "Terror"],
+      "categories": [
+        "Todos",
+        "Fantasía",
+        "Romance",
+        "Thriller",
+        "Ciencia Ficción",
+        "Terror"
+      ],
       "items": [
-        { "name": "Susurros del Bosque", "priceUSD": "$35", "pricePYG": "₲250.000", "description": "Portada premade — Fantasía/Romance", "category": "Fantasía", "imageUrl": "", "available": true, "format": "eBook", "includes": ["Portada eBook (JPG/PDF)", "Título PNG + Portadilla PNG", "2 banners de revelación", "2 mockups"], "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Susurros%20del%20Bosque'" },
-        { "name": "Corazón de Cenizas", "priceUSD": "$35", "pricePYG": "₲250.000", "description": "Portada premade — Romance Oscuro", "category": "Romance", "imageUrl": "", "available": true, "format": "eBook", "includes": ["Portada eBook (JPG/PDF)", "Título PNG + Portadilla PNG", "2 banners de revelación", "2 mockups"], "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Coraz%C3%B3n%20de%20Cenizas'" },
-        { "name": "El Último Código", "priceUSD": "$30", "pricePYG": "₲250.000", "description": "Portada premade — Thriller/Suspenso", "category": "Thriller", "imageUrl": "", "available": true, "format": "eBook", "includes": ["Portada eBook (JPG/PDF)", "Título PNG + Portadilla PNG", "2 banners de revelación", "2 mockups"], "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'El%20%C3%9Altimo%20C%C3%B3digo'" },
-        { "name": "Galaxia Interior", "priceUSD": "$35", "pricePYG": "₲250.000", "description": "Portada premade — Ciencia Ficción", "category": "Ciencia Ficción", "imageUrl": "", "available": true, "format": "eBook", "includes": ["Portada eBook (JPG/PDF)", "Título PNG + Portadilla PNG", "2 banners de revelación", "2 mockups"], "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Galaxia%20Interior'" },
-        { "name": "Sombras en el Espejo", "priceUSD": "$30", "pricePYG": "₲250.000", "description": "Portada premade — Terror/Horror", "category": "Terror", "imageUrl": "", "available": true, "format": "eBook", "includes": ["Portada eBook (JPG/PDF)", "Título PNG + Portadilla PNG", "2 banners de revelación", "2 mockups"], "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Sombras%20en%20el%20Espejo'" },
-        { "name": "Alas de Cristal", "priceUSD": "$35", "pricePYG": "₲250.000", "description": "Portada premade — Fantasía Juvenil", "category": "Fantasía", "imageUrl": "", "available": true, "format": "eBook", "includes": ["Portada eBook (JPG/PDF)", "Título PNG + Portadilla PNG", "2 banners de revelación", "2 mockups"], "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Alas%20de%20Cristal'" }
+        {
+          "name": "Susurros del Bosque",
+          "priceUSD": "$35",
+          "pricePYG": "₲250.000",
+          "description": "Portada premade — Fantasía/Romance",
+          "category": "Fantasía",
+          "imageUrl": "",
+          "available": true,
+          "format": "eBook",
+          "includes": [
+            "Portada eBook (JPG/PDF)",
+            "Título PNG + Portadilla PNG",
+            "2 banners de revelación",
+            "2 mockups"
+          ],
+          "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Susurros%20del%20Bosque'"
+        },
+        {
+          "name": "Corazón de Cenizas",
+          "priceUSD": "$35",
+          "pricePYG": "₲250.000",
+          "description": "Portada premade — Romance Oscuro",
+          "category": "Romance",
+          "imageUrl": "",
+          "available": true,
+          "format": "eBook",
+          "includes": [
+            "Portada eBook (JPG/PDF)",
+            "Título PNG + Portadilla PNG",
+            "2 banners de revelación",
+            "2 mockups"
+          ],
+          "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Coraz%C3%B3n%20de%20Cenizas'"
+        },
+        {
+          "name": "El Último Código",
+          "priceUSD": "$30",
+          "pricePYG": "₲250.000",
+          "description": "Portada premade — Thriller/Suspenso",
+          "category": "Thriller",
+          "imageUrl": "",
+          "available": true,
+          "format": "eBook",
+          "includes": [
+            "Portada eBook (JPG/PDF)",
+            "Título PNG + Portadilla PNG",
+            "2 banners de revelación",
+            "2 mockups"
+          ],
+          "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'El%20%C3%9Altimo%20C%C3%B3digo'"
+        },
+        {
+          "name": "Galaxia Interior",
+          "priceUSD": "$35",
+          "pricePYG": "₲250.000",
+          "description": "Portada premade — Ciencia Ficción",
+          "category": "Ciencia Ficción",
+          "imageUrl": "",
+          "available": true,
+          "format": "eBook",
+          "includes": [
+            "Portada eBook (JPG/PDF)",
+            "Título PNG + Portadilla PNG",
+            "2 banners de revelación",
+            "2 mockups"
+          ],
+          "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Galaxia%20Interior'"
+        },
+        {
+          "name": "Sombras en el Espejo",
+          "priceUSD": "$30",
+          "pricePYG": "₲250.000",
+          "description": "Portada premade — Terror/Horror",
+          "category": "Terror",
+          "imageUrl": "",
+          "available": true,
+          "format": "eBook",
+          "includes": [
+            "Portada eBook (JPG/PDF)",
+            "Título PNG + Portadilla PNG",
+            "2 banners de revelación",
+            "2 mockups"
+          ],
+          "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Sombras%20en%20el%20Espejo'"
+        },
+        {
+          "name": "Alas de Cristal",
+          "priceUSD": "$35",
+          "pricePYG": "₲250.000",
+          "description": "Portada premade — Fantasía Juvenil",
+          "category": "Fantasía",
+          "imageUrl": "",
+          "available": true,
+          "format": "eBook",
+          "includes": [
+            "Portada eBook (JPG/PDF)",
+            "Título PNG + Portadilla PNG",
+            "2 banners de revelación",
+            "2 mockups"
+          ],
+          "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Alas%20de%20Cristal'"
+        }
       ]
     },
     "process": {
       "title": "Nuestro Proceso",
       "subtitle": "Cómo transformamos tu manuscrito en una portada que vende",
       "steps": [
-        { "title": "Consulta inicial", "description": "Conocemos tu libro, tu público y tus referencias visuales", "duration": "Día 1" },
-        { "title": "Brief y referencias", "description": "Definimos estilo, mood y dirección creativa", "duration": "Días 1–2" },
-        { "title": "Propuestas de diseño", "description": "Te presentamos 2–3 opciones iniciales", "duration": "Días 3–5" },
-        { "title": "Revisiones", "description": "Ajustes hasta que quede perfecto", "duration": "Días 5–7" },
-        { "title": "Entrega final", "description": "Todos los archivos en alta resolución, listos para tu plataforma", "duration": "Día 7" }
+        {
+          "title": "Consulta inicial",
+          "description": "Conocemos tu libro, tu público y tus referencias visuales",
+          "duration": "Día 1"
+        },
+        {
+          "title": "Brief y referencias",
+          "description": "Definimos estilo, mood y dirección creativa",
+          "duration": "Días 1–2"
+        },
+        {
+          "title": "Propuestas de diseño",
+          "description": "Te presentamos 2–3 opciones iniciales",
+          "duration": "Días 3–5"
+        },
+        {
+          "title": "Revisiones",
+          "description": "Ajustes hasta que quede perfecto",
+          "duration": "Días 5–7"
+        },
+        {
+          "title": "Entrega final",
+          "description": "Todos los archivos en alta resolución, listos para tu plataforma",
+          "duration": "Día 7"
+        }
       ]
     },
     "faq": {
       "title": "Preguntas Frecuentes",
       "items": [
-        { "question": "¿Cuánto tarda una portada personalizada?", "answer": "Entre 1 y 3 semanas dependiendo de la complejidad del proyecto. Las premades se entregan en 1–2 semanas." },
-        { "question": "¿Cuántas revisiones incluye?", "answer": "Las revisiones están incluidas dentro del plan predefinido. Cambios adicionales fuera del scope pueden tener costo extra." },
-        { "question": "¿Cómo es el proceso de pago?", "answer": "Se requiere un anticipo del 50% para comenzar. El resto al aprobar el diseño final. Aceptamos Western Union, transferencia bancaria y efectivo." },
-        { "question": "¿En qué moneda cobran?", "answer": "Cobramos en USD y en guaraníes (₲). Los precios en guaraníes están en nuestra tabla de servicios." },
-        { "question": "¿Puedo usar la portada en Amazon KDP / Wattpad / editorial?", "answer": "Sí. Los derechos del diseño pertenecen a Dayah LitWorks hasta el pago completo. Una vez pago al 100%, podés usar la portada en la plataforma que elijas." },
-        { "question": "¿Qué es un mockup 3D?", "answer": "Es una imagen realista de tu libro renderizada en 3D. Ideal para promocionar en redes sociales y marketing." },
-        { "question": "¿Qué pasa si cancelo el proyecto?", "answer": "Si el cliente decide rescindir el contrato una vez iniciado el proyecto, el anticipo no es reembolsable." },
-        { "question": "¿Hacés rediseños de portadas existentes?", "answer": "Sí, podés contratar un rediseño como portada personalizada. Envianos la portada actual y tus nuevas ideas." },
-        { "question": "¿Qué necesito enviar para empezar?", "answer": "Título del libro, sinopsis, género, referencias visuales (ideas, tipografías, colores, estilos). Es importante enviar las referencias ANTES de solicitar el diseño." },
-        { "question": "¿En qué idioma diseñás?", "answer": "Diseñamos portadas en español e inglés. Los textos tipográficos se adaptan al idioma de tu libro." },
-        { "question": "¿Puedo contratar urgente (48–72h)?", "answer": "Contáctanos por WhatsApp para verificar disponibilidad. Los proyectos urgentes pueden tener un recargo." },
-        { "question": "¿Cómo se entregan los archivos finales?", "answer": "Archivos en alta resolución (JPG, PDF, PNG) listos para subir a tu plataforma. Los mockups se entregan como imágenes renderizadas." }
+        {
+          "question": "¿Cuánto tarda una portada personalizada?",
+          "answer": "Entre 1 y 3 semanas dependiendo de la complejidad del proyecto. Las premades se entregan en 1–2 semanas."
+        },
+        {
+          "question": "¿Cuántas revisiones incluye?",
+          "answer": "Las revisiones están incluidas dentro del plan predefinido. Cambios adicionales fuera del scope pueden tener costo extra."
+        },
+        {
+          "question": "¿Cómo es el proceso de pago?",
+          "answer": "Se requiere un anticipo del 50% para comenzar. El resto al aprobar el diseño final. Aceptamos Western Union, transferencia bancaria y efectivo."
+        },
+        {
+          "question": "¿En qué moneda cobran?",
+          "answer": "Cobramos en USD y en guaraníes (₲). Los precios en guaraníes están en nuestra tabla de servicios."
+        },
+        {
+          "question": "¿Puedo usar la portada en Amazon KDP / Wattpad / editorial?",
+          "answer": "Sí. Los derechos del diseño pertenecen a Dayah LitWorks hasta el pago completo. Una vez pago al 100%, podés usar la portada en la plataforma que elijas."
+        },
+        {
+          "question": "¿Qué es un mockup 3D?",
+          "answer": "Es una imagen realista de tu libro renderizada en 3D. Ideal para promocionar en redes sociales y marketing."
+        },
+        {
+          "question": "¿Qué pasa si cancelo el proyecto?",
+          "answer": "Si el cliente decide rescindir el contrato una vez iniciado el proyecto, el anticipo no es reembolsable."
+        },
+        {
+          "question": "¿Hacés rediseños de portadas existentes?",
+          "answer": "Sí, podés contratar un rediseño como portada personalizada. Envianos la portada actual y tus nuevas ideas."
+        },
+        {
+          "question": "¿Qué necesito enviar para empezar?",
+          "answer": "Título del libro, sinopsis, género, referencias visuales (ideas, tipografías, colores, estilos). Es importante enviar las referencias ANTES de solicitar el diseño."
+        },
+        {
+          "question": "¿En qué idioma diseñás?",
+          "answer": "Diseñamos portadas en español e inglés. Los textos tipográficos se adaptan al idioma de tu libro."
+        },
+        {
+          "question": "¿Puedo contratar urgente (48–72h)?",
+          "answer": "Contáctanos por WhatsApp para verificar disponibilidad. Los proyectos urgentes pueden tener un recargo."
+        },
+        {
+          "question": "¿Cómo se entregan los archivos finales?",
+          "answer": "Archivos en alta resolución (JPG, PDF, PNG) listos para subir a tu plataforma. Los mockups se entregan como imágenes renderizadas."
+        }
       ]
     },
     "testimonials": {
       "title": "Testimonios",
       "items": [
-        { "quote": "Mi portada quedó increíble! Dayah entendió perfectamente la esencia de mi libro.", "author": "María G.", "rating": 5 },
-        { "quote": "Profesional, creativa y super rápida. Mi portada premade fue amor a primera vista.", "author": "Carlos R.", "rating": 5 }
+        {
+          "quote": "Mi portada quedó increíble! Dayah entendió perfectamente la esencia de mi libro.",
+          "author": "María G.",
+          "rating": 5
+        },
+        {
+          "quote": "Profesional, creativa y super rápida. Mi portada premade fue amor a primera vista.",
+          "author": "Carlos R.",
+          "rating": 5
+        }
       ]
     },
     "contact": {
@@ -285,7 +637,14 @@
     },
     "title": "Portafolio",
     "subtitle": "Portadas que venden libros",
-    "filters": ["Todos", "Fantasía", "Romance", "Thriller", "Ciencia Ficción", "Terror"],
+    "filters": [
+      "Todos",
+      "Fantasía",
+      "Romance",
+      "Thriller",
+      "Ciencia Ficción",
+      "Terror"
+    ],
     "items": []
   },
   "blog": {
@@ -341,10 +700,37 @@
   "quoteForm": {
     "title": "Contame sobre tu proyecto",
     "steps": [
-      { "id": "genre", "title": "¿De qué trata tu libro?", "fields": ["Género", "Título"] },
-      { "id": "service", "title": "¿Qué necesitás?", "fields": ["Tipo de servicio"] },
-      { "id": "details", "title": "Detalles", "fields": ["Plazo", "Presupuesto"] },
-      { "id": "contact", "title": "Tus datos", "fields": ["Nombre", "Email o WhatsApp"] }
+      {
+        "id": "genre",
+        "title": "¿De qué trata tu libro?",
+        "fields": [
+          "Género",
+          "Título"
+        ]
+      },
+      {
+        "id": "service",
+        "title": "¿Qué necesitás?",
+        "fields": [
+          "Tipo de servicio"
+        ]
+      },
+      {
+        "id": "details",
+        "title": "Detalles",
+        "fields": [
+          "Plazo",
+          "Presupuesto"
+        ]
+      },
+      {
+        "id": "contact",
+        "title": "Tus datos",
+        "fields": [
+          "Nombre",
+          "Email o WhatsApp"
+        ]
+      }
     ],
     "serviceOptions": [
       "Portada Personalizada — eBook ($45)",
@@ -373,13 +759,44 @@
       "short": "Diseñadora de portadas de libros con más de 6 años de experiencia. Desde Asunción, Paraguay, para autores en todo el mundo.",
       "long": "Soy Daihana Araujo, fundadora de Dayah LitWorks. Desde noviembre de 2019 me dedico a transformar manuscritos en portadas que venden libros.\n\nCreé Dayah LitWorks con la convicción de que cada libro merece una portada profesional, sin importar el presupuesto del autor. Trabajo con autores indie de todo el mundo hispano y angloparlante, diseñando portadas que capturan la esencia de cada historia.\n\nMi enfoque combina la comprensión profunda de cada género literario con un proceso creativo colaborativo. Creo que la mejor portada nace de escuchar al autor, entender su visión y traducirla en un diseño que no solo sea hermoso, sino que funcione como herramienta de venta.",
       "founded": "Fundada el 20 de noviembre de 2019",
-      "location": "Asunción, Paraguay"
+      "location": "Asunción, Paraguay",
+      "features": [
+        {
+          "title": "",
+          "description": "Diseñadora de portadas de libros con más de 6 años de experiencia. Desde Asunción, Paraguay, para autores en todo el mundo."
+        },
+        {
+          "title": "",
+          "description": "Soy Daihana Araujo, fundadora de Dayah LitWorks. Desde noviembre de 2019 me dedico a transformar manuscritos en portadas que venden libros.\n\nCreé Dayah LitWorks con la convicción de que cada libro merece una portada profesional, sin importar el presupuesto del autor. Trabajo con autores indie de todo el mundo hispano y angloparlante, diseñando portadas que capturan la esencia de cada historia.\n\nMi enfoque combina la comprensión profunda de cada género literario con un proceso creativo colaborativo. Creo que la mejor portada nace de escuchar al autor, entender su visión y traducirla en un diseño que no solo sea hermoso, sino que funcione como herramienta de venta."
+        },
+        {
+          "title": "Fundación",
+          "description": "Fundada el 20 de noviembre de 2019"
+        },
+        {
+          "title": "Ubicación",
+          "description": "Asunción, Paraguay"
+        }
+      ],
+      "title": "Sobre Daihana"
     },
     "highlights": [
-      { "label": "6+", "description": "Años de experiencia" },
-      { "label": "100+", "description": "Portadas diseñadas" },
-      { "label": "Global", "description": "Clientes en LATAM, USA y Europa" },
-      { "label": "Bilingüe", "description": "Español e inglés" }
+      {
+        "title": "6+",
+        "description": "Años de experiencia"
+      },
+      {
+        "title": "100+",
+        "description": "Portadas diseñadas"
+      },
+      {
+        "title": "Global",
+        "description": "Clientes en LATAM, USA y Europa"
+      },
+      {
+        "title": "Bilingüe",
+        "description": "Español e inglés"
+      }
     ]
   },
   "terminos": {
@@ -391,42 +808,68 @@
     "subtitle": "El pago del presupuesto implica la aceptación de las siguientes condiciones",
     "sections": [
       {
-        "title": "1. Referencias previas",
-        "content": "Envía siempre referencias de ideas, tipografías, colores o estilos ANTES de solicitar el diseño, no después de enviar la propuesta terminada."
+        "question": "1. Referencias previas",
+        "answer": "Envía siempre referencias de ideas, tipografías, colores o estilos ANTES de solicitar el diseño, no después de enviar la propuesta terminada."
       },
       {
-        "title": "2. Días hábiles",
-        "content": "El trabajo se realiza en días hábiles (lunes a viernes), con el tiempo suficiente acordado para entregar una pieza de calidad."
+        "question": "2. Días hábiles",
+        "answer": "El trabajo se realiza en días hábiles (lunes a viernes), con el tiempo suficiente acordado para entregar una pieza de calidad."
       },
       {
-        "title": "3. Cancelación",
-        "content": "Si una vez iniciado el proyecto el cliente decidiera rescindir el contrato y no seguir trabajando con Dayah LitWorks, no se le reembolsará el porcentaje adelantado."
+        "question": "3. Cancelación",
+        "answer": "Si una vez iniciado el proyecto el cliente decidiera rescindir el contrato y no seguir trabajando con Dayah LitWorks, no se le reembolsará el porcentaje adelantado."
       },
       {
-        "title": "4. Responsabilidad de revisión",
-        "content": "El cliente adquiere la responsabilidad de revisar el diseño, los textos y datos antes de empezar cualquier proceso de impresión, reproducción y/o publicación, y libera a Dayah LitWorks de cualquier responsabilidad por los errores que se pudieran producir."
+        "question": "4. Responsabilidad de revisión",
+        "answer": "El cliente adquiere la responsabilidad de revisar el diseño, los textos y datos antes de empezar cualquier proceso de impresión, reproducción y/o publicación, y libera a Dayah LitWorks de cualquier responsabilidad por los errores que se pudieran producir."
       },
       {
-        "title": "5. Cambios de alcance",
-        "content": "Este acuerdo no incluye los trabajos adicionales que se puedan derivar de los cambios de orientación en su desarrollo por parte del cliente. Si se diera el caso, Dayah LitWorks informará al cliente y podrá modificar el presupuesto."
+        "question": "5. Cambios de alcance",
+        "answer": "Este acuerdo no incluye los trabajos adicionales que se puedan derivar de los cambios de orientación en su desarrollo por parte del cliente. Si se diera el caso, Dayah LitWorks informará al cliente y podrá modificar el presupuesto."
       },
       {
-        "title": "6. Derechos de diseño",
-        "content": "Los derechos del o los diseños realizados pertenecen a Dayah LitWorks hasta que el cliente no haya efectuado el 100% del pago."
+        "question": "6. Derechos de diseño",
+        "answer": "Los derechos del o los diseños realizados pertenecen a Dayah LitWorks hasta que el cliente no haya efectuado el 100% del pago."
       },
       {
-        "title": "7. Uso en portafolio",
-        "content": "Dayah LitWorks podrá mostrar los trabajos realizados en el portfolio, así como en otras plataformas digitales como Instagram, Facebook, TikTok o página web."
+        "question": "7. Uso en portafolio",
+        "answer": "Dayah LitWorks podrá mostrar los trabajos realizados en el portfolio, así como en otras plataformas digitales como Instagram, Facebook, TikTok o página web."
       }
     ],
     "payment": {
       "title": "Métodos de pago",
       "methods": [
-        { "name": "Western Union", "description": "Para clientes internacionales" },
-        { "name": "Transferencia bancaria", "description": "Bancos de Paraguay" },
-        { "name": "Efectivo", "description": "Pago presencial en Asunción" }
+        {
+          "name": "Western Union",
+          "description": "Para clientes internacionales"
+        },
+        {
+          "name": "Transferencia bancaria",
+          "description": "Bancos de Paraguay"
+        },
+        {
+          "name": "Efectivo",
+          "description": "Pago presencial en Asunción"
+        }
       ],
-      "note": "Se requiere anticipo del 50% para iniciar el proyecto. El saldo restante se abona al aprobar el diseño final."
+      "note": "Se requiere anticipo del 50% para iniciar el proyecto. El saldo restante se abona al aprobar el diseño final.",
+      "features": [
+        {
+          "title": "Western Union",
+          "description": "Para clientes internacionales",
+          "icon": null
+        },
+        {
+          "title": "Transferencia bancaria",
+          "description": "Bancos de Paraguay",
+          "icon": null
+        },
+        {
+          "title": "Efectivo",
+          "description": "Pago presencial en Asunción",
+          "icon": null
+        }
+      ]
     }
   },
   "footer": {

--- a/sites/dayah-litworks/pages/blog.json
+++ b/sites/dayah-litworks/pages/blog.json
@@ -3,12 +3,45 @@
   "titleKey": "blog.seo.title",
   "descriptionKey": "blog.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "minimal", "content": "blog" },
-    { "id": "blog-index", "variant": "grid", "content": "blog.posts" },
-    { "id": "newsletter-signup", "variant": "standard", "content": "newsletter" },
-    { "id": "cta-banner", "variant": "gradient", "content": "ctaBanner" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "blog"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "blog.placeholder"
+    },
+    {
+      "id": "features",
+      "variant": "three-col",
+      "content": "blog.placeholder"
+    },
+    {
+      "id": "newsletter-signup",
+      "variant": "standard",
+      "content": "newsletter"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "gradient",
+      "content": "ctaBanner"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/dayah-litworks/pages/catalogo.json
+++ b/sites/dayah-litworks/pages/catalogo.json
@@ -3,11 +3,30 @@
   "titleKey": "home.products.title",
   "descriptionKey": "home.products.subtitle",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "product-catalog", "variant": "grid", "content": "home.products" },
-    { "id": "testimonials", "variant": "carousel", "content": "home.testimonials" },
-    { "id": "contact", "variant": "split", "content": "home.contact" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "product-catalog",
+      "variant": "grid",
+      "content": "home.products"
+    },
+    {
+      "id": "contact",
+      "variant": "split",
+      "content": "home.contact"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/dayah-litworks/pages/contacto.json
+++ b/sites/dayah-litworks/pages/contacto.json
@@ -1,14 +1,42 @@
 {
   "slug": "contacto",
-  "title": "Contacto - Dayah LitWorks",
-  "description": "Contáctanos para tu proyecto de portada de libro",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "minimal", "content": "contactHero" },
-    { "id": "contact", "variant": "split", "content": "home.contact" },
-    { "id": "quote-form", "variant": "standard", "content": "quoteForm" },
-    { "id": "newsletter-signup", "variant": "standard", "content": "newsletter" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
-  ]
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "contactHero"
+    },
+    {
+      "id": "contact",
+      "variant": "split",
+      "content": "home.contact"
+    },
+    {
+      "id": "quote-form",
+      "variant": "standard",
+      "content": "quoteForm"
+    },
+    {
+      "id": "newsletter-signup",
+      "variant": "standard",
+      "content": "newsletter"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
+  ],
+  "titleKey": "contactHero.title",
+  "descriptionKey": "contactHero.subtitle"
 }

--- a/sites/dayah-litworks/pages/home.json
+++ b/sites/dayah-litworks/pages/home.json
@@ -3,17 +3,60 @@
   "titleKey": "home.seo.title",
   "descriptionKey": "home.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "image", "content": "home.hero" },
-    { "id": "trust-badges", "variant": "strip", "content": "home.trustBadges" },
-    { "id": "services", "variant": "cards", "content": "home.services" },
-    { "id": "product-catalog", "variant": "grid", "content": "home.products" },
-    { "id": "process", "variant": "steps", "content": "home.process" },
-    { "id": "testimonials", "variant": "carousel", "content": "home.testimonials" },
-    { "id": "faq", "variant": "accordion", "content": "home.faq" },
-    { "id": "cta-banner", "variant": "gradient", "content": "ctaBanner" },
-    { "id": "contact", "variant": "split", "content": "home.contact" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "image",
+      "content": "home.hero"
+    },
+    {
+      "id": "trust-badges",
+      "variant": "strip",
+      "content": "home.trustBadges"
+    },
+    {
+      "id": "services",
+      "variant": "cards",
+      "content": "home.services"
+    },
+    {
+      "id": "product-catalog",
+      "variant": "grid",
+      "content": "home.products"
+    },
+    {
+      "id": "process",
+      "variant": "steps",
+      "content": "home.process"
+    },
+    {
+      "id": "faq",
+      "variant": "accordion",
+      "content": "home.faq"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "gradient",
+      "content": "ctaBanner"
+    },
+    {
+      "id": "contact",
+      "variant": "split",
+      "content": "home.contact"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/dayah-litworks/pages/portafolio.json
+++ b/sites/dayah-litworks/pages/portafolio.json
@@ -3,11 +3,35 @@
   "titleKey": "portfolio.seo.title",
   "descriptionKey": "portfolio.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "gallery", "variant": "grid", "content": "portfolio" },
-    { "id": "testimonials", "variant": "carousel", "content": "home.testimonials" },
-    { "id": "contact", "variant": "split", "content": "home.contact" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "portfolio.placeholder"
+    },
+    {
+      "id": "features",
+      "variant": "three-col",
+      "content": "portfolio.placeholder"
+    },
+    {
+      "id": "contact",
+      "variant": "split",
+      "content": "home.contact"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/sites/dayah-litworks/pages/servicios.json
+++ b/sites/dayah-litworks/pages/servicios.json
@@ -3,12 +3,45 @@
   "titleKey": "home.services.title",
   "descriptionKey": "home.services.subtitle",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "minimal", "content": "home.services" },
-    { "id": "services", "variant": "cards", "content": "home.services" },
-    { "id": "faq", "variant": "accordion", "content": "home.faq" },
-    { "id": "cta-banner", "variant": "gradient", "content": "ctaBanner" },
-    { "id": "footer", "variant": "standard", "content": "footer" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" }
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "home.services"
+    },
+    {
+      "id": "services",
+      "variant": "cards",
+      "content": "home.services"
+    },
+    {
+      "id": "features",
+      "variant": "grid",
+      "content": "home.services.addons_block"
+    },
+    {
+      "id": "faq",
+      "variant": "accordion",
+      "content": "home.faq"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "gradient",
+      "content": "ctaBanner"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
   ]
 }

--- a/web/components/sections/contact-section.tsx
+++ b/web/components/sections/contact-section.tsx
@@ -14,13 +14,41 @@ export interface ContactSectionProps {
   phone?: string
   email?: string
   whatsapp?: string
+  whatsappMessage?: string
   googleMapsUrl?: string
   hours?: Record<string, string>
+  __locale?: string
+}
+
+const CONTACT_LABELS: Record<string, {
+  address: string
+  contact: string
+  whatsappCta: string
+  email: string
+  hours: string
+  mapAlt: (city: string) => string
+}> = {
+  en: {
+    address: 'Address',
+    contact: 'Contact',
+    whatsappCta: 'Message on WhatsApp',
+    email: 'Email',
+    hours: 'Business hours',
+    mapAlt: (city) => `Map of ${city}`,
+  },
+  es: {
+    address: 'Dirección',
+    contact: 'Contacto',
+    whatsappCta: 'Escribir por WhatsApp',
+    email: 'Email',
+    hours: 'Horario de atención',
+    mapAlt: (city) => `Mapa de ${city}`,
+  },
 }
 
 /**
  * Enhanced Contact section with improved layout and UX.
- * 
+ *
  * Improvements:
  * - Better visual hierarchy with cards
  * - Improved spacing and typography
@@ -37,11 +65,17 @@ export function ContactSection({
   phone,
   email,
   whatsapp,
+  whatsappMessage,
   googleMapsUrl,
   hours,
+  __locale = 'es',
 }: ContactSectionProps) {
+  const labels = CONTACT_LABELS[__locale] ?? CONTACT_LABELS.es
   const hasContactInfo = phone || email || whatsapp
   const hasHours = hours && Object.keys(hours).length > 0
+  const whatsappHref = whatsapp
+    ? `https://wa.me/${whatsapp.replace(/\D/g, '')}${whatsappMessage ? `?text=${encodeURIComponent(whatsappMessage)}` : ''}`
+    : ''
 
   return (
     <section id="contacto" className="bg-[var(--surface)] py-20 sm:py-28 lg:py-32">
@@ -90,7 +124,7 @@ export function ContactSection({
                     className="mb-2 text-base font-bold uppercase tracking-wide"
                     style={{ color: 'var(--text)' }}
                   >
-                    Adresse
+                    {labels.address}
                   </Heading>
                   <p className="leading-relaxed" style={{ color: 'var(--text-light)' }}>
                     {address && <span className="block">{address}</span>}
@@ -122,7 +156,7 @@ export function ContactSection({
                       className="mb-2 text-base font-bold uppercase tracking-wide"
                       style={{ color: 'var(--text)' }}
                     >
-                      Kontakt
+                      {labels.contact}
                     </Heading>
                     {phone && (
                       <a 
@@ -135,7 +169,7 @@ export function ContactSection({
                     )}
                     {whatsapp && (
                       <a
-                        href={`https://wa.me/${whatsapp.replace(/\D/g, '')}`}
+                        href={whatsappHref}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-2 mt-2 px-5 py-2.5 rounded-lg text-sm font-semibold transition-all duration-300 hover:scale-[1.02]"
@@ -146,7 +180,7 @@ export function ContactSection({
                         }}
                       >
                         <MessageCircle size={18} />
-                        WhatsApp schreiben
+                        {labels.whatsappCta}
                         <ArrowRight size={14} />
                       </a>
                     )}
@@ -176,7 +210,7 @@ export function ContactSection({
                       className="mb-2 text-base font-bold uppercase tracking-wide"
                       style={{ color: 'var(--text)' }}
                     >
-                      E-Mail
+                      {labels.email}
                     </Heading>
                     <a 
                       href={`mailto:${email}`}
@@ -211,7 +245,7 @@ export function ContactSection({
                       className="mb-3 text-base font-bold uppercase tracking-wide"
                       style={{ color: 'var(--text)' }}
                     >
-                      Bürozeiten
+                      {labels.hours}
                     </Heading>
                     <dl className="space-y-2">
                       {Object.entries(hours).map(([day, time]) => (
@@ -248,7 +282,7 @@ export function ContactSection({
                   allowFullScreen
                   loading="lazy"
                   referrerPolicy="no-referrer-when-downgrade"
-                  title={`Karte von ${city}`}
+                  title={labels.mapAlt(city)}
                   style={{ filter: 'grayscale(15%) contrast(105%)' }}
                 />
               ) : (

--- a/web/components/sections/services-section.tsx
+++ b/web/components/sections/services-section.tsx
@@ -13,6 +13,13 @@ export interface ServiceItem {
   description?: string
   price?: string
   priceFrom?: string
+  /** Optional dual-currency prices — when both present they render as "$X / ₲Y" */
+  priceUSD?: string
+  pricePYG?: string
+  /** Optional expected delivery time (e.g. "1–2 semanas") */
+  delivery?: string
+  /** Optional list of bullet points describing what's included */
+  includes?: string[]
   duration?: number
   imageUrl?: string
   category?: string
@@ -38,12 +45,20 @@ export interface ServicesSectionProps {
   __locale?: string
 }
 
-const SERVICE_LABELS: Record<string, { from: string; otherCategory: string }> = {
-  de: { from: 'Ab', otherCategory: 'Sonstige' },
-  en: { from: 'From', otherCategory: 'Other' },
-  es: { from: 'Desde', otherCategory: 'Otros' },
-  nl: { from: 'Vanaf', otherCategory: 'Overig' },
-  pt: { from: 'Desde', otherCategory: 'Outros' },
+const SERVICE_LABELS: Record<string, { from: string; otherCategory: string; includes: string; delivery: string }> = {
+  en: { from: 'From', otherCategory: 'Other', includes: 'Includes', delivery: 'Delivery' },
+  es: { from: 'Desde', otherCategory: 'Otros', includes: 'Incluye', delivery: 'Entrega' },
+}
+
+function renderPriceLabel(service: ServiceItem, fromLabel: string): string | null {
+  if (service.priceUSD && service.pricePYG) {
+    return `${service.priceUSD} / ${service.pricePYG}`
+  }
+  if (service.priceUSD) return service.priceUSD
+  if (service.pricePYG) return service.pricePYG
+  if (service.priceFrom) return `${fromLabel} ${service.priceFrom}`
+  if (service.price) return service.price
+  return null
 }
 
 /**
@@ -128,20 +143,41 @@ export function ServicesSection({
             <Heading level={3} className="text-lg font-semibold text-[var(--text)]" style={{ fontFamily: 'var(--font-heading)' }}>
               {service.name}
             </Heading>
-            {showPrices && (service.price || service.priceFrom) && (
+            {showPrices && renderPriceLabel(service, L.from) && (
               <Badge variant="outline">
-                {service.priceFrom ? `${L.from} ${service.priceFrom}` : service.price}
+                {renderPriceLabel(service, L.from)}
               </Badge>
             )}
           </div>
           {service.description && (
             <p className="mt-1 text-sm text-[var(--text-muted)]">{service.description}</p>
           )}
-          {showDuration && service.duration && (
+          {service.delivery && (
+            <p className="mt-3 flex items-center gap-1 text-xs text-[var(--text-muted)]">
+              <Clock size={12} />
+              {L.delivery}: {service.delivery}
+            </p>
+          )}
+          {showDuration && service.duration && !service.delivery && (
             <p className="mt-3 flex items-center gap-1 text-xs text-[var(--text-muted)]">
               <Clock size={12} />
               {service.duration} min
             </p>
+          )}
+          {service.includes && service.includes.length > 0 && (
+            <div className="mt-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                {L.includes}
+              </p>
+              <ul className="mt-2 space-y-1">
+                {service.includes.map((item, i) => (
+                  <li key={i} className="flex gap-2 text-sm text-[var(--text)]">
+                    <span className="text-[var(--primary)]">•</span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
           )}
         </div>
       </>

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -5752,9 +5752,14 @@ export const PAGES: Record<string, JsonRecord> = {
         "variant": "minimal"
       },
       {
-        "content": "blog.posts",
-        "id": "blog-index",
-        "variant": "grid"
+        "content": "blog.placeholder",
+        "id": "hero",
+        "variant": "minimal"
+      },
+      {
+        "content": "blog.placeholder",
+        "id": "features",
+        "variant": "three-col"
       },
       {
         "content": "newsletter",
@@ -5794,11 +5799,6 @@ export const PAGES: Record<string, JsonRecord> = {
         "variant": "grid"
       },
       {
-        "content": "home.testimonials",
-        "id": "testimonials",
-        "variant": "carousel"
-      },
-      {
         "content": "home.contact",
         "id": "contact",
         "variant": "split"
@@ -5818,7 +5818,7 @@ export const PAGES: Record<string, JsonRecord> = {
     "titleKey": "home.products.title"
   },
   "dayah-litworks:contacto": {
-    "description": "Contáctanos para tu proyecto de portada de libro",
+    "descriptionKey": "contactHero.subtitle",
     "sections": [
       {
         "content": "navigation",
@@ -5857,7 +5857,7 @@ export const PAGES: Record<string, JsonRecord> = {
       }
     ],
     "slug": "contacto",
-    "title": "Contacto - Dayah LitWorks"
+    "titleKey": "contactHero.title"
   },
   "dayah-litworks:home": {
     "descriptionKey": "home.seo.description",
@@ -5891,11 +5891,6 @@ export const PAGES: Record<string, JsonRecord> = {
         "content": "home.process",
         "id": "process",
         "variant": "steps"
-      },
-      {
-        "content": "home.testimonials",
-        "id": "testimonials",
-        "variant": "carousel"
       },
       {
         "content": "home.faq",
@@ -5935,14 +5930,14 @@ export const PAGES: Record<string, JsonRecord> = {
         "variant": "standard"
       },
       {
-        "content": "portfolio",
-        "id": "gallery",
-        "variant": "grid"
+        "content": "portfolio.placeholder",
+        "id": "hero",
+        "variant": "minimal"
       },
       {
-        "content": "home.testimonials",
-        "id": "testimonials",
-        "variant": "carousel"
+        "content": "portfolio.placeholder",
+        "id": "features",
+        "variant": "three-col"
       },
       {
         "content": "home.contact",
@@ -5980,6 +5975,11 @@ export const PAGES: Record<string, JsonRecord> = {
         "content": "home.services",
         "id": "services",
         "variant": "cards"
+      },
+      {
+        "content": "home.services.addons_block",
+        "id": "features",
+        "variant": "grid"
       },
       {
         "content": "home.faq",
@@ -12906,6 +12906,27 @@ export const CONTENT: Record<string, JsonRecord> = {
         "subtitle": "Tips, trends and resources for authors",
         "title": "Blog"
       },
+      "placeholder": {
+        "features": [
+          {
+            "description": "One email a month with tips and examples of covers that sell.",
+            "href": "#newsletter",
+            "title": "Newsletter"
+          },
+          {
+            "description": "Follow recent work + behind-the-scenes.",
+            "href": "https://instagram.com/dayah.litworks",
+            "title": "Instagram @dayah.litworks"
+          },
+          {
+            "description": "Direct questions, fast answers.",
+            "href": "https://wa.me/595986868241",
+            "title": "WhatsApp"
+          }
+        ],
+        "subtitle": "Soon you will find cover design tips, trends, and resources for indie authors. In the meantime, subscribe to the newsletter.",
+        "title": "Blog coming soon"
+      },
       "posts": [
         {
           "category": "Design",
@@ -13015,13 +13036,24 @@ export const CONTENT: Record<string, JsonRecord> = {
     },
     "home": {
       "contact": {
+        "city": "Asunción, Paraguay",
         "email": "dayahlitworks@gmail.com",
         "facebook": "https://www.facebook.com/bookc0verdesign/",
+        "hours": {
+          "Friday": "09:00 – 18:00",
+          "Monday": "09:00 – 18:00",
+          "Saturday": "Closed",
+          "Sunday": "Closed",
+          "Thursday": "09:00 – 18:00",
+          "Tuesday": "09:00 – 18:00",
+          "Wednesday": "09:00 – 18:00"
+        },
         "instagram": "@dayah.litworks",
         "linkedin": "https://www.linkedin.com/in/daihana-araujo/",
         "subtitle": "Same-day response",
         "title": "Contact Us",
-        "whatsapp": "+595986868241"
+        "whatsapp": "+595986868241",
+        "whatsappMessage": "Hi Dayah! I want to ask about a cover design."
       },
       "faq": {
         "items": [
@@ -13253,6 +13285,24 @@ export const CONTENT: Record<string, JsonRecord> = {
             "price": "Per evaluation"
           }
         ],
+        "addons_block": {
+          "features": [
+            {
+              "description": "Realistic 3D render of your book (Quote)",
+              "title": "Static 3D Mockup"
+            },
+            {
+              "description": "Professional animation of your cover (Quote)",
+              "title": "3D Video Mockup"
+            },
+            {
+              "description": "Priced based on evaluation of first chapters and manuscript length (Per evaluation)",
+              "title": "Copyediting & Proofreading"
+            }
+          ],
+          "subtitle": "Add-ons you can attach to any package. Quote on request.",
+          "title": "Additional services"
+        },
         "categories": [
           {
             "description": "Exclusive design created from scratch for your book",
@@ -13378,6 +13428,118 @@ export const CONTENT: Record<string, JsonRecord> = {
             "title": "Interior Layout"
           }
         ],
+        "items": [
+          {
+            "category": "Custom Covers",
+            "delivery": "1–2 weeks",
+            "description": "Exclusive eBook cover design",
+            "includes": [
+              "eBook cover (JPG/PDF)",
+              "Title PNG + Title page PNG",
+              "2 cover reveal banners",
+              "2 Mockups"
+            ],
+            "name": "Custom Cover — eBook",
+            "pricePYG": "₲300,000",
+            "priceUSD": "$45"
+          },
+          {
+            "category": "Custom Covers",
+            "delivery": "1–2 weeks",
+            "description": "Full cover (front + spine + back) for print",
+            "includes": [
+              "Paperback cover (JPG/PDF)",
+              "Print-ready file (PDF)",
+              "Title PNG + Title page PNG",
+              "2 cover reveal banners",
+              "2 Mockups"
+            ],
+            "name": "Custom Cover — Paperback",
+            "pricePYG": "₲500,000",
+            "priceUSD": "$80"
+          },
+          {
+            "category": "Custom Covers",
+            "delivery": "2–3 weeks",
+            "description": "Complete combo: eBook + paperback cover",
+            "includes": [
+              "eBook cover (JPG/PDF)",
+              "Print-ready file (PDF)",
+              "Title PNG + Title page PNG",
+              "2 cover reveal banners",
+              "2 Mockups"
+            ],
+            "name": "Cover Paperback & eBook",
+            "pricePYG": "₲800,000",
+            "priceUSD": "$120"
+          },
+          {
+            "category": "Premade Covers",
+            "delivery": "1–2 weeks",
+            "description": "Premade eBook cover with customization",
+            "includes": [
+              "eBook cover (JPG/PDF)",
+              "Title PNG + Title page PNG",
+              "2 cover reveal banners",
+              "2 Mockups"
+            ],
+            "name": "Premade eBook",
+            "pricePYG": "₲250,000",
+            "priceUSD": "$35",
+            "scopeNote": "Includes copy and typography alterations, color changes, minor element repositioning"
+          },
+          {
+            "category": "Premade Covers",
+            "delivery": "1–2 weeks",
+            "description": "Premade cover with paperback version",
+            "includes": [
+              "Paperback cover (JPG/PDF)",
+              "Print-ready file (PDF)",
+              "Title PNG + Title page PNG",
+              "2 cover reveal banners",
+              "2 Mockups"
+            ],
+            "name": "Premade eBook & Paperback",
+            "pricePYG": "₲500,000",
+            "priceUSD": "$80"
+          },
+          {
+            "category": "Interior Layout",
+            "delivery": "1–2 weeks",
+            "description": "Professional interior design for eBooks",
+            "includes": [
+              "Professional interior design",
+              "File per platform specs (WORD/PDF)"
+            ],
+            "name": "eBook Layout",
+            "pricePYG": "₲160,000",
+            "priceUSD": "$25"
+          },
+          {
+            "category": "Interior Layout",
+            "delivery": "1–2 weeks",
+            "description": "Professional interior design for print",
+            "includes": [
+              "Professional interior design",
+              "File per platform specs (WORD/PDF)"
+            ],
+            "name": "Paperback Layout",
+            "pricePYG": "₲250,000",
+            "priceUSD": "$35"
+          },
+          {
+            "category": "Interior Layout",
+            "delivery": "1–2 weeks",
+            "description": "Complete interior design for both formats",
+            "includes": [
+              "Professional interior design",
+              "File per platform specs (WORD/PDF)"
+            ],
+            "name": "eBook & Paperback Layout",
+            "pricePYG": "₲320,000",
+            "priceUSD": "$50"
+          }
+        ],
         "subtitle": "Professional design for your book",
         "title": "Our Services"
       },
@@ -13478,6 +13640,27 @@ export const CONTENT: Record<string, JsonRecord> = {
         "Horror"
       ],
       "items": [],
+      "placeholder": {
+        "features": [
+          {
+            "description": "Ready-to-use designs — with typography and color customization.",
+            "href": "/s/en/dayah-litworks/catalogo",
+            "title": "Premade Catalog"
+          },
+          {
+            "description": "Latest work + behind-the-scenes on Instagram.",
+            "href": "https://instagram.com/dayah.litworks",
+            "title": "Instagram @dayah.litworks"
+          },
+          {
+            "description": "Tell me what you're writing — I reply during business hours.",
+            "href": "https://wa.me/595986868241",
+            "title": "WhatsApp"
+          }
+        ],
+        "subtitle": "I'm curating recent work to share here. In the meantime, browse the premade catalog or DM me on WhatsApp.",
+        "title": "Portfolio coming soon"
+      },
       "seo": {
         "description": "Gallery of book covers designed by Dayah LitWorks",
         "title": "Portfolio — Dayah LitWorks"
@@ -13543,10 +13726,29 @@ export const CONTENT: Record<string, JsonRecord> = {
     "siteName": "Dayah LitWorks",
     "sobre": {
       "bio": {
+        "features": [
+          {
+            "description": "Book cover designer with 6+ years of experience. From Asunción, Paraguay, to authors worldwide.",
+            "title": ""
+          },
+          {
+            "description": "I'm Daihana Araujo, founder of Dayah LitWorks. Since November 2019, I've been transforming manuscripts into covers that sell books.\n\nI created Dayah LitWorks with the conviction that every book deserves a professional cover, regardless of the author's budget. I work with indie authors across the Spanish and English-speaking world, designing covers that capture the essence of each story.\n\nMy approach combines a deep understanding of literary genres with a collaborative creative process. I believe the best cover comes from listening to the author, understanding their vision, and translating it into a design that's not only beautiful but works as a sales tool.",
+            "title": ""
+          },
+          {
+            "description": "Founded November 20, 2019",
+            "title": "Founded"
+          },
+          {
+            "description": "Asunción, Paraguay",
+            "title": "Location"
+          }
+        ],
         "founded": "Founded November 20, 2019",
         "location": "Asunción, Paraguay",
         "long": "I'm Daihana Araujo, founder of Dayah LitWorks. Since November 2019, I've been transforming manuscripts into covers that sell books.\n\nI created Dayah LitWorks with the conviction that every book deserves a professional cover, regardless of the author's budget. I work with indie authors across the Spanish and English-speaking world, designing covers that capture the essence of each story.\n\nMy approach combines a deep understanding of literary genres with a collaborative creative process. I believe the best cover comes from listening to the author, understanding their vision, and translating it into a design that's not only beautiful but works as a sales tool.",
-        "short": "Book cover designer with 6+ years of experience. From Asunción, Paraguay, to authors worldwide."
+        "short": "Book cover designer with 6+ years of experience. From Asunción, Paraguay, to authors worldwide.",
+        "title": "About Daihana"
       },
       "hero": {
         "subtitle": "Where fantasy becomes reality",
@@ -13555,19 +13757,19 @@ export const CONTENT: Record<string, JsonRecord> = {
       "highlights": [
         {
           "description": "Years of experience",
-          "label": "6+"
+          "title": "6+"
         },
         {
           "description": "Covers designed",
-          "label": "100+"
+          "title": "100+"
         },
         {
           "description": "Clients in LATAM, USA and Europe",
-          "label": "Global"
+          "title": "Global"
         },
         {
           "description": "Spanish and English",
-          "label": "Bilingual"
+          "title": "Bilingual"
         }
       ],
       "seo": {
@@ -13578,6 +13780,23 @@ export const CONTENT: Record<string, JsonRecord> = {
     "tagline": "Book cover design — from manuscript to a cover that sells",
     "terminos": {
       "payment": {
+        "features": [
+          {
+            "description": "For international clients",
+            "icon": null,
+            "title": "Western Union"
+          },
+          {
+            "description": "Paraguayan banks",
+            "icon": null,
+            "title": "Bank transfer"
+          },
+          {
+            "description": "In-person payment in Asunción",
+            "icon": null,
+            "title": "Cash"
+          }
+        ],
         "methods": [
           {
             "description": "For international clients",
@@ -13597,32 +13816,32 @@ export const CONTENT: Record<string, JsonRecord> = {
       },
       "sections": [
         {
-          "content": "Always send references for ideas, fonts, colors or styles BEFORE requesting design — not after the finished proposal is delivered.",
-          "title": "1. References first"
+          "answer": "Always send references for ideas, fonts, colors or styles BEFORE requesting design — not after the finished proposal is delivered.",
+          "question": "1. References first"
         },
         {
-          "content": "Work is done on business days (Monday through Friday), with sufficient time allocated for quality delivery.",
-          "title": "2. Business days"
+          "answer": "Work is done on business days (Monday through Friday), with sufficient time allocated for quality delivery.",
+          "question": "2. Business days"
         },
         {
-          "content": "If the client decides to terminate the contract after the project has started, the advance payment is non-refundable.",
-          "title": "3. Cancellation"
+          "answer": "If the client decides to terminate the contract after the project has started, the advance payment is non-refundable.",
+          "question": "3. Cancellation"
         },
         {
-          "content": "The client is responsible for reviewing the design, text and data before any printing, reproduction and/or publication. Dayah LitWorks is not liable for errors not communicated beforehand.",
-          "title": "4. Review responsibility"
+          "answer": "The client is responsible for reviewing the design, text and data before any printing, reproduction and/or publication. Dayah LitWorks is not liable for errors not communicated beforehand.",
+          "question": "4. Review responsibility"
         },
         {
-          "content": "This agreement does not include additional work arising from changes in direction during development by the client. If this occurs, Dayah LitWorks will inform the client and may adjust the budget.",
-          "title": "5. Scope changes"
+          "answer": "This agreement does not include additional work arising from changes in direction during development by the client. If this occurs, Dayah LitWorks will inform the client and may adjust the budget.",
+          "question": "5. Scope changes"
         },
         {
-          "content": "Design rights remain with Dayah LitWorks until the client has made 100% payment.",
-          "title": "6. Design rights"
+          "answer": "Design rights remain with Dayah LitWorks until the client has made 100% payment.",
+          "question": "6. Design rights"
         },
         {
-          "content": "Dayah LitWorks may display completed work in the portfolio, as well as on other digital platforms such as Instagram, Facebook, TikTok and the website.",
-          "title": "7. Portfolio usage"
+          "answer": "Dayah LitWorks may display completed work in the portfolio, as well as on other digital platforms such as Instagram, Facebook, TikTok and the website.",
+          "question": "7. Portfolio usage"
         }
       ],
       "seo": {
@@ -13646,6 +13865,27 @@ export const CONTENT: Record<string, JsonRecord> = {
       "hero": {
         "subtitle": "Tips, tendencias y recursos para autores",
         "title": "Blog"
+      },
+      "placeholder": {
+        "features": [
+          {
+            "description": "Un email al mes con tips y ejemplos de portadas que venden.",
+            "href": "#newsletter",
+            "title": "Newsletter"
+          },
+          {
+            "description": "Seguimiento de trabajos recientes + proceso.",
+            "href": "https://instagram.com/dayah.litworks",
+            "title": "Instagram @dayah.litworks"
+          },
+          {
+            "description": "Preguntas directas, respuestas rápidas.",
+            "href": "https://wa.me/595986868241",
+            "title": "WhatsApp"
+          }
+        ],
+        "subtitle": "Pronto vas a encontrar acá tips de diseño, tendencias de portadas y recursos para autores indie. Mientras tanto suscribite al newsletter.",
+        "title": "Blog en preparación"
       },
       "posts": [
         {
@@ -13757,13 +13997,24 @@ export const CONTENT: Record<string, JsonRecord> = {
     },
     "home": {
       "contact": {
+        "city": "Asunción, Paraguay",
         "email": "dayahlitworks@gmail.com",
         "facebook": "https://www.facebook.com/bookc0verdesign/",
+        "hours": {
+          "Domingo": "Cerrado",
+          "Jueves": "09:00 – 18:00",
+          "Lunes": "09:00 – 18:00",
+          "Martes": "09:00 – 18:00",
+          "Miércoles": "09:00 – 18:00",
+          "Sábado": "Cerrado",
+          "Viernes": "09:00 – 18:00"
+        },
         "instagram": "@dayah.litworks",
         "linkedin": "https://www.linkedin.com/in/daihana-araujo/",
         "subtitle": "Respuesta en el día",
         "title": "Contactanos",
-        "whatsapp": "+595986868241"
+        "whatsapp": "+595986868241",
+        "whatsappMessage": "Hola Dayah! Quiero consultar por una portada."
       },
       "faq": {
         "items": [
@@ -13995,6 +14246,24 @@ export const CONTENT: Record<string, JsonRecord> = {
             "price": "Según evaluación"
           }
         ],
+        "addons_block": {
+          "features": [
+            {
+              "description": "Imagen realista de tu libro en 3D (Cotizar)",
+              "title": "Mockup 3D Estático"
+            },
+            {
+              "description": "Animación profesional de tu portada (Cotizar)",
+              "title": "Video Mockup 3D"
+            },
+            {
+              "description": "Se cotiza según evaluación de primeros capítulos y extensión del manuscrito (Según evaluación)",
+              "title": "Corrección ortotipográfica y de estilo"
+            }
+          ],
+          "subtitle": "Extras que puedes sumar a cualquier paquete. Cotización según necesidad.",
+          "title": "Servicios adicionales"
+        },
         "categories": [
           {
             "description": "Diseño exclusivo creado desde cero para tu libro",
@@ -14120,6 +14389,118 @@ export const CONTENT: Record<string, JsonRecord> = {
             "title": "Maquetación Interior"
           }
         ],
+        "items": [
+          {
+            "category": "Portadas Personalizadas",
+            "delivery": "1–2 semanas",
+            "description": "Portada de libro electrónica exclusiva",
+            "includes": [
+              "Portada de libro electrónico (JPG/PDF)",
+              "Título en formato PNG y Portadilla PNG",
+              "2 banners de revelación de portada",
+              "2 Mockups"
+            ],
+            "name": "Portada Personalizada — eBook",
+            "pricePYG": "₲300.000",
+            "priceUSD": "$45"
+          },
+          {
+            "category": "Portadas Personalizadas",
+            "delivery": "1–2 semanas",
+            "description": "Portada completa (frente, lomo y contra) para impresión",
+            "includes": [
+              "Portada de libro tapa blanda (JPG/PDF)",
+              "Archivo imprimible (PDF)",
+              "Título en formato PNG y Portadilla PNG",
+              "2 banners de revelación de portada",
+              "2 Mockups"
+            ],
+            "name": "Portada Personalizada — Tapa Blanda",
+            "pricePYG": "₲500.000",
+            "priceUSD": "$80"
+          },
+          {
+            "category": "Portadas Personalizadas",
+            "delivery": "2–3 semanas",
+            "description": "Combo completo: portada eBook + tapa blanda",
+            "includes": [
+              "Portada de libro electrónico (JPG/PDF)",
+              "Archivo imprimible (PDF)",
+              "Título en formato PNG y Portadilla PNG",
+              "2 banners de revelación de portada",
+              "2 Mockups"
+            ],
+            "name": "Portada Paperback & eBook",
+            "pricePYG": "₲800.000",
+            "priceUSD": "$120"
+          },
+          {
+            "category": "Portadas Premade",
+            "delivery": "1–2 semanas",
+            "description": "Portada premade para eBook con personalización",
+            "includes": [
+              "Portada de libro electrónico (JPG/PDF)",
+              "Título en formato PNG y Portadilla PNG",
+              "2 banners de revelación de portada",
+              "2 Mockups"
+            ],
+            "name": "Premade eBook",
+            "pricePYG": "₲250.000",
+            "priceUSD": "$35",
+            "scopeNote": "Incluye alteraciones en redacción y tipografía, cambios de color, cambios menores en posición de elementos"
+          },
+          {
+            "category": "Portadas Premade",
+            "delivery": "1–2 semanas",
+            "description": "Portada premade completa con versión tapa blanda",
+            "includes": [
+              "Portada de libro tapa blanda (JPG/PDF)",
+              "Archivo imprimible (PDF)",
+              "Título en formato PNG y Portadilla PNG",
+              "2 banners de revelación de portada",
+              "2 Mockups"
+            ],
+            "name": "Premade eBook & Paperback",
+            "pricePYG": "₲500.000",
+            "priceUSD": "$80"
+          },
+          {
+            "category": "Maquetación Interior",
+            "delivery": "1–2 semanas",
+            "description": "Diseño interior para libro electrónico",
+            "includes": [
+              "Diseño interior profesional",
+              "Entrega del archivo según especificaciones de la plataforma (WORD/PDF)"
+            ],
+            "name": "Maquetación eBook",
+            "pricePYG": "₲160.000",
+            "priceUSD": "$25"
+          },
+          {
+            "category": "Maquetación Interior",
+            "delivery": "1–2 semanas",
+            "description": "Diseño interior para libro impreso",
+            "includes": [
+              "Diseño interior profesional",
+              "Entrega del archivo según especificaciones de la plataforma (WORD/PDF)"
+            ],
+            "name": "Maquetación Paperback",
+            "pricePYG": "₲250.000",
+            "priceUSD": "$35"
+          },
+          {
+            "category": "Maquetación Interior",
+            "delivery": "1–2 semanas",
+            "description": "Diseño interior completo para ambas versiones",
+            "includes": [
+              "Diseño interior profesional",
+              "Entrega del archivo según especificaciones de la plataforma (WORD/PDF)"
+            ],
+            "name": "Maquetación eBook & Paperback",
+            "pricePYG": "₲320.000",
+            "priceUSD": "$50"
+          }
+        ],
         "subtitle": "Diseño profesional para tu libro",
         "title": "Nuestros Servicios"
       },
@@ -14220,6 +14601,27 @@ export const CONTENT: Record<string, JsonRecord> = {
         "Terror"
       ],
       "items": [],
+      "placeholder": {
+        "features": [
+          {
+            "description": "Diseños listos para usar — con personalización de tipografía y color.",
+            "href": "/s/es/dayah-litworks/catalogo",
+            "title": "Catálogo Premade"
+          },
+          {
+            "description": "Últimos trabajos + proceso en Instagram.",
+            "href": "https://instagram.com/dayah.litworks",
+            "title": "Instagram @dayah.litworks"
+          },
+          {
+            "description": "Contame qué estás escribiendo — respondo en horario de oficina.",
+            "href": "https://wa.me/595986868241",
+            "title": "WhatsApp"
+          }
+        ],
+        "subtitle": "Estoy curando los trabajos recientes para compartirlos acá. Mientras tanto, mirá el catálogo de premades o escribime por WhatsApp.",
+        "title": "Portafolio en preparación"
+      },
       "seo": {
         "description": "Galería de portadas de libros diseñadas por Dayah LitWorks",
         "title": "Portafolio — Dayah LitWorks"
@@ -14279,10 +14681,29 @@ export const CONTENT: Record<string, JsonRecord> = {
     "siteName": "Dayah LitWorks",
     "sobre": {
       "bio": {
+        "features": [
+          {
+            "description": "Diseñadora de portadas de libros con más de 6 años de experiencia. Desde Asunción, Paraguay, para autores en todo el mundo.",
+            "title": ""
+          },
+          {
+            "description": "Soy Daihana Araujo, fundadora de Dayah LitWorks. Desde noviembre de 2019 me dedico a transformar manuscritos en portadas que venden libros.\n\nCreé Dayah LitWorks con la convicción de que cada libro merece una portada profesional, sin importar el presupuesto del autor. Trabajo con autores indie de todo el mundo hispano y angloparlante, diseñando portadas que capturan la esencia de cada historia.\n\nMi enfoque combina la comprensión profunda de cada género literario con un proceso creativo colaborativo. Creo que la mejor portada nace de escuchar al autor, entender su visión y traducirla en un diseño que no solo sea hermoso, sino que funcione como herramienta de venta.",
+            "title": ""
+          },
+          {
+            "description": "Fundada el 20 de noviembre de 2019",
+            "title": "Fundación"
+          },
+          {
+            "description": "Asunción, Paraguay",
+            "title": "Ubicación"
+          }
+        ],
         "founded": "Fundada el 20 de noviembre de 2019",
         "location": "Asunción, Paraguay",
         "long": "Soy Daihana Araujo, fundadora de Dayah LitWorks. Desde noviembre de 2019 me dedico a transformar manuscritos en portadas que venden libros.\n\nCreé Dayah LitWorks con la convicción de que cada libro merece una portada profesional, sin importar el presupuesto del autor. Trabajo con autores indie de todo el mundo hispano y angloparlante, diseñando portadas que capturan la esencia de cada historia.\n\nMi enfoque combina la comprensión profunda de cada género literario con un proceso creativo colaborativo. Creo que la mejor portada nace de escuchar al autor, entender su visión y traducirla en un diseño que no solo sea hermoso, sino que funcione como herramienta de venta.",
-        "short": "Diseñadora de portadas de libros con más de 6 años de experiencia. Desde Asunción, Paraguay, para autores en todo el mundo."
+        "short": "Diseñadora de portadas de libros con más de 6 años de experiencia. Desde Asunción, Paraguay, para autores en todo el mundo.",
+        "title": "Sobre Daihana"
       },
       "hero": {
         "subtitle": "Donde la fantasía se convierte en realidad",
@@ -14291,19 +14712,19 @@ export const CONTENT: Record<string, JsonRecord> = {
       "highlights": [
         {
           "description": "Años de experiencia",
-          "label": "6+"
+          "title": "6+"
         },
         {
           "description": "Portadas diseñadas",
-          "label": "100+"
+          "title": "100+"
         },
         {
           "description": "Clientes en LATAM, USA y Europa",
-          "label": "Global"
+          "title": "Global"
         },
         {
           "description": "Español e inglés",
-          "label": "Bilingüe"
+          "title": "Bilingüe"
         }
       ],
       "seo": {
@@ -14314,6 +14735,23 @@ export const CONTENT: Record<string, JsonRecord> = {
     "tagline": "Diseño de tapas de libros — del manuscrito a la portada que vende",
     "terminos": {
       "payment": {
+        "features": [
+          {
+            "description": "Para clientes internacionales",
+            "icon": null,
+            "title": "Western Union"
+          },
+          {
+            "description": "Bancos de Paraguay",
+            "icon": null,
+            "title": "Transferencia bancaria"
+          },
+          {
+            "description": "Pago presencial en Asunción",
+            "icon": null,
+            "title": "Efectivo"
+          }
+        ],
         "methods": [
           {
             "description": "Para clientes internacionales",
@@ -14333,32 +14771,32 @@ export const CONTENT: Record<string, JsonRecord> = {
       },
       "sections": [
         {
-          "content": "Envía siempre referencias de ideas, tipografías, colores o estilos ANTES de solicitar el diseño, no después de enviar la propuesta terminada.",
-          "title": "1. Referencias previas"
+          "answer": "Envía siempre referencias de ideas, tipografías, colores o estilos ANTES de solicitar el diseño, no después de enviar la propuesta terminada.",
+          "question": "1. Referencias previas"
         },
         {
-          "content": "El trabajo se realiza en días hábiles (lunes a viernes), con el tiempo suficiente acordado para entregar una pieza de calidad.",
-          "title": "2. Días hábiles"
+          "answer": "El trabajo se realiza en días hábiles (lunes a viernes), con el tiempo suficiente acordado para entregar una pieza de calidad.",
+          "question": "2. Días hábiles"
         },
         {
-          "content": "Si una vez iniciado el proyecto el cliente decidiera rescindir el contrato y no seguir trabajando con Dayah LitWorks, no se le reembolsará el porcentaje adelantado.",
-          "title": "3. Cancelación"
+          "answer": "Si una vez iniciado el proyecto el cliente decidiera rescindir el contrato y no seguir trabajando con Dayah LitWorks, no se le reembolsará el porcentaje adelantado.",
+          "question": "3. Cancelación"
         },
         {
-          "content": "El cliente adquiere la responsabilidad de revisar el diseño, los textos y datos antes de empezar cualquier proceso de impresión, reproducción y/o publicación, y libera a Dayah LitWorks de cualquier responsabilidad por los errores que se pudieran producir.",
-          "title": "4. Responsabilidad de revisión"
+          "answer": "El cliente adquiere la responsabilidad de revisar el diseño, los textos y datos antes de empezar cualquier proceso de impresión, reproducción y/o publicación, y libera a Dayah LitWorks de cualquier responsabilidad por los errores que se pudieran producir.",
+          "question": "4. Responsabilidad de revisión"
         },
         {
-          "content": "Este acuerdo no incluye los trabajos adicionales que se puedan derivar de los cambios de orientación en su desarrollo por parte del cliente. Si se diera el caso, Dayah LitWorks informará al cliente y podrá modificar el presupuesto.",
-          "title": "5. Cambios de alcance"
+          "answer": "Este acuerdo no incluye los trabajos adicionales que se puedan derivar de los cambios de orientación en su desarrollo por parte del cliente. Si se diera el caso, Dayah LitWorks informará al cliente y podrá modificar el presupuesto.",
+          "question": "5. Cambios de alcance"
         },
         {
-          "content": "Los derechos del o los diseños realizados pertenecen a Dayah LitWorks hasta que el cliente no haya efectuado el 100% del pago.",
-          "title": "6. Derechos de diseño"
+          "answer": "Los derechos del o los diseños realizados pertenecen a Dayah LitWorks hasta que el cliente no haya efectuado el 100% del pago.",
+          "question": "6. Derechos de diseño"
         },
         {
-          "content": "Dayah LitWorks podrá mostrar los trabajos realizados en el portfolio, así como en otras plataformas digitales como Instagram, Facebook, TikTok o página web.",
-          "title": "7. Uso en portafolio"
+          "answer": "Dayah LitWorks podrá mostrar los trabajos realizados en el portfolio, así como en otras plataformas digitales como Instagram, Facebook, TikTok o página web.",
+          "question": "7. Uso en portafolio"
         }
       ],
       "seo": {

--- a/web/lib/i18n/config.ts
+++ b/web/lib/i18n/config.ts
@@ -2,27 +2,21 @@
  * Supported locales across the platform.
  * Sites opt into a subset via `site.json.locales`.
  */
-export const ALL_LOCALES = ['nl', 'en', 'de', 'es', 'pt'] as const
+export const ALL_LOCALES = ['en', 'es'] as const
 export type Locale = (typeof ALL_LOCALES)[number]
 
 export const LOCALE_LABELS: Record<Locale, string> = {
-  nl: 'Nederlands',
   en: 'English',
-  de: 'Deutsch',
   es: 'Español',
-  pt: 'Português',
 }
 
 export const LOCALE_HTML_LANG: Record<Locale, string> = {
-  nl: 'nl-NL',
   en: 'en-US',
-  de: 'de-DE',
   es: 'es',
-  pt: 'pt-BR',
 }
 
 export function isLocale(value: string): value is Locale {
   return (ALL_LOCALES as readonly string[]).includes(value)
 }
 
-export const DEFAULT_LOCALE: Locale = 'en'
+export const DEFAULT_LOCALE: Locale = 'es'


### PR DESCRIPTION
## Summary

Full overhaul of Dayah LitWorks tenant site + platform-wide locale cleanup.

## Platform

- Strip de/nl/pt — ALL_LOCALES reduced to en+es per user directive
- Fix contact-section German labels → locale-aware ES/EN
- Extend services-section: priceUSD+pricePYG dual currency, delivery, includes bullet list

## Dayah tenant

Populated previously-empty pages:
- /servicios — all 8 tiers from source-of-truth + 3 add-ons
- /terminos — 7 T&C clauses + 3 payment methods
- /sobre — bio + highlights
- /portafolio — placeholder (Catálogo / IG / WA)
- /blog — placeholder (Newsletter / IG / WA)
- /contacto — proper metadata + business hours + WA prefill

Removed fake María G. / Carlos R. testimonials.

## Blocked on CF dashboard (not code)

- x-robots-tag noindex is CF-injected
- [email protected] mangling is CF Email Obfuscation