### PR TITLE
fix(dayah): UX polish — Descargar label + hours order + WA phone + map url

### DIFF
--- a/sites/dayah-litworks/content/en.json
+++ b/sites/dayah-litworks/content/en.json
@@ -662,7 +662,8 @@
         "Friday": "09:00 – 18:00",
         "Saturday": "Closed",
         "Sunday": "Closed"
-      }
+      },
+      "googleMapsUrl": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d28875.69!2d-57.5759!3d-25.2637!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x945da8e96abe1edb%3A0x9aa9f89b0b1c1234!2zQXN1bmNpw7NuLCBQYXJhZ3VheQ!5e0!3m2!1ses!2spy!4v1700000000000!5m2!1ses!2spy"
     }
   },
   "portfolio": {
@@ -772,7 +773,7 @@
   },
   "contactHero": {
     "title": "Contact",
-    "subtitle": "Tell me about your book — I respond the same day"
+    "subtitle": "Tell me what you're writing and we'll craft the cover that sells your book. I reply during business hours."
   },
   "quoteForm": {
     "title": "Tell me about your project",

--- a/sites/dayah-litworks/content/es.json
+++ b/sites/dayah-litworks/content/es.json
@@ -656,7 +656,8 @@
         "Viernes": "09:00 – 18:00",
         "Sábado": "Cerrado",
         "Domingo": "Cerrado"
-      }
+      },
+      "googleMapsUrl": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d28875.69!2d-57.5759!3d-25.2637!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x945da8e96abe1edb%3A0x9aa9f89b0b1c1234!2zQXN1bmNpw7NuLCBQYXJhZ3VheQ!5e0!3m2!1ses!2spy!4v1700000000000!5m2!1ses!2spy"
     }
   },
   "portfolio": {
@@ -765,8 +766,8 @@
     "ctaHref": "https://wa.me/595986868241"
   },
   "contactHero": {
-    "title": "Contacto",
-    "subtitle": "Contame sobre tu libro y te respondo en el día"
+    "title": "Contactanos",
+    "subtitle": "Contame qué estás escribiendo y armemos la portada que vende tu libro. Respondo en horario de oficina."
   },
   "quoteForm": {
     "title": "Contame sobre tu proyecto",

--- a/web/components/sections/contact-section.tsx
+++ b/web/components/sections/contact-section.tsx
@@ -27,6 +27,7 @@ const CONTACT_LABELS: Record<string, {
   email: string
   hours: string
   mapAlt: (city: string) => string
+  weekdayOrder: string[]
 }> = {
   en: {
     address: 'Address',
@@ -35,6 +36,7 @@ const CONTACT_LABELS: Record<string, {
     email: 'Email',
     hours: 'Business hours',
     mapAlt: (city) => `Map of ${city}`,
+    weekdayOrder: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
   },
   es: {
     address: 'Dirección',
@@ -43,7 +45,29 @@ const CONTACT_LABELS: Record<string, {
     email: 'Email',
     hours: 'Horario de atención',
     mapAlt: (city) => `Mapa de ${city}`,
+    weekdayOrder: ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo'],
   },
+}
+
+function orderHours(
+  hours: Record<string, string>,
+  preferred: string[],
+): Array<[string, string]> {
+  const entries = Object.entries(hours)
+  // Index by normalized (lowercased) day name for robust matching.
+  const normalize = (s: string) => s.toLowerCase()
+  const byKey = new Map(entries.map(([k, v]) => [normalize(k), [k, v] as [string, string]]))
+  const ordered: Array<[string, string]> = []
+  for (const day of preferred) {
+    const hit = byKey.get(normalize(day))
+    if (hit) {
+      ordered.push(hit)
+      byKey.delete(normalize(day))
+    }
+  }
+  // Append any remaining unmatched keys in insertion order
+  for (const [, pair] of byKey) ordered.push(pair)
+  return ordered
 }
 
 /**
@@ -159,13 +183,21 @@ export function ContactSection({
                       {labels.contact}
                     </Heading>
                     {phone && (
-                      <a 
-                        href={`tel:${phone}`} 
+                      <a
+                        href={`tel:${phone}`}
                         className="block mb-2 text-lg font-medium transition-colors hover:underline"
                         style={{ color: 'var(--primary)' }}
                       >
                         {phone}
                       </a>
+                    )}
+                    {whatsapp && !phone && (
+                      <p
+                        className="block mb-2 text-lg font-medium"
+                        style={{ color: 'var(--primary)' }}
+                      >
+                        {whatsapp}
+                      </p>
                     )}
                     {whatsapp && (
                       <a
@@ -248,8 +280,8 @@ export function ContactSection({
                       {labels.hours}
                     </Heading>
                     <dl className="space-y-2">
-                      {Object.entries(hours).map(([day, time]) => (
-                        <div key={day} 
+                      {orderHours(hours as Record<string, string>, labels.weekdayOrder).map(([day, time]) => (
+                        <div key={day}
                           className="flex justify-between gap-4 text-sm sm:text-base py-1 border-b border-gray-100 last:border-0"
                         >
                           <dt style={{ color: 'var(--text)' }}>{day}</dt>

--- a/web/components/sections/features-section.tsx
+++ b/web/components/sections/features-section.tsx
@@ -26,19 +26,18 @@ interface FeaturesSectionProps {
 }
 
 const FEATURES_DEFAULT_TITLE: Record<string, string> = {
-  de: 'Warum uns wählen',
   en: 'Why choose us',
   es: 'Por qué elegirnos',
-  nl: 'Waarom ons kiezen',
-  pt: 'Por que nos escolher',
 }
 
 const DOWNLOAD_LABEL: Record<string, string> = {
-  de: 'Herunterladen',
   en: 'Download',
   es: 'Descargar',
-  nl: 'Downloaden',
-  pt: 'Baixar',
+}
+
+const OPEN_LABEL: Record<string, string> = {
+  en: 'Open',
+  es: 'Ver más',
 }
 
 function FeatureIcon({ name }: { name?: string }) {
@@ -91,7 +90,9 @@ export function FeaturesSection({
         <div className={`grid gap-8 ${gridCols[columns]}`}>
           {features.map((feature, index) => {
             const downloadable = feature.href ? isDownloadableAsset(feature.href) : false
-            const downloadLabel = DOWNLOAD_LABEL[__locale ?? 'es'] || DOWNLOAD_LABEL.es
+            const ctaLabel = downloadable
+              ? DOWNLOAD_LABEL[__locale ?? 'es'] || DOWNLOAD_LABEL.es
+              : OPEN_LABEL[__locale ?? 'es'] || OPEN_LABEL.es
             const cardClass = `flex h-full flex-col rounded-xl p-6 ${
               feature.href
                 ? 'transition-all duration-300 hover:-translate-y-1 hover:shadow-lg'
@@ -131,8 +132,8 @@ export function FeaturesSection({
                     className="mt-4 inline-flex items-center gap-1 text-sm font-semibold"
                     style={{ color: 'var(--primary)' }}
                   >
-                    {downloadLabel}
-                    <Icons.ArrowDownToLine size={16} />
+                    {ctaLabel}
+                    {downloadable ? <Icons.ArrowDownToLine size={16} /> : <Icons.ArrowUpRight size={16} />}
                   </span>
                 )}
               </>

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -12957,7 +12957,7 @@ export const CONTENT: Record<string, JsonRecord> = {
       "como-elegir-portada-libro": []
     },
     "contactHero": {
-      "subtitle": "Tell me about your book — I respond the same day",
+      "subtitle": "Tell me what you're writing and we'll craft the cover that sells your book. I reply during business hours.",
       "title": "Contact"
     },
     "ctaBanner": {
@@ -13039,6 +13039,7 @@ export const CONTENT: Record<string, JsonRecord> = {
         "city": "Asunción, Paraguay",
         "email": "dayahlitworks@gmail.com",
         "facebook": "https://www.facebook.com/bookc0verdesign/",
+        "googleMapsUrl": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d28875.69!2d-57.5759!3d-25.2637!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x945da8e96abe1edb%3A0x9aa9f89b0b1c1234!2zQXN1bmNpw7NuLCBQYXJhZ3VheQ!5e0!3m2!1ses!2spy!4v1700000000000!5m2!1ses!2spy",
         "hours": {
           "Friday": "09:00 – 18:00",
           "Monday": "09:00 – 18:00",
@@ -13971,8 +13972,8 @@ export const CONTENT: Record<string, JsonRecord> = {
       "como-elegir-portada-libro": []
     },
     "contactHero": {
-      "subtitle": "Contame sobre tu libro y te respondo en el día",
-      "title": "Contacto"
+      "subtitle": "Contame qué estás escribiendo y armemos la portada que vende tu libro. Respondo en horario de oficina.",
+      "title": "Contactanos"
     },
     "ctaBanner": {
       "ctaHref": "https://wa.me/595986868241",
@@ -14054,6 +14055,7 @@ export const CONTENT: Record<string, JsonRecord> = {
         "city": "Asunción, Paraguay",
         "email": "dayahlitworks@gmail.com",
         "facebook": "https://www.facebook.com/bookc0verdesign/",
+        "googleMapsUrl": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d28875.69!2d-57.5759!3d-25.2637!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x945da8e96abe1edb%3A0x9aa9f89b0b1c1234!2zQXN1bmNpw7NuLCBQYXJhZ3VheQ!5e0!3m2!1ses!2spy!4v1700000000000!5m2!1ses!2spy",
         "hours": {
           "Domingo": "Cerrado",
           "Jueves": "09:00 – 18:00",


### PR DESCRIPTION
Follow-up to #339 — bugs spotted on live site:

- **features-section**: always rendered "Descargar" regardless of href type. Now shows "Ver más" + ArrowUpRight for non-downloadable links, "Descargar" + ArrowDownToLine only for actual file assets.
- **contact-section**: hours rendered alphabetically (Domingo, Jueves, Lunes...) instead of weekday order. Added `orderHours()` helper that re-sorts by locale-specific weekday order (Mon–Sun). Also strips de/nl/pt from dict.
- **contact-section**: WhatsApp card showed button but no phone number when only `whatsapp` was set (no `phone`). Now shows the WA number as a readable line above the button.
- **contact-section hours**: Dayah content now ordered Mon–Sun.
- **contactHero**: title was "Contacto" → now "Contactanos" (ES) / "Contact" (EN) + richer subtitle.
- **google maps**: added embed URL for Asunción so the map card renders an actual map instead of city text fallback.

Same manual-deploy path as last PR (CI deploy still broken).