### PR TITLE
feat(superspuma+platform): mattress recommendation quiz

### DIFF
--- a/sites/superspuma/content/es.json
+++ b/sites/superspuma/content/es.json
@@ -1727,6 +1727,111 @@
       ]
     }
   },
+  "quiz": {
+    "seo": {
+      "title": "¿Qué colchón necesitás? — Quiz Superspuma",
+      "description": "En 6 preguntas te recomendamos el colchón ideal según tu peso, postura al dormir, y necesidades de soporte. 19 modelos disponibles."
+    },
+    "hero": {
+      "headline": "¿Qué colchón necesitás?",
+      "subheadline": "6 preguntas. 2 minutos. Te recomendamos los 3 modelos que mejor se adaptan a vos.",
+      "ctaPrimaryText": "Empezar el quiz",
+      "ctaPrimaryHref": "#quiz",
+      "ctaSecondaryText": "Ver todo el catálogo",
+      "ctaSecondaryHref": "/s/es/superspuma#catalogo",
+      "trustBadges": ["6 preguntas", "2 minutos", "Recomendación personalizada"]
+    },
+    "quiz": {
+      "eyebrow": "Recomendador",
+      "title": "Contanos qué buscás",
+      "subtitle": "Respondé honestamente — las recomendaciones son mejores cuanto más ajustadas sean las respuestas.",
+      "resultHeading": "Tus 3 mejores matches",
+      "resultSubheading": "Ordenados por afinidad con tus respuestas. Escribinos para confirmar medidas, cuotas y disponibilidad.",
+      "topK": 3,
+      "steps": [
+        {
+          "id": "peso",
+          "question": "¿Cuánto pesa la persona que va a usarlo?",
+          "helperText": "Si es para dos, elegí el peso de la persona más pesada.",
+          "options": [
+            { "value": "menos-60", "label": "Menos de 60 kg", "scores": { "luna-soft": 3, "super-kids": 2, "pop-kids": 2, "delta-soft": 2, "golden": 1 } },
+            { "value": "60-80", "label": "Entre 60 y 80 kg", "scores": { "harmony": 3, "serena": 2, "golden": 2, "serrat": 2, "essential-top": 2, "duo-confort": 1 } },
+            { "value": "80-100", "label": "Entre 80 y 100 kg", "scores": { "imperial": 3, "harmony": 2, "duo-confort": 2, "titanium": 2, "serena": 1 } },
+            { "value": "100-130", "label": "Entre 100 y 130 kg", "scores": { "titanium": 3, "imperial": 2, "ortopedico": 2, "duo-confort": 1 } },
+            { "value": "mas-130", "label": "Más de 130 kg", "scores": { "ortopedico": 5, "titanium": 1 } }
+          ]
+        },
+        {
+          "id": "posicion",
+          "question": "¿En qué posición dormís más?",
+          "options": [
+            { "value": "costado", "label": "De costado", "scores": { "duo-confort": 3, "harmony": 2, "luna-soft": 2, "delta-soft": 1 } },
+            { "value": "espalda", "label": "Boca arriba", "scores": { "harmony": 2, "serena": 2, "imperial": 2, "titanium": 1 } },
+            { "value": "estomago", "label": "Boca abajo", "scores": { "titanium": 2, "imperial": 2, "ortopedico": 2, "serena": 1 } },
+            { "value": "mixto", "label": "Cambio de posición toda la noche", "scores": { "duo-confort": 3, "harmony": 2 } }
+          ]
+        },
+        {
+          "id": "columna",
+          "question": "¿Tenés problemas de columna o dolor de espalda?",
+          "options": [
+            { "value": "no", "label": "No, todo bien", "scores": { "harmony": 2, "luna-soft": 1, "serena": 1, "golden": 1 } },
+            { "value": "ocasional", "label": "Dolor ocasional", "scores": { "duo-confort": 3, "harmony": 2, "serena": 1 } },
+            { "value": "cronico", "label": "Dolor crónico / recomendación médica", "scores": { "ortopedico": 4, "duo-confort": 3, "titanium": 2 } }
+          ]
+        },
+        {
+          "id": "firmeza",
+          "question": "¿Qué firmeza preferís?",
+          "helperText": "Si tuviste un colchón antes, pensá en qué cambiarías de ese.",
+          "options": [
+            { "value": "suave", "label": "Suave / mullido", "scores": { "luna-soft": 3, "delta-soft": 2, "super-kids": 1 } },
+            { "value": "medio", "label": "Medio (equilibrado)", "scores": { "harmony": 3, "serena": 2, "serrat": 2, "golden": 2, "essential-top": 1 } },
+            { "value": "firme", "label": "Firme", "scores": { "imperial": 3, "titanium": 2 } },
+            { "value": "extra-firme", "label": "Extra firme / ortopédico", "scores": { "ortopedico": 4, "titanium": 2 } },
+            { "value": "adaptable", "label": "Adaptable (se ajusta al cuerpo)", "scores": { "duo-confort": 4, "serena": 1 } }
+          ]
+        },
+        {
+          "id": "presupuesto",
+          "question": "¿Cuál es tu presupuesto ideal?",
+          "helperText": "Pensá en el precio total, con cuotas sin interés el mensual puede ser mucho menor.",
+          "options": [
+            { "value": "economico", "label": "Hasta Gs. 800.000", "scores": { "luna-soft": 3, "super-kids": 2, "pop-kids": 2, "golden": 2, "renovate": 2, "pop-teen": 1 } },
+            { "value": "medio", "label": "Entre Gs. 800.000 y 1.500.000", "scores": { "harmony": 3, "essential-top": 2, "serrat": 2, "serena": 2, "duo-confort": 1, "golden": 1, "ortopedico": 1 } },
+            { "value": "alto", "label": "Entre Gs. 1.500.000 y 2.500.000", "scores": { "titanium": 3, "imperial": 2, "duo-confort": 2, "harmony": 1, "ortopedico": 2 } },
+            { "value": "premium", "label": "Más de Gs. 2.500.000", "scores": { "titanium": 3, "imperial": 3, "ortopedico": 1 } }
+          ]
+        },
+        {
+          "id": "tipo",
+          "question": "¿Tenés preferencia por resorte o espuma?",
+          "options": [
+            { "value": "resorte", "label": "Resorte (más firme, más ventilado)", "scores": { "titanium": 3, "imperial": 2, "harmony": 2, "serrat": 1, "essential-top": 1 } },
+            { "value": "espuma", "label": "Espuma (más silenciosa, más confortable)", "scores": { "duo-confort": 3, "serena": 2, "golden": 2, "luna-soft": 2, "ortopedico": 2 } },
+            { "value": "indiferente", "label": "Me da igual, decidime", "scores": { "harmony": 1, "duo-confort": 1, "titanium": 1, "ortopedico": 1 } }
+          ]
+        }
+      ],
+      "products": [
+        { "id": "luna-soft", "name": "Luna Soft", "description": "Espuma suave, económica. Ideal para invitados o uso ocasional.", "priceFromLabel": "Desde Gs. 500.000", "ctaHref": "/s/es/superspuma/producto/luna-soft", "ctaLabel": "Ver Luna Soft" },
+        { "id": "super-kids", "name": "Super Kids", "description": "Espuma infantil, liviana. Para cunas y primeras camas.", "priceFromLabel": "Desde Gs. 420.000", "ctaHref": "/s/es/superspuma/producto/super-kids", "ctaLabel": "Ver Super Kids", "badge": "Niños" },
+        { "id": "pop-kids", "name": "Pop Kids", "description": "Resorte económico para niños con diseños divertidos.", "priceFromLabel": "Desde Gs. 649.000", "ctaHref": "/s/es/superspuma/producto/pop-kids", "ctaLabel": "Ver Pop Kids", "badge": "Niños" },
+        { "id": "delta-soft", "name": "Delta Soft", "description": "Resorte con pillow suave. Tacto mullido con soporte de resorte.", "priceFromLabel": "Desde Gs. 1.050.000", "ctaHref": "/s/es/superspuma/producto/delta-soft", "ctaLabel": "Ver Delta Soft" },
+        { "id": "golden", "name": "Golden", "description": "Espuma reversible con Pillow Top. Excelente relación calidad/precio.", "priceFromLabel": "Desde Gs. 696.000", "ctaHref": "/s/es/superspuma/producto/golden", "ctaLabel": "Ver Golden" },
+        { "id": "harmony", "name": "Harmony", "description": "Equilibrio ideal entre soporte y confort. Euro-Top antiácaros.", "priceFromLabel": "Desde Gs. 1.274.000", "ctaHref": "/s/es/superspuma/producto/harmony", "ctaLabel": "Ver Harmony", "badge": "Más vendido" },
+        { "id": "serena", "name": "Serena", "description": "Espuma alta densidad con buen confort y recuperación.", "priceFromLabel": "Desde Gs. 850.000", "ctaHref": "/s/es/superspuma/producto/serena", "ctaLabel": "Ver Serena" },
+        { "id": "serrat", "name": "Serrat", "description": "Resorte con superficie suave, firmeza media.", "priceFromLabel": "Desde Gs. 1.150.000", "ctaHref": "/s/es/superspuma/producto/serrat", "ctaLabel": "Ver Serrat" },
+        { "id": "essential-top", "name": "Essential Top", "description": "Entrada a resorte con Pillow Top. Esencial.", "priceFromLabel": "Desde Gs. 890.000", "ctaHref": "/s/es/superspuma/producto/essential-top", "ctaLabel": "Ver Essential Top" },
+        { "id": "renovate", "name": "Renovate", "description": "Reemplazo económico y confiable para tu viejo colchón.", "priceFromLabel": "Desde Gs. 780.000", "ctaHref": "/s/es/superspuma/producto/renovate", "ctaLabel": "Ver Renovate" },
+        { "id": "pop-teen", "name": "Pop Teen", "description": "Pop para adolescentes, precio accesible.", "priceFromLabel": "Desde Gs. 780.000", "ctaHref": "/s/es/superspuma/producto/pop-teen", "ctaLabel": "Ver Pop Teen" },
+        { "id": "imperial", "name": "Imperial", "description": "Resortes Bonell con Pillow Top. Descanso regenerador.", "priceFromLabel": "Desde Gs. 2.230.000", "ctaHref": "/s/es/superspuma/producto/imperial", "ctaLabel": "Ver Imperial" },
+        { "id": "titanium", "name": "Titanium", "description": "Premium con Euro Pillow Top. Resortes Bonell reforzados, hasta 120 kg.", "priceFromLabel": "Desde Gs. 1.800.000", "ctaHref": "/s/es/superspuma/producto/titanium", "ctaLabel": "Ver Titanium", "badge": "Premium" },
+        { "id": "duo-confort", "name": "Duo Confort", "description": "Memory foam adaptable. Alivio real de puntos de presión.", "priceFromLabel": "Desde Gs. 980.000", "ctaHref": "/s/es/superspuma/producto/duo-confort", "ctaLabel": "Ver Duo Confort" },
+        { "id": "ortopedico", "name": "Ortopédico", "description": "Espuma densidad 45. Hasta 140 kg. 6 años de garantía.", "priceFromLabel": "Desde Gs. 1.290.000", "ctaHref": "/s/es/superspuma/producto/ortopedico", "ctaLabel": "Ver Ortopédico", "badge": "Más firme" }
+      ]
+    }
+  },
   "navigation": {
     "businessName": "Superspuma",
     "ctaText": "Consultar por WhatsApp",
@@ -1739,6 +1844,10 @@
       {
         "label": "Catálogo",
         "href": "/s/es/superspuma#catalogo"
+      },
+      {
+        "label": "¿Qué necesitás?",
+        "href": "/s/es/superspuma/quiz"
       },
       {
         "label": "Tiendas",

--- a/sites/superspuma/pages/quiz.json
+++ b/sites/superspuma/pages/quiz.json
@@ -1,0 +1,14 @@
+{
+  "slug": "quiz",
+  "titleKey": "quiz.seo.title",
+  "descriptionKey": "quiz.seo.description",
+  "sections": [
+    { "id": "header", "variant": "standard", "content": "navigation" },
+    { "id": "hero", "variant": "image", "content": "quiz.hero" },
+    { "id": "mattress-quiz", "variant": "default", "content": "quiz.quiz" },
+    { "id": "enhanced-faq", "variant": "searchable", "content": "home.enhancedFaq" },
+    { "id": "contact", "variant": "split", "content": "home.contact" },
+    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" },
+    { "id": "footer", "variant": "standard", "content": "footer" }
+  ]
+}

--- a/sites/superspuma/site.json
+++ b/sites/superspuma/site.json
@@ -11,7 +11,7 @@
   "defaultLocale": "es",
   "locales": ["es"],
   "pages": [
-    "home", "nosotros", "tiendas", "guias", "garantia", "envios", "financiacion", "terminos", "privacidad", "promo-cartagena",
+    "home", "nosotros", "tiendas", "guias", "garantia", "envios", "financiacion", "terminos", "privacidad", "promo-cartagena", "quiz",
     "producto/titanium", "producto/imperial", "producto/harmony", "producto/serrat", "producto/delta-soft",
     "producto/essential-top", "producto/renovate", "producto/impulse-kids", "producto/impulse-teens", "producto/pop-kids",
     "producto/pop-plus", "producto/pop-teen", "producto/superteen", "producto/super-kids", "producto/luna-soft",

--- a/src/verticals/retail-local/vertical.json
+++ b/src/verticals/retail-local/vertical.json
@@ -20,7 +20,7 @@
     "why-destination", "process-timeline", "enhanced-faq",
     "programs-comparison", "our-story", "team", "b2b-wholesale",
     "booking-embed", "compliance-disclaimer-footer",
-    "promo-banner", "newsletter-signup", "lead-form"
+    "promo-banner", "newsletter-signup", "lead-form", "mattress-quiz"
   ],
   "defaultStarterKit": "minimal",
   "locales": ["es"]

--- a/web/components/sections/mattress-quiz-section.tsx
+++ b/web/components/sections/mattress-quiz-section.tsx
@@ -1,0 +1,295 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+import { Button } from '@/components/ui/button'
+import { AnimatedSectionHeader } from '@/components/ui/animate-on-scroll'
+import { ChevronLeft, ChevronRight, RotateCcw, Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Mattress recommendation quiz. Domain-specific product finder — maps
+ * 5-6 user answers to a scored top-3 recommendation from the tenant's
+ * catalog. Designed for Superspuma but the scoring rules live in the
+ * content block so any mattress tenant can plug in their own rubric.
+ *
+ * Content shape:
+ *   steps: [{ id, question, options: [{ value, label, scores: { <productId>: <n> } }] }]
+ *   products: [{ id, name, description, priceFromLabel, ctaHref }]
+ *
+ * Each answer contributes points to each product via its `scores` map.
+ * After the last step we sort products by total points and show the
+ * top 3. Missing scores default to 0 — flexible enough that adding a
+ * new product only means adding a score key to the relevant options.
+ */
+
+export interface QuizOption {
+  value: string
+  label: string
+  /** Score contribution per candidate product. Missing = 0. */
+  scores?: Record<string, number>
+}
+
+export interface QuizStep {
+  id: string
+  question: string
+  helperText?: string
+  options: QuizOption[]
+}
+
+export interface QuizProduct {
+  id: string
+  name: string
+  description?: string
+  priceFromLabel?: string
+  ctaHref: string
+  ctaLabel?: string
+  badge?: string
+}
+
+export interface MattressQuizSectionProps {
+  eyebrow?: string
+  title: string
+  subtitle?: string
+  steps: QuizStep[]
+  products: QuizProduct[]
+  resultHeading?: string
+  resultSubheading?: string
+  /** How many top results to show (default 3). */
+  topK?: number
+  /** Override labels for navigation controls. */
+  labels?: {
+    next?: string
+    back?: string
+    restart?: string
+    submit?: string
+    step?: string
+    of?: string
+  }
+}
+
+const DEFAULT_LABELS = {
+  next: 'Siguiente',
+  back: 'Atrás',
+  restart: 'Empezar de nuevo',
+  submit: 'Ver mi recomendación',
+  step: 'Paso',
+  of: 'de',
+}
+
+export function MattressQuizSection({
+  eyebrow,
+  title,
+  subtitle,
+  steps = [],
+  products = [],
+  resultHeading,
+  resultSubheading,
+  topK = 3,
+  labels: labelsProp,
+}: MattressQuizSectionProps) {
+  const labels = { ...DEFAULT_LABELS, ...(labelsProp ?? {}) }
+  const [idx, setIdx] = useState(0)
+  const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [done, setDone] = useState(false)
+
+  if (steps.length === 0 || products.length === 0) return null
+
+  const current = steps[idx]
+  const selected = answers[current.id]
+  const isLast = idx === steps.length - 1
+
+  const ranking = useMemo(() => {
+    if (!done) return []
+    const scores: Record<string, number> = {}
+    for (const step of steps) {
+      const answer = answers[step.id]
+      if (!answer) continue
+      const chosen = step.options.find((o) => o.value === answer)
+      if (!chosen?.scores) continue
+      for (const [productId, delta] of Object.entries(chosen.scores)) {
+        scores[productId] = (scores[productId] ?? 0) + delta
+      }
+    }
+    return products
+      .map((p) => ({ product: p, score: scores[p.id] ?? 0 }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topK)
+  }, [done, answers, steps, products, topK])
+
+  function pick(value: string) {
+    setAnswers((prev) => ({ ...prev, [current.id]: value }))
+  }
+
+  function next() {
+    if (isLast) setDone(true)
+    else setIdx(idx + 1)
+  }
+
+  function back() {
+    if (idx === 0) return
+    setIdx(idx - 1)
+  }
+
+  function restart() {
+    setAnswers({})
+    setIdx(0)
+    setDone(false)
+  }
+
+  return (
+    <section id="quiz" className="bg-[var(--background)] py-16 sm:py-20 lg:py-24">
+      <Container className="max-w-3xl">
+        <AnimatedSectionHeader className="mb-10 text-center">
+          {eyebrow && (
+            <p className="mb-3 text-sm font-semibold uppercase tracking-widest" style={{ color: 'var(--secondary)' }}>
+              {eyebrow}
+            </p>
+          )}
+          <Heading level={2}>{title}</Heading>
+          {subtitle && (
+            <p className="mx-auto mt-4 max-w-xl text-lg text-[var(--text-light)]">{subtitle}</p>
+          )}
+        </AnimatedSectionHeader>
+
+        {!done ? (
+          <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 sm:p-10 shadow-lg">
+            {/* Progress */}
+            <div className="mb-6 flex items-center justify-between text-sm" style={{ color: 'var(--text-light)' }}>
+              <span>
+                {labels.step} {idx + 1} {labels.of} {steps.length}
+              </span>
+              <div className="h-1 w-1/2 overflow-hidden rounded-full bg-[var(--border)]">
+                <div
+                  className="h-full transition-all"
+                  style={{
+                    width: `${((idx + 1) / steps.length) * 100}%`,
+                    backgroundColor: 'var(--primary)',
+                  }}
+                />
+              </div>
+            </div>
+
+            <fieldset>
+              <legend className="mb-2 text-2xl font-bold" style={{ color: 'var(--text)' }}>
+                {current.question}
+              </legend>
+              {current.helperText && (
+                <p className="mb-6 text-sm" style={{ color: 'var(--text-light)' }}>
+                  {current.helperText}
+                </p>
+              )}
+              <div className="mt-6 grid gap-3">
+                {current.options.map((opt) => (
+                  <label
+                    key={opt.value}
+                    className={cn(
+                      'flex cursor-pointer items-center gap-3 rounded-lg border-2 p-4 transition-colors',
+                      selected === opt.value
+                        ? 'border-[var(--primary)] bg-[var(--primary)]/5'
+                        : 'border-[var(--border)] hover:border-[var(--primary)]/40',
+                    )}
+                  >
+                    <input
+                      type="radio"
+                      name={current.id}
+                      value={opt.value}
+                      checked={selected === opt.value}
+                      onChange={() => pick(opt.value)}
+                      className="h-4 w-4 accent-[var(--primary)]"
+                    />
+                    <span style={{ color: 'var(--text)' }}>{opt.label}</span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            <div className="mt-8 flex items-center justify-between">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={back}
+                disabled={idx === 0}
+                className="min-h-[44px]"
+              >
+                <ChevronLeft size={16} /> {labels.back}
+              </Button>
+              <Button
+                variant="primary"
+                size="md"
+                onClick={next}
+                disabled={!selected}
+                className="min-h-[44px]"
+              >
+                {isLast ? labels.submit : labels.next}
+                {!isLast && <ChevronRight size={16} />}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 sm:p-10 shadow-lg">
+            {resultHeading && (
+              <Heading level={3} className="mb-2 text-center">
+                {resultHeading}
+              </Heading>
+            )}
+            {resultSubheading && (
+              <p className="mb-8 text-center text-[var(--text-light)]">{resultSubheading}</p>
+            )}
+            <div className="grid gap-4 sm:grid-cols-1 md:grid-cols-3">
+              {ranking.map((entry, i) => (
+                <article
+                  key={entry.product.id}
+                  className={cn(
+                    'rounded-xl border p-5 transition-transform',
+                    i === 0
+                      ? 'border-[var(--primary)] bg-[var(--primary)]/5 md:scale-105'
+                      : 'border-[var(--border)]',
+                  )}
+                >
+                  {i === 0 && (
+                    <span className="mb-3 inline-block rounded-full bg-[var(--primary)] px-3 py-1 text-xs font-bold text-white">
+                      Mejor match
+                    </span>
+                  )}
+                  {entry.product.badge && i !== 0 && (
+                    <span className="mb-3 inline-block rounded-full bg-[var(--secondary)]/10 px-3 py-1 text-xs font-medium" style={{ color: 'var(--secondary)' }}>
+                      {entry.product.badge}
+                    </span>
+                  )}
+                  <h4 className="mb-2 text-xl font-bold" style={{ color: 'var(--text)' }}>
+                    {entry.product.name}
+                  </h4>
+                  {entry.product.priceFromLabel && (
+                    <p className="mb-3 text-sm font-semibold" style={{ color: 'var(--primary)' }}>
+                      {entry.product.priceFromLabel}
+                    </p>
+                  )}
+                  {entry.product.description && (
+                    <p className="mb-5 text-sm" style={{ color: 'var(--text-light)' }}>
+                      {entry.product.description}
+                    </p>
+                  )}
+                  <Button
+                    variant={i === 0 ? 'primary' : 'outline'}
+                    size="sm"
+                    href={entry.product.ctaHref}
+                    className="min-h-[44px] w-full"
+                  >
+                    <Check size={16} /> {entry.product.ctaLabel ?? 'Consultar'}
+                  </Button>
+                </article>
+              ))}
+            </div>
+            <div className="mt-8 text-center">
+              <Button variant="ghost" size="sm" onClick={restart} className="min-h-[44px]">
+                <RotateCcw size={16} /> {labels.restart}
+              </Button>
+            </div>
+          </div>
+        )}
+      </Container>
+    </section>
+  )
+}

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -11,7 +11,7 @@
  */
 
 export type JsonRecord = Record<string, unknown>
-/** Counts: sites=118, pages=233, content=138, blog=31, images=3, verticals=23. */
+/** Counts: sites=118, pages=234, content=138, blog=31, images=3, verticals=23. */
 export const SITE_SLUGS: readonly string[] = [
   "dayah-litworks",
   "de-abasto-a-casa",
@@ -5136,6 +5136,7 @@ export const SITES: Record<string, JsonRecord> = {
       "terminos",
       "privacidad",
       "promo-cartagena",
+      "quiz",
       "producto/titanium",
       "producto/imperial",
       "producto/harmony",
@@ -14756,6 +14757,48 @@ export const PAGES: Record<string, JsonRecord> = {
     ],
     "slug": "promo-cartagena",
     "titleKey": "home.promo-cartagena.title"
+  },
+  "superspuma:quiz": {
+    "descriptionKey": "quiz.seo.description",
+    "sections": [
+      {
+        "content": "navigation",
+        "id": "header",
+        "variant": "standard"
+      },
+      {
+        "content": "quiz.hero",
+        "id": "hero",
+        "variant": "image"
+      },
+      {
+        "content": "quiz.quiz",
+        "id": "mattress-quiz",
+        "variant": "default"
+      },
+      {
+        "content": "home.enhancedFaq",
+        "id": "enhanced-faq",
+        "variant": "searchable"
+      },
+      {
+        "content": "home.contact",
+        "id": "contact",
+        "variant": "split"
+      },
+      {
+        "content": "whatsapp",
+        "id": "whatsapp-float",
+        "variant": "standard"
+      },
+      {
+        "content": "footer",
+        "id": "footer",
+        "variant": "standard"
+      }
+    ],
+    "slug": "quiz",
+    "titleKey": "quiz.seo.title"
   },
   "superspuma:terminos": {
     "descriptionKey": "terminos.seo.description",
@@ -37584,6 +37627,10 @@ export const CONTENT: Record<string, JsonRecord> = {
           "label": "Catálogo"
         },
         {
+          "href": "/s/es/superspuma/quiz",
+          "label": "¿Qué necesitás?"
+        },
+        {
           "href": "/s/es/superspuma/tiendas",
           "label": "Tiendas"
         },
@@ -40159,6 +40206,440 @@ export const CONTENT: Record<string, JsonRecord> = {
         }
       }
     },
+    "quiz": {
+      "hero": {
+        "ctaPrimaryHref": "#quiz",
+        "ctaPrimaryText": "Empezar el quiz",
+        "ctaSecondaryHref": "/s/es/superspuma#catalogo",
+        "ctaSecondaryText": "Ver todo el catálogo",
+        "headline": "¿Qué colchón necesitás?",
+        "subheadline": "6 preguntas. 2 minutos. Te recomendamos los 3 modelos que mejor se adaptan a vos.",
+        "trustBadges": [
+          "6 preguntas",
+          "2 minutos",
+          "Recomendación personalizada"
+        ]
+      },
+      "quiz": {
+        "eyebrow": "Recomendador",
+        "products": [
+          {
+            "ctaHref": "/s/es/superspuma/producto/luna-soft",
+            "ctaLabel": "Ver Luna Soft",
+            "description": "Espuma suave, económica. Ideal para invitados o uso ocasional.",
+            "id": "luna-soft",
+            "name": "Luna Soft",
+            "priceFromLabel": "Desde Gs. 500.000"
+          },
+          {
+            "badge": "Niños",
+            "ctaHref": "/s/es/superspuma/producto/super-kids",
+            "ctaLabel": "Ver Super Kids",
+            "description": "Espuma infantil, liviana. Para cunas y primeras camas.",
+            "id": "super-kids",
+            "name": "Super Kids",
+            "priceFromLabel": "Desde Gs. 420.000"
+          },
+          {
+            "badge": "Niños",
+            "ctaHref": "/s/es/superspuma/producto/pop-kids",
+            "ctaLabel": "Ver Pop Kids",
+            "description": "Resorte económico para niños con diseños divertidos.",
+            "id": "pop-kids",
+            "name": "Pop Kids",
+            "priceFromLabel": "Desde Gs. 649.000"
+          },
+          {
+            "ctaHref": "/s/es/superspuma/producto/delta-soft",
+            "ctaLabel": "Ver Delta Soft",
+            "description": "Resorte con pillow suave. Tacto mullido con soporte de resorte.",
+            "id": "delta-soft",
+            "name": "Delta Soft",
+            "priceFromLabel": "Desde Gs. 1.050.000"
+          },
+          {
+            "ctaHref": "/s/es/superspuma/producto/golden",
+            "ctaLabel": "Ver Golden",
+            "description": "Espuma reversible con Pillow Top. Excelente relación calidad/precio.",
+            "id": "golden",
+            "name": "Golden",
+            "priceFromLabel": "Desde Gs. 696.000"
+          },
+          {
+            "badge": "Más vendido",
+            "ctaHref": "/s/es/superspuma/producto/harmony",
+            "ctaLabel": "Ver Harmony",
+            "description": "Equilibrio ideal entre soporte y confort. Euro-Top antiácaros.",
+            "id": "harmony",
+            "name": "Harmony",
+            "priceFromLabel": "Desde Gs. 1.274.000"
+          },
+          {
+            "ctaHref": "/s/es/superspuma/producto/serena",
+            "ctaLabel": "Ver Serena",
+            "description": "Espuma alta densidad con buen confort y recuperación.",
+            "id": "serena",
+            "name": "Serena",
+            "priceFromLabel": "Desde Gs. 850.000"
+          },
+          {
+            "ctaHref": "/s/es/superspuma/producto/serrat",
+            "ctaLabel": "Ver Serrat",
+            "description": "Resorte con superficie suave, firmeza media.",
+            "id": "serrat",
+            "name": "Serrat",
+            "priceFromLabel": "Desde Gs. 1.150.000"
+          },
+          {
+            "ctaHref": "/s/es/superspuma/producto/essential-top",
+            "ctaLabel": "Ver Essential Top",
+            "description": "Entrada a resorte con Pillow Top. Esencial.",
+            "id": "essential-top",
+            "name": "Essential Top",
+            "priceFromLabel": "Desde Gs. 890.000"
+          },
+          {
+            "ctaHref": "/s/es/superspuma/producto/renovate",
+            "ctaLabel": "Ver Renovate",
+            "description": "Reemplazo económico y confiable para tu viejo colchón.",
+            "id": "renovate",
+            "name": "Renovate",
+            "priceFromLabel": "Desde Gs. 780.000"
+          },
+          {
+            "ctaHref": "/s/es/superspuma/producto/pop-teen",
+            "ctaLabel": "Ver Pop Teen",
+            "description": "Pop para adolescentes, precio accesible.",
+            "id": "pop-teen",
+            "name": "Pop Teen",
+            "priceFromLabel": "Desde Gs. 780.000"
+          },
+          {
+            "ctaHref": "/s/es/superspuma/producto/imperial",
+            "ctaLabel": "Ver Imperial",
+            "description": "Resortes Bonell con Pillow Top. Descanso regenerador.",
+            "id": "imperial",
+            "name": "Imperial",
+            "priceFromLabel": "Desde Gs. 2.230.000"
+          },
+          {
+            "badge": "Premium",
+            "ctaHref": "/s/es/superspuma/producto/titanium",
+            "ctaLabel": "Ver Titanium",
+            "description": "Premium con Euro Pillow Top. Resortes Bonell reforzados, hasta 120 kg.",
+            "id": "titanium",
+            "name": "Titanium",
+            "priceFromLabel": "Desde Gs. 1.800.000"
+          },
+          {
+            "ctaHref": "/s/es/superspuma/producto/duo-confort",
+            "ctaLabel": "Ver Duo Confort",
+            "description": "Memory foam adaptable. Alivio real de puntos de presión.",
+            "id": "duo-confort",
+            "name": "Duo Confort",
+            "priceFromLabel": "Desde Gs. 980.000"
+          },
+          {
+            "badge": "Más firme",
+            "ctaHref": "/s/es/superspuma/producto/ortopedico",
+            "ctaLabel": "Ver Ortopédico",
+            "description": "Espuma densidad 45. Hasta 140 kg. 6 años de garantía.",
+            "id": "ortopedico",
+            "name": "Ortopédico",
+            "priceFromLabel": "Desde Gs. 1.290.000"
+          }
+        ],
+        "resultHeading": "Tus 3 mejores matches",
+        "resultSubheading": "Ordenados por afinidad con tus respuestas. Escribinos para confirmar medidas, cuotas y disponibilidad.",
+        "steps": [
+          {
+            "helperText": "Si es para dos, elegí el peso de la persona más pesada.",
+            "id": "peso",
+            "options": [
+              {
+                "label": "Menos de 60 kg",
+                "scores": {
+                  "delta-soft": 2,
+                  "golden": 1,
+                  "luna-soft": 3,
+                  "pop-kids": 2,
+                  "super-kids": 2
+                },
+                "value": "menos-60"
+              },
+              {
+                "label": "Entre 60 y 80 kg",
+                "scores": {
+                  "duo-confort": 1,
+                  "essential-top": 2,
+                  "golden": 2,
+                  "harmony": 3,
+                  "serena": 2,
+                  "serrat": 2
+                },
+                "value": "60-80"
+              },
+              {
+                "label": "Entre 80 y 100 kg",
+                "scores": {
+                  "duo-confort": 2,
+                  "harmony": 2,
+                  "imperial": 3,
+                  "serena": 1,
+                  "titanium": 2
+                },
+                "value": "80-100"
+              },
+              {
+                "label": "Entre 100 y 130 kg",
+                "scores": {
+                  "duo-confort": 1,
+                  "imperial": 2,
+                  "ortopedico": 2,
+                  "titanium": 3
+                },
+                "value": "100-130"
+              },
+              {
+                "label": "Más de 130 kg",
+                "scores": {
+                  "ortopedico": 5,
+                  "titanium": 1
+                },
+                "value": "mas-130"
+              }
+            ],
+            "question": "¿Cuánto pesa la persona que va a usarlo?"
+          },
+          {
+            "id": "posicion",
+            "options": [
+              {
+                "label": "De costado",
+                "scores": {
+                  "delta-soft": 1,
+                  "duo-confort": 3,
+                  "harmony": 2,
+                  "luna-soft": 2
+                },
+                "value": "costado"
+              },
+              {
+                "label": "Boca arriba",
+                "scores": {
+                  "harmony": 2,
+                  "imperial": 2,
+                  "serena": 2,
+                  "titanium": 1
+                },
+                "value": "espalda"
+              },
+              {
+                "label": "Boca abajo",
+                "scores": {
+                  "imperial": 2,
+                  "ortopedico": 2,
+                  "serena": 1,
+                  "titanium": 2
+                },
+                "value": "estomago"
+              },
+              {
+                "label": "Cambio de posición toda la noche",
+                "scores": {
+                  "duo-confort": 3,
+                  "harmony": 2
+                },
+                "value": "mixto"
+              }
+            ],
+            "question": "¿En qué posición dormís más?"
+          },
+          {
+            "id": "columna",
+            "options": [
+              {
+                "label": "No, todo bien",
+                "scores": {
+                  "golden": 1,
+                  "harmony": 2,
+                  "luna-soft": 1,
+                  "serena": 1
+                },
+                "value": "no"
+              },
+              {
+                "label": "Dolor ocasional",
+                "scores": {
+                  "duo-confort": 3,
+                  "harmony": 2,
+                  "serena": 1
+                },
+                "value": "ocasional"
+              },
+              {
+                "label": "Dolor crónico / recomendación médica",
+                "scores": {
+                  "duo-confort": 3,
+                  "ortopedico": 4,
+                  "titanium": 2
+                },
+                "value": "cronico"
+              }
+            ],
+            "question": "¿Tenés problemas de columna o dolor de espalda?"
+          },
+          {
+            "helperText": "Si tuviste un colchón antes, pensá en qué cambiarías de ese.",
+            "id": "firmeza",
+            "options": [
+              {
+                "label": "Suave / mullido",
+                "scores": {
+                  "delta-soft": 2,
+                  "luna-soft": 3,
+                  "super-kids": 1
+                },
+                "value": "suave"
+              },
+              {
+                "label": "Medio (equilibrado)",
+                "scores": {
+                  "essential-top": 1,
+                  "golden": 2,
+                  "harmony": 3,
+                  "serena": 2,
+                  "serrat": 2
+                },
+                "value": "medio"
+              },
+              {
+                "label": "Firme",
+                "scores": {
+                  "imperial": 3,
+                  "titanium": 2
+                },
+                "value": "firme"
+              },
+              {
+                "label": "Extra firme / ortopédico",
+                "scores": {
+                  "ortopedico": 4,
+                  "titanium": 2
+                },
+                "value": "extra-firme"
+              },
+              {
+                "label": "Adaptable (se ajusta al cuerpo)",
+                "scores": {
+                  "duo-confort": 4,
+                  "serena": 1
+                },
+                "value": "adaptable"
+              }
+            ],
+            "question": "¿Qué firmeza preferís?"
+          },
+          {
+            "helperText": "Pensá en el precio total, con cuotas sin interés el mensual puede ser mucho menor.",
+            "id": "presupuesto",
+            "options": [
+              {
+                "label": "Hasta Gs. 800.000",
+                "scores": {
+                  "golden": 2,
+                  "luna-soft": 3,
+                  "pop-kids": 2,
+                  "pop-teen": 1,
+                  "renovate": 2,
+                  "super-kids": 2
+                },
+                "value": "economico"
+              },
+              {
+                "label": "Entre Gs. 800.000 y 1.500.000",
+                "scores": {
+                  "duo-confort": 1,
+                  "essential-top": 2,
+                  "golden": 1,
+                  "harmony": 3,
+                  "ortopedico": 1,
+                  "serena": 2,
+                  "serrat": 2
+                },
+                "value": "medio"
+              },
+              {
+                "label": "Entre Gs. 1.500.000 y 2.500.000",
+                "scores": {
+                  "duo-confort": 2,
+                  "harmony": 1,
+                  "imperial": 2,
+                  "ortopedico": 2,
+                  "titanium": 3
+                },
+                "value": "alto"
+              },
+              {
+                "label": "Más de Gs. 2.500.000",
+                "scores": {
+                  "imperial": 3,
+                  "ortopedico": 1,
+                  "titanium": 3
+                },
+                "value": "premium"
+              }
+            ],
+            "question": "¿Cuál es tu presupuesto ideal?"
+          },
+          {
+            "id": "tipo",
+            "options": [
+              {
+                "label": "Resorte (más firme, más ventilado)",
+                "scores": {
+                  "essential-top": 1,
+                  "harmony": 2,
+                  "imperial": 2,
+                  "serrat": 1,
+                  "titanium": 3
+                },
+                "value": "resorte"
+              },
+              {
+                "label": "Espuma (más silenciosa, más confortable)",
+                "scores": {
+                  "duo-confort": 3,
+                  "golden": 2,
+                  "luna-soft": 2,
+                  "ortopedico": 2,
+                  "serena": 2
+                },
+                "value": "espuma"
+              },
+              {
+                "label": "Me da igual, decidime",
+                "scores": {
+                  "duo-confort": 1,
+                  "harmony": 1,
+                  "ortopedico": 1,
+                  "titanium": 1
+                },
+                "value": "indiferente"
+              }
+            ],
+            "question": "¿Tenés preferencia por resorte o espuma?"
+          }
+        ],
+        "subtitle": "Respondé honestamente — las recomendaciones son mejores cuanto más ajustadas sean las respuestas.",
+        "title": "Contanos qué buscás",
+        "topK": 3
+      },
+      "seo": {
+        "description": "En 6 preguntas te recomendamos el colchón ideal según tu peso, postura al dormir, y necesidades de soporte. 19 modelos disponibles.",
+        "title": "¿Qué colchón necesitás? — Quiz Superspuma"
+      }
+    },
     "siteName": "Superspuma",
     "terminos": {
       "hero": {
@@ -42454,7 +42935,8 @@ export const VERTICALS: Record<string, JsonRecord> = {
       "compliance-disclaimer-footer",
       "promo-banner",
       "newsletter-signup",
-      "lead-form"
+      "lead-form",
+      "mattress-quiz"
     ],
     "baseType": "retail_base",
     "defaultStarterKit": "minimal",

--- a/web/lib/engine/section-registry.ts
+++ b/web/lib/engine/section-registry.ts
@@ -114,6 +114,12 @@ export const SECTION_CATALOG: Record<string, SectionManifest> = {
     variants: ['default'],
     requiredContentFields: [],
   },
+  'mattress-quiz': {
+    id: 'mattress-quiz',
+    defaultVariant: 'default',
+    variants: ['default'],
+    requiredContentFields: ['steps', 'products'],
+  },
   gallery: {
     id: 'gallery',
     defaultVariant: 'grid',

--- a/web/lib/engine/site-renderer.tsx
+++ b/web/lib/engine/site-renderer.tsx
@@ -57,6 +57,7 @@ import { CalcIreSection } from '@/components/sections/calc-ire-section'
 import { CalcIpsSection } from '@/components/sections/calc-ips-section'
 import { CalcCostoEmpleadoSection } from '@/components/sections/calc-costo-empleado-section'
 import { IntakeWizardSection } from '@/components/sections/intake-wizard-section'
+import { MattressQuizSection } from '@/components/sections/mattress-quiz-section'
 import { FeaturesSection } from '@/components/sections/features-section'
 import { ResourcesListSection } from '@/components/sections/resources-list-section'
 import { IntakeQuestionnaireSection } from '@/components/sections/intake-questionnaire-section'
@@ -135,6 +136,7 @@ export const COMPONENTS: Record<string, React.ComponentType<any>> = {
   'calc-ips': CalcIpsSection,
   'calc-costo-empleado': CalcCostoEmpleadoSection,
   'intake-wizard': IntakeWizardSection,
+  'mattress-quiz': MattressQuizSection,
   features: FeaturesSection,
   'resources-list': ResourcesListSection,
   'intake-questionnaire': IntakeQuestionnaireSection,


### PR DESCRIPTION
## Summary

6-question product-recommender quiz at `/s/es/superspuma/quiz` that maps user answers to top-3 catalog recommendations.

## What it does

- Visitor answers: peso / posición / dolor de columna / firmeza preferida / presupuesto / resorte vs espuma
- Each answer contributes weighted scores to 15 candidate products
- Top 3 shown with primary match highlighted, direct links to PDPs

## Scoring model (excerpt)

| Answer | Strongest boost |
|--------|----------------|
| Más de 130 kg | Ortopédico (+5) |
| Dolor crónico | Ortopédico (+4), Duo Confort (+3) |
| Firmeza suave | Luna Soft (+3), Delta Soft (+2) |
| Presupuesto económico | Luna Soft / Super Kids / Pop Kids / Golden |
| Resorte preferido | Titanium (+3), Imperial (+2), Harmony (+2) |

## Files

- **New:** `web/components/sections/mattress-quiz-section.tsx` — generic scorable quiz component
- **New:** `sites/superspuma/pages/quiz.json` + content block in es.json
- section-registry + site-renderer wired
- retail-local vertical: +mattress-quiz in allowedSections
- Nav gets '¿Qué necesitás?' link between Catálogo and Tiendas

## Test plan

- [x] 319 all-tenants compose combos pass (+4 quiz page variants)
- [x] Renderer wiring intact
- [x] Generic enough that other mattress tenants (or any product-recommender use case) can plug in their own rubric

🤖 Generated with [Claude Code](https://claude.com/claude-code)