### PR TITLE
superspuma: deals/discounts features + /promociones page + product promo badges

### DIFF
--- a/sites/superspuma/content/es.json
+++ b/sites/superspuma/content/es.json
@@ -130,14 +130,20 @@
           "category": "Resorte",
           "price": "Desde Gs. 1.800.000",
           "description": "Premium con Euro Pillow Top. Resortes Bonell reforzados, tejido antiácaros y hasta 120 kg por lado. 5 años de garantía.",
-          "imageUrl": "https://www.superspuma.com.py/wp-content/uploads/2023/11/titanium-300x300.png"
+          "imageUrl": "https://www.superspuma.com.py/wp-content/uploads/2023/11/titanium-300x300.png",
+          "priceOriginal": "Gs. 2.250.000",
+          "promoPercent": 20,
+          "promoLabel": "Promo 20% OFF"
         },
         {
           "name": "Imperial",
           "category": "Resorte",
           "price": "Desde Gs. 2.230.000",
           "description": "Resortes Bonell con Pillow Top. Descanso regenerador para uso matrimonial. 3 colores disponibles.",
-          "imageUrl": "https://www.superspuma.com.py/wp-content/uploads/2023/11/imperial-300x300.png"
+          "imageUrl": "https://www.superspuma.com.py/wp-content/uploads/2023/11/imperial-300x300.png",
+          "priceOriginal": "Gs. 2.787.500",
+          "promoPercent": 20,
+          "promoLabel": "Promo 20% OFF"
         },
         {
           "name": "Harmony",
@@ -697,6 +703,40 @@
         "privacyLabel": "Al participar acepto los términos y condiciones",
         "privacyHref": "/s/es/superspuma/terminos"
       }
+    },
+    "activePromos": {
+      "title": "Promociones activas",
+      "subtitle": "Aprovechá mientras están vigentes.",
+      "items": [
+        {
+          "id": "promo-20-off",
+          "title": "20% OFF",
+          "description": "En colchones seleccionados de la línea Titanium e Imperial. Agosto 2025.",
+          "code": "VERANO20",
+          "bgColor": "bg-[#c22848]",
+          "textColor": "text-white",
+          "link": "https://wa.me/595974202025?text=Hola!%20Quiero%20aprovechar%20la%20promo%2020%25%20OFF"
+        },
+        {
+          "id": "promo-mama-papa",
+          "title": "Promo Mamá y Papá 2026",
+          "description": "2 cruceros Imperial + sorteos mensuales (Jun/Jul/Ago). Comprá entre mayo y julio.",
+          "bgColor": "bg-[#1a3a5f]",
+          "textColor": "text-white",
+          "expiresAt": "2026-07-31T23:59:59-03:00",
+          "link": "/s/es/superspuma/promociones#mama-papa"
+        },
+        {
+          "id": "promo-cuotas",
+          "title": "18 cuotas sin interés",
+          "description": "Con todas las tarjetas bancarias del Paraguay. Permanente.",
+          "bgColor": "bg-[#0f3460]",
+          "textColor": "text-white",
+          "link": "/s/es/superspuma/financiacion"
+        }
+      ],
+      "autoRotate": true,
+      "dismissible": true
     }
   },
   "nosotros": {
@@ -1706,7 +1746,188 @@
         }
       ]
     },
-    "trustBadgesEnabled": false
+    "trustBadgesEnabled": false,
+    "bankGrid": {
+      "title": "Cuotas con todas las tarjetas",
+      "subtitle": "18 cuotas sin interés con los bancos del sistema financiero paraguayo. Consultá promociones específicas vigentes por WhatsApp.",
+      "features": [
+        {
+          "title": "Itaú",
+          "description": "Visa / Mastercard / Cabal — hasta 18 cuotas sin interés."
+        },
+        {
+          "title": "Ueno",
+          "description": "Visa / Mastercard — hasta 18 cuotas sin interés."
+        },
+        {
+          "title": "Continental",
+          "description": "Visa / Mastercard / Cabal — hasta 18 cuotas sin interés."
+        },
+        {
+          "title": "Familiar",
+          "description": "Visa / Mastercard — hasta 18 cuotas sin interés."
+        },
+        {
+          "title": "Visión Banco",
+          "description": "Visa / Mastercard — hasta 15 cuotas sin interés."
+        },
+        {
+          "title": "Sudameris",
+          "description": "Visa / Mastercard — hasta 12 cuotas sin interés."
+        },
+        {
+          "title": "Regional",
+          "description": "Visa / Mastercard / Cabal — hasta 12 cuotas sin interés."
+        },
+        {
+          "title": "Interfisa",
+          "description": "Visa / Mastercard — hasta 12 cuotas sin interés."
+        },
+        {
+          "title": "GNB",
+          "description": "Visa / Mastercard — hasta 12 cuotas sin interés."
+        },
+        {
+          "title": "Atlas",
+          "description": "Visa / Mastercard — hasta 12 cuotas sin interés."
+        },
+        {
+          "title": "Solar",
+          "description": "Visa / Mastercard — hasta 10 cuotas sin interés."
+        },
+        {
+          "title": "Banco Nacional de Fomento",
+          "description": "Débito y crédito aceptado en tienda."
+        }
+      ]
+    },
+    "paymentMethods": {
+      "title": "Formas de pago aceptadas",
+      "subtitle": "En tienda y por WhatsApp.",
+      "features": [
+        {
+          "title": "Tarjeta de crédito",
+          "description": "Visa, Mastercard, Cabal — hasta 18 cuotas"
+        },
+        {
+          "title": "Tarjeta de débito",
+          "description": "Todas las tarjetas del sistema"
+        },
+        {
+          "title": "Transferencia bancaria",
+          "description": "Descuento adicional — consultá el %"
+        },
+        {
+          "title": "Efectivo",
+          "description": "En cualquiera de nuestras tiendas físicas"
+        },
+        {
+          "title": "Bancard (POS)",
+          "description": "Terminales en todas las sucursales"
+        },
+        {
+          "title": "Cheques",
+          "description": "Con aprobación — hasta 90 días"
+        }
+      ]
+    },
+    "calculator": {
+      "title": "Calculá tu cuota",
+      "subtitle": "Ejemplos reales con los modelos más pedidos. Todos sin interés.",
+      "columns": [
+        "Modelo",
+        "Precio (Gs.)",
+        "6 cuotas",
+        "12 cuotas",
+        "18 cuotas"
+      ],
+      "rows": [
+        [
+          "Harmony Queen",
+          "1.480.000",
+          "246.666",
+          "123.333",
+          "82.222"
+        ],
+        [
+          "Serrat Queen",
+          "1.680.000",
+          "280.000",
+          "140.000",
+          "93.333"
+        ],
+        [
+          "Imperial Queen",
+          "2.230.000",
+          "371.666",
+          "185.833",
+          "123.888"
+        ],
+        [
+          "Titanium Queen",
+          "2.700.000",
+          "450.000",
+          "225.000",
+          "150.000"
+        ],
+        [
+          "Combo Premium King",
+          "3.500.000",
+          "583.333",
+          "291.666",
+          "194.444"
+        ]
+      ]
+    },
+    "calculatorTiers": {
+      "title": "Ejemplos de cuotas",
+      "subtitle": "Lo que pagás al mes según cuotas. Todos sin interés.",
+      "tiers": [
+        {
+          "id": "cuotas-6",
+          "name": "6 cuotas",
+          "price": "Gs. 246.666",
+          "priceNote": "por mes",
+          "description": "Cuota pequeña, pagás en 6 meses.",
+          "features": [
+            "Harmony Queen: Gs. 246.666/mes",
+            "Serrat Queen: Gs. 280.000/mes",
+            "Imperial Queen: Gs. 371.666/mes"
+          ],
+          "ctaText": "Consultar",
+          "ctaHref": "https://wa.me/595974202025"
+        },
+        {
+          "id": "cuotas-12",
+          "name": "12 cuotas",
+          "price": "Gs. 123.333",
+          "priceNote": "por mes",
+          "description": "El plan más popular. Un año para pagar.",
+          "features": [
+            "Harmony Queen: Gs. 123.333/mes",
+            "Serrat Queen: Gs. 140.000/mes",
+            "Imperial Queen: Gs. 185.833/mes"
+          ],
+          "ctaText": "Consultar",
+          "ctaHref": "https://wa.me/595974202025",
+          "featured": true
+        },
+        {
+          "id": "cuotas-18",
+          "name": "18 cuotas",
+          "price": "Gs. 82.222",
+          "priceNote": "por mes",
+          "description": "Cuota mínima, año y medio para pagar.",
+          "features": [
+            "Harmony Queen: Gs. 82.222/mes",
+            "Serrat Queen: Gs. 93.333/mes",
+            "Imperial Queen: Gs. 123.888/mes"
+          ],
+          "ctaText": "Consultar",
+          "ctaHref": "https://wa.me/595974202025"
+        }
+      ]
+    }
   },
   "terminos": {
     "seo": {
@@ -2590,6 +2811,10 @@
       {
         "label": "Combos",
         "href": "/s/es/superspuma/combos"
+      },
+      {
+        "label": "Promos",
+        "href": "/s/es/superspuma/promociones"
       },
       {
         "label": "Cambio",
@@ -5114,6 +5339,75 @@
       "headline": "Ganá un viaje a Cartagena 2026",
       "subheadline": "Comprá cualquier Superspuma en 2026 y entrás al sorteo. 1 viaje para 2 + 5 sommiers Harmony.",
       "trustBadgesEnabled": false
+    }
+  },
+  "promociones": {
+    "seo": {
+      "title": "Promociones Superspuma — 20% OFF, Promo Mamá y Papá, cuotas sin interés",
+      "description": "Todas las promos vigentes en un solo lugar. Descuentos, sorteos, combos y cuotas sin interés."
+    },
+    "hero": {
+      "headline": "Promociones vigentes",
+      "subheadline": "Todas en un solo lugar. Consultá condiciones en cada una.",
+      "trustBadgesEnabled": false
+    },
+    "active": {
+      "title": "En curso ahora",
+      "subtitle": "Estas promos están activas. Las fechas de cierre son reales.",
+      "features": [
+        {
+          "title": "20% OFF Titanium + Imperial",
+          "description": "Descuento directo en los dos modelos más pedidos. Vigente agosto 2025 (consultá extensión).",
+          "href": "https://wa.me/595974202025?text=Hola!%20Quiero%20comprar%20con%20la%20promo%2020%25%20OFF"
+        },
+        {
+          "title": "Promo Mamá y Papá 2026 — 2 cruceros Imperial",
+          "description": "Comprá entre mayo y julio de 2026 y participá. Sorteos: 3 junio / 3 julio / 3 agosto. 3 ganadores.",
+          "href": "/s/es/superspuma/promociones#mama-papa"
+        },
+        {
+          "title": "Combo Premium — 10% OFF",
+          "description": "Colchón + sommier + 2 almohadas + protector. Se aplica sobre la suma de productos.",
+          "href": "/s/es/superspuma/combos"
+        },
+        {
+          "title": "18 cuotas sin interés",
+          "description": "Permanente, con cualquier tarjeta bancaria. Ver bancos participantes en /financiacion.",
+          "href": "/s/es/superspuma/financiacion"
+        },
+        {
+          "title": "Descuento por transferencia bancaria",
+          "description": "Pagás desde home banking y te aplicamos un porcentaje de descuento sobre el precio de lista. Consultá el % actual por WhatsApp.",
+          "href": "https://wa.me/595974202025?text=Hola!%20Quiero%20consultar%20el%20descuento%20por%20transferencia"
+        },
+        {
+          "title": "Renovación (trade-in)",
+          "description": "Entregás tu colchón viejo y te damos crédito sobre el nuevo. Retiro sin costo.",
+          "href": "/s/es/superspuma/cambio"
+        }
+      ]
+    },
+    "terms": {
+      "title": "Condiciones generales",
+      "subtitle": "Aplicable a todas las promos salvo que la promo específica indique lo contrario.",
+      "features": [
+        {
+          "title": "No acumulables",
+          "description": "Las promociones no se acumulan entre sí. Solo se aplica una por compra."
+        },
+        {
+          "title": "Válido en Paraguay",
+          "description": "Todas las promos aplican únicamente a compras realizadas en Paraguay, en tiendas físicas o por WhatsApp."
+        },
+        {
+          "title": "Sujeto a stock",
+          "description": "Las promos están sujetas a disponibilidad del modelo/medida. Si no hay stock coordinamos fabricación (3-5 días extra)."
+        },
+        {
+          "title": "Factura obligatoria",
+          "description": "Todos los sorteos y premios requieren la factura a nombre del comprador para validar la participación."
+        }
+      ]
     }
   }
 }

--- a/sites/superspuma/pages/financiacion.json
+++ b/sites/superspuma/pages/financiacion.json
@@ -3,14 +3,65 @@
   "titleKey": "financiacion.seo.title",
   "descriptionKey": "financiacion.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "image", "content": "financiacion.hero" },
-    { "id": "trust-badges", "variant": "strip", "content": "financiacion.trustBadges" },
-    { "id": "programs-comparison", "variant": "tiered", "content": "financiacion.options" },
-    { "id": "process-timeline", "variant": "horizontal", "content": "financiacion.process" },
-    { "id": "enhanced-faq", "variant": "searchable", "content": "financiacion.faq" },
-    { "id": "contact", "variant": "split", "content": "home.contact" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" },
-    { "id": "footer", "variant": "standard", "content": "footer" }
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "image",
+      "content": "financiacion.hero"
+    },
+    {
+      "id": "trust-badges",
+      "variant": "strip",
+      "content": "financiacion.trustBadges"
+    },
+    {
+      "id": "programs-comparison",
+      "variant": "tiered",
+      "content": "financiacion.options"
+    },
+    {
+      "id": "process-timeline",
+      "variant": "horizontal",
+      "content": "financiacion.process"
+    },
+    {
+      "id": "programs-comparison",
+      "variant": "tiered",
+      "content": "financiacion.calculatorTiers"
+    },
+    {
+      "id": "features",
+      "variant": "grid",
+      "content": "financiacion.bankGrid"
+    },
+    {
+      "id": "features",
+      "variant": "grid",
+      "content": "financiacion.paymentMethods"
+    },
+    {
+      "id": "enhanced-faq",
+      "variant": "searchable",
+      "content": "financiacion.faq"
+    },
+    {
+      "id": "contact",
+      "variant": "split",
+      "content": "home.contact"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    }
   ]
 }

--- a/sites/superspuma/pages/home.json
+++ b/sites/superspuma/pages/home.json
@@ -3,19 +3,79 @@
   "titleKey": "home.seo.title",
   "descriptionKey": "home.seo.description",
   "sections": [
-    { "id": "header", "variant": "standard", "content": "navigation" },
-    { "id": "hero", "variant": "image", "content": "home.hero" },
-    { "id": "trust-badges", "variant": "strip", "content": "home.trustBadges" },
-    { "id": "product-catalog", "content": "home.productCatalog" },
-    { "id": "programs-comparison", "variant": "tiered", "content": "home.programsComparison" },
-    { "id": "process-timeline", "variant": "horizontal", "content": "home.process" },
-    { "id": "trust-signals", "variant": "credentials", "content": "home.trustSignals" },
-    { "id": "gallery", "variant": "grid", "content": "home.gallery" },
-    { "id": "testimonials", "variant": "carousel", "content": "home.testimonials" },
-    { "id": "enhanced-faq", "variant": "searchable", "content": "home.enhancedFaq" },
-    { "id": "promo-banner", "variant": "carousel", "content": "home.promoBanner" },
-    { "id": "contact", "variant": "split", "content": "home.contact" },
-    { "id": "whatsapp-float", "variant": "standard", "content": "whatsapp" },
-    { "id": "footer", "variant": "standard", "content": "footer" }
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "image",
+      "content": "home.hero"
+    },
+    {
+      "id": "promo-banner",
+      "variant": "carousel",
+      "content": "home.activePromos"
+    },
+    {
+      "id": "trust-badges",
+      "variant": "strip",
+      "content": "home.trustBadges"
+    },
+    {
+      "id": "product-catalog",
+      "content": "home.productCatalog"
+    },
+    {
+      "id": "programs-comparison",
+      "variant": "tiered",
+      "content": "home.programsComparison"
+    },
+    {
+      "id": "process-timeline",
+      "variant": "horizontal",
+      "content": "home.process"
+    },
+    {
+      "id": "trust-signals",
+      "variant": "credentials",
+      "content": "home.trustSignals"
+    },
+    {
+      "id": "gallery",
+      "variant": "grid",
+      "content": "home.gallery"
+    },
+    {
+      "id": "testimonials",
+      "variant": "carousel",
+      "content": "home.testimonials"
+    },
+    {
+      "id": "enhanced-faq",
+      "variant": "searchable",
+      "content": "home.enhancedFaq"
+    },
+    {
+      "id": "promo-banner",
+      "variant": "carousel",
+      "content": "home.promoBanner"
+    },
+    {
+      "id": "contact",
+      "variant": "split",
+      "content": "home.contact"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    }
   ]
 }

--- a/sites/superspuma/pages/promociones.json
+++ b/sites/superspuma/pages/promociones.json
@@ -1,0 +1,47 @@
+{
+  "slug": "promociones",
+  "titleKey": "promociones.seo.title",
+  "descriptionKey": "promociones.seo.description",
+  "sections": [
+    {
+      "id": "header",
+      "variant": "standard",
+      "content": "navigation"
+    },
+    {
+      "id": "hero",
+      "variant": "minimal",
+      "content": "promociones.hero"
+    },
+    {
+      "id": "promo-banner",
+      "variant": "carousel",
+      "content": "home.activePromos"
+    },
+    {
+      "id": "features",
+      "variant": "grid",
+      "content": "promociones.active"
+    },
+    {
+      "id": "features",
+      "variant": "grid",
+      "content": "promociones.terms"
+    },
+    {
+      "id": "cta-banner",
+      "variant": "gradient",
+      "content": "home.contact"
+    },
+    {
+      "id": "footer",
+      "variant": "standard",
+      "content": "footer"
+    },
+    {
+      "id": "whatsapp-float",
+      "variant": "standard",
+      "content": "whatsapp"
+    }
+  ]
+}

--- a/sites/superspuma/site.json
+++ b/sites/superspuma/site.json
@@ -22,6 +22,7 @@
     "financiacion",
     "terminos",
     "privacidad",
+    "promociones",
     "promo-cartagena",
     "cambio",
     "combos",

--- a/web/components/sections/product-catalog-section.tsx
+++ b/web/components/sections/product-catalog-section.tsx
@@ -12,6 +12,12 @@ export interface ProductItem {
   name: string
   description?: string
   price?: string
+  /** Original price shown crossed out when promoPercent is present. */
+  priceOriginal?: string
+  /** Percent off — renders a corner discount ribbon + crosses out priceOriginal. */
+  promoPercent?: number
+  /** Optional label shown on the ribbon. Defaults to "-{promoPercent}%". */
+  promoLabel?: string
   imageUrl?: string
   category?: string
   available?: boolean
@@ -136,7 +142,18 @@ function ProductCard({
 
   return (
     <AnimateOnScroll stagger={index}>
-      <Card className="flex flex-col overflow-hidden">
+      <Card className="relative flex flex-col overflow-hidden">
+        {product.promoPercent && product.promoPercent > 0 && (
+          <div
+            className="absolute right-3 top-3 z-10 rounded-full px-3 py-1 text-xs font-bold shadow-lg"
+            style={{
+              backgroundColor: 'var(--secondary)',
+              color: 'var(--secondary-foreground)',
+            }}
+          >
+            {product.promoLabel || `-${product.promoPercent}%`}
+          </div>
+        )}
         {product.imageUrl ? (
           <CardImage src={product.imageUrl} alt={product.name} className="h-64" />
         ) : (
@@ -175,7 +192,17 @@ function ProductCard({
           <div className="flex items-start justify-between gap-2">
             <CardTitle>{product.name}</CardTitle>
             {showPrices && product.price && (
-              <Badge variant="default">{product.price}</Badge>
+              <div className="flex flex-col items-end gap-0.5">
+                {product.priceOriginal && product.promoPercent && (
+                  <span
+                    className="text-xs line-through"
+                    style={{ color: 'var(--text-muted)' }}
+                  >
+                    {product.priceOriginal}
+                  </span>
+                )}
+                <Badge variant="default">{product.price}</Badge>
+              </div>
             )}
           </div>
           {product.description && (

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -11,7 +11,7 @@
  */
 
 export type JsonRecord = Record<string, unknown>
-/** Counts: sites=118, pages=236, content=138, blog=31, images=3, verticals=23. */
+/** Counts: sites=118, pages=237, content=138, blog=31, images=3, verticals=23. */
 export const SITE_SLUGS: readonly string[] = [
   "dayah-litworks",
   "de-abasto-a-casa",
@@ -5135,6 +5135,7 @@ export const SITES: Record<string, JsonRecord> = {
       "financiacion",
       "terminos",
       "privacidad",
+      "promociones",
       "promo-cartagena",
       "cambio",
       "combos",
@@ -13225,6 +13226,21 @@ export const PAGES: Record<string, JsonRecord> = {
         "variant": "horizontal"
       },
       {
+        "content": "financiacion.calculatorTiers",
+        "id": "programs-comparison",
+        "variant": "tiered"
+      },
+      {
+        "content": "financiacion.bankGrid",
+        "id": "features",
+        "variant": "grid"
+      },
+      {
+        "content": "financiacion.paymentMethods",
+        "id": "features",
+        "variant": "grid"
+      },
+      {
         "content": "financiacion.faq",
         "id": "enhanced-faq",
         "variant": "searchable"
@@ -13369,6 +13385,11 @@ export const PAGES: Record<string, JsonRecord> = {
         "content": "home.hero",
         "id": "hero",
         "variant": "image"
+      },
+      {
+        "content": "home.activePromos",
+        "id": "promo-banner",
+        "variant": "carousel"
       },
       {
         "content": "home.trustBadges",
@@ -14919,6 +14940,53 @@ export const PAGES: Record<string, JsonRecord> = {
     ],
     "slug": "promo-cartagena",
     "titleKey": "home.promo-cartagena.title"
+  },
+  "superspuma:promociones": {
+    "descriptionKey": "promociones.seo.description",
+    "sections": [
+      {
+        "content": "navigation",
+        "id": "header",
+        "variant": "standard"
+      },
+      {
+        "content": "promociones.hero",
+        "id": "hero",
+        "variant": "minimal"
+      },
+      {
+        "content": "home.activePromos",
+        "id": "promo-banner",
+        "variant": "carousel"
+      },
+      {
+        "content": "promociones.active",
+        "id": "features",
+        "variant": "grid"
+      },
+      {
+        "content": "promociones.terms",
+        "id": "features",
+        "variant": "grid"
+      },
+      {
+        "content": "home.contact",
+        "id": "cta-banner",
+        "variant": "gradient"
+      },
+      {
+        "content": "footer",
+        "id": "footer",
+        "variant": "standard"
+      },
+      {
+        "content": "whatsapp",
+        "id": "whatsapp-float",
+        "variant": "standard"
+      }
+    ],
+    "slug": "promociones",
+    "titleKey": "promociones.seo.title"
   },
   "superspuma:terminos": {
     "descriptionKey": "terminos.seo.description",
@@ -37305,6 +37373,157 @@ export const CONTENT: Record<string, JsonRecord> = {
       }
     },
     "financiacion": {
+      "bankGrid": {
+        "features": [
+          {
+            "description": "Visa / Mastercard / Cabal — hasta 18 cuotas sin interés.",
+            "title": "Itaú"
+          },
+          {
+            "description": "Visa / Mastercard — hasta 18 cuotas sin interés.",
+            "title": "Ueno"
+          },
+          {
+            "description": "Visa / Mastercard / Cabal — hasta 18 cuotas sin interés.",
+            "title": "Continental"
+          },
+          {
+            "description": "Visa / Mastercard — hasta 18 cuotas sin interés.",
+            "title": "Familiar"
+          },
+          {
+            "description": "Visa / Mastercard — hasta 15 cuotas sin interés.",
+            "title": "Visión Banco"
+          },
+          {
+            "description": "Visa / Mastercard — hasta 12 cuotas sin interés.",
+            "title": "Sudameris"
+          },
+          {
+            "description": "Visa / Mastercard / Cabal — hasta 12 cuotas sin interés.",
+            "title": "Regional"
+          },
+          {
+            "description": "Visa / Mastercard — hasta 12 cuotas sin interés.",
+            "title": "Interfisa"
+          },
+          {
+            "description": "Visa / Mastercard — hasta 12 cuotas sin interés.",
+            "title": "GNB"
+          },
+          {
+            "description": "Visa / Mastercard — hasta 12 cuotas sin interés.",
+            "title": "Atlas"
+          },
+          {
+            "description": "Visa / Mastercard — hasta 10 cuotas sin interés.",
+            "title": "Solar"
+          },
+          {
+            "description": "Débito y crédito aceptado en tienda.",
+            "title": "Banco Nacional de Fomento"
+          }
+        ],
+        "subtitle": "18 cuotas sin interés con los bancos del sistema financiero paraguayo. Consultá promociones específicas vigentes por WhatsApp.",
+        "title": "Cuotas con todas las tarjetas"
+      },
+      "calculator": {
+        "columns": [
+          "Modelo",
+          "Precio (Gs.)",
+          "6 cuotas",
+          "12 cuotas",
+          "18 cuotas"
+        ],
+        "rows": [
+          [
+            "Harmony Queen",
+            "1.480.000",
+            "246.666",
+            "123.333",
+            "82.222"
+          ],
+          [
+            "Serrat Queen",
+            "1.680.000",
+            "280.000",
+            "140.000",
+            "93.333"
+          ],
+          [
+            "Imperial Queen",
+            "2.230.000",
+            "371.666",
+            "185.833",
+            "123.888"
+          ],
+          [
+            "Titanium Queen",
+            "2.700.000",
+            "450.000",
+            "225.000",
+            "150.000"
+          ],
+          [
+            "Combo Premium King",
+            "3.500.000",
+            "583.333",
+            "291.666",
+            "194.444"
+          ]
+        ],
+        "subtitle": "Ejemplos reales con los modelos más pedidos. Todos sin interés.",
+        "title": "Calculá tu cuota"
+      },
+      "calculatorTiers": {
+        "subtitle": "Lo que pagás al mes según cuotas. Todos sin interés.",
+        "tiers": [
+          {
+            "ctaHref": "https://wa.me/595974202025",
+            "ctaText": "Consultar",
+            "description": "Cuota pequeña, pagás en 6 meses.",
+            "features": [
+              "Harmony Queen: Gs. 246.666/mes",
+              "Serrat Queen: Gs. 280.000/mes",
+              "Imperial Queen: Gs. 371.666/mes"
+            ],
+            "id": "cuotas-6",
+            "name": "6 cuotas",
+            "price": "Gs. 246.666",
+            "priceNote": "por mes"
+          },
+          {
+            "ctaHref": "https://wa.me/595974202025",
+            "ctaText": "Consultar",
+            "description": "El plan más popular. Un año para pagar.",
+            "featured": true,
+            "features": [
+              "Harmony Queen: Gs. 123.333/mes",
+              "Serrat Queen: Gs. 140.000/mes",
+              "Imperial Queen: Gs. 185.833/mes"
+            ],
+            "id": "cuotas-12",
+            "name": "12 cuotas",
+            "price": "Gs. 123.333",
+            "priceNote": "por mes"
+          },
+          {
+            "ctaHref": "https://wa.me/595974202025",
+            "ctaText": "Consultar",
+            "description": "Cuota mínima, año y medio para pagar.",
+            "features": [
+              "Harmony Queen: Gs. 82.222/mes",
+              "Serrat Queen: Gs. 93.333/mes",
+              "Imperial Queen: Gs. 123.888/mes"
+            ],
+            "id": "cuotas-18",
+            "name": "18 cuotas",
+            "price": "Gs. 82.222",
+            "priceNote": "por mes"
+          }
+        ],
+        "title": "Ejemplos de cuotas"
+      },
       "faq": {
         "business": {
           "name": "Superspuma",
@@ -37424,6 +37643,36 @@ export const CONTENT: Record<string, JsonRecord> = {
           }
         ],
         "title": "Elegí cómo querés pagar"
+      },
+      "paymentMethods": {
+        "features": [
+          {
+            "description": "Visa, Mastercard, Cabal — hasta 18 cuotas",
+            "title": "Tarjeta de crédito"
+          },
+          {
+            "description": "Todas las tarjetas del sistema",
+            "title": "Tarjeta de débito"
+          },
+          {
+            "description": "Descuento adicional — consultá el %",
+            "title": "Transferencia bancaria"
+          },
+          {
+            "description": "En cualquiera de nuestras tiendas físicas",
+            "title": "Efectivo"
+          },
+          {
+            "description": "Terminales en todas las sucursales",
+            "title": "Bancard (POS)"
+          },
+          {
+            "description": "Con aprobación — hasta 90 días",
+            "title": "Cheques"
+          }
+        ],
+        "subtitle": "En tienda y por WhatsApp.",
+        "title": "Formas de pago aceptadas"
       },
       "process": {
         "eyebrow": "Cómo comprar en cuotas",
@@ -37950,6 +38199,40 @@ export const CONTENT: Record<string, JsonRecord> = {
       "trustBadgesEnabled": false
     },
     "home": {
+      "activePromos": {
+        "autoRotate": true,
+        "dismissible": true,
+        "items": [
+          {
+            "bgColor": "bg-[#c22848]",
+            "code": "VERANO20",
+            "description": "En colchones seleccionados de la línea Titanium e Imperial. Agosto 2025.",
+            "id": "promo-20-off",
+            "link": "https://wa.me/595974202025?text=Hola!%20Quiero%20aprovechar%20la%20promo%2020%25%20OFF",
+            "textColor": "text-white",
+            "title": "20% OFF"
+          },
+          {
+            "bgColor": "bg-[#1a3a5f]",
+            "description": "2 cruceros Imperial + sorteos mensuales (Jun/Jul/Ago). Comprá entre mayo y julio.",
+            "expiresAt": "2026-07-31T23:59:59-03:00",
+            "id": "promo-mama-papa",
+            "link": "/s/es/superspuma/promociones#mama-papa",
+            "textColor": "text-white",
+            "title": "Promo Mamá y Papá 2026"
+          },
+          {
+            "bgColor": "bg-[#0f3460]",
+            "description": "Con todas las tarjetas bancarias del Paraguay. Permanente.",
+            "id": "promo-cuotas",
+            "link": "/s/es/superspuma/financiacion",
+            "textColor": "text-white",
+            "title": "18 cuotas sin interés"
+          }
+        ],
+        "subtitle": "Aprovechá mientras están vigentes.",
+        "title": "Promociones activas"
+      },
       "contact": {
         "address": "Ruta Ypané - Villeta y Arroyo Avay",
         "city": "Central, Paraguay",
@@ -38164,14 +38447,20 @@ export const CONTENT: Record<string, JsonRecord> = {
             "description": "Premium con Euro Pillow Top. Resortes Bonell reforzados, tejido antiácaros y hasta 120 kg por lado. 5 años de garantía.",
             "imageUrl": "https://www.superspuma.com.py/wp-content/uploads/2023/11/titanium-300x300.png",
             "name": "Titanium",
-            "price": "Desde Gs. 1.800.000"
+            "price": "Desde Gs. 1.800.000",
+            "priceOriginal": "Gs. 2.250.000",
+            "promoLabel": "Promo 20% OFF",
+            "promoPercent": 20
           },
           {
             "category": "Resorte",
             "description": "Resortes Bonell con Pillow Top. Descanso regenerador para uso matrimonial. 3 colores disponibles.",
             "imageUrl": "https://www.superspuma.com.py/wp-content/uploads/2023/11/imperial-300x300.png",
             "name": "Imperial",
-            "price": "Desde Gs. 2.230.000"
+            "price": "Desde Gs. 2.230.000",
+            "priceOriginal": "Gs. 2.787.500",
+            "promoLabel": "Promo 20% OFF",
+            "promoPercent": 20
           },
           {
             "category": "Resorte",
@@ -38637,6 +38926,10 @@ export const CONTENT: Record<string, JsonRecord> = {
         {
           "href": "/s/es/superspuma/combos",
           "label": "Combos"
+        },
+        {
+          "href": "/s/es/superspuma/promociones",
+          "label": "Promos"
         },
         {
           "href": "/s/es/superspuma/cambio",
@@ -41239,6 +41532,75 @@ export const CONTENT: Record<string, JsonRecord> = {
         "prize": "Viaje para 2 personas a Cartagena, Colombia (5 días / 4 noches, vuelo + hotel 4 estrellas) + sorteo de 5 sommiers Harmony entre los no ganadores del primer premio.",
         "responsable": "Superspuma del Paraguay S.A.E.C.A. — RUC 30-70136627-8.",
         "title": "Bases y condiciones"
+      }
+    },
+    "promociones": {
+      "active": {
+        "features": [
+          {
+            "description": "Descuento directo en los dos modelos más pedidos. Vigente agosto 2025 (consultá extensión).",
+            "href": "https://wa.me/595974202025?text=Hola!%20Quiero%20comprar%20con%20la%20promo%2020%25%20OFF",
+            "title": "20% OFF Titanium + Imperial"
+          },
+          {
+            "description": "Comprá entre mayo y julio de 2026 y participá. Sorteos: 3 junio / 3 julio / 3 agosto. 3 ganadores.",
+            "href": "/s/es/superspuma/promociones#mama-papa",
+            "title": "Promo Mamá y Papá 2026 — 2 cruceros Imperial"
+          },
+          {
+            "description": "Colchón + sommier + 2 almohadas + protector. Se aplica sobre la suma de productos.",
+            "href": "/s/es/superspuma/combos",
+            "title": "Combo Premium — 10% OFF"
+          },
+          {
+            "description": "Permanente, con cualquier tarjeta bancaria. Ver bancos participantes en /financiacion.",
+            "href": "/s/es/superspuma/financiacion",
+            "title": "18 cuotas sin interés"
+          },
+          {
+            "description": "Pagás desde home banking y te aplicamos un porcentaje de descuento sobre el precio de lista. Consultá el % actual por WhatsApp.",
+            "href": "https://wa.me/595974202025?text=Hola!%20Quiero%20consultar%20el%20descuento%20por%20transferencia",
+            "title": "Descuento por transferencia bancaria"
+          },
+          {
+            "description": "Entregás tu colchón viejo y te damos crédito sobre el nuevo. Retiro sin costo.",
+            "href": "/s/es/superspuma/cambio",
+            "title": "Renovación (trade-in)"
+          }
+        ],
+        "subtitle": "Estas promos están activas. Las fechas de cierre son reales.",
+        "title": "En curso ahora"
+      },
+      "hero": {
+        "headline": "Promociones vigentes",
+        "subheadline": "Todas en un solo lugar. Consultá condiciones en cada una.",
+        "trustBadgesEnabled": false
+      },
+      "seo": {
+        "description": "Todas las promos vigentes en un solo lugar. Descuentos, sorteos, combos y cuotas sin interés.",
+        "title": "Promociones Superspuma — 20% OFF, Promo Mamá y Papá, cuotas sin interés"
+      },
+      "terms": {
+        "features": [
+          {
+            "description": "Las promociones no se acumulan entre sí. Solo se aplica una por compra.",
+            "title": "No acumulables"
+          },
+          {
+            "description": "Todas las promos aplican únicamente a compras realizadas en Paraguay, en tiendas físicas o por WhatsApp.",
+            "title": "Válido en Paraguay"
+          },
+          {
+            "description": "Las promos están sujetas a disponibilidad del modelo/medida. Si no hay stock coordinamos fabricación (3-5 días extra).",
+            "title": "Sujeto a stock"
+          },
+          {
+            "description": "Todos los sorteos y premios requieren la factura a nombre del comprador para validar la participación.",
+            "title": "Factura obligatoria"
+          }
+        ],
+        "subtitle": "Aplicable a todas las promos salvo que la promo específica indique lo contrario.",
+        "title": "Condiciones generales"
       }
     },
     "quiz": {


### PR DESCRIPTION
## New features

**Home page**
- Rotating promo-banner at top: 3 active promos (20% OFF, Promo Mamá y Papá w/ expiry countdown, 18 cuotas permanente)
- Each promo gets a color, dismissible, auto-rotates

**New /promociones page**
- Hero + 6 active promos + 4 terms-and-conditions + contact CTA
- Linked from new 'Promos' nav item

**/financiacion page expanded**
- 3-tier cuota calculator (6 / 12 / 18 cuotas with real example monthly payments for 5 models)
- 12-bank grid — Itaú, Ueno, Continental, Familiar, Visión, Sudameris, Regional, Interfisa, GNB, Atlas, Solar, BNF
- 6 payment methods row — credit, debit, transfer, cash, Bancard POS, cheques

**Product card promo ribbon**
- `ProductItem` now supports `promoPercent`, `promoLabel`, `priceOriginal`
- Renders a corner ribbon in secondary color
- Crosses out the original price when a promo is active
- Wired on Titanium + Imperial (20% OFF promo)