### PR TITLE
feat(visual): SVG covers + PY map + illustration section + content wiring

### DIFF
--- a/sites/dayah-litworks/content/en.json
+++ b/sites/dayah-litworks/content/en.json
@@ -735,7 +735,15 @@
       ],
       "trustBadgesEnabled": false
     },
-    "trustBadgesEnabled": false
+    "trustBadgesEnabled": false,
+    "nda": {
+      "title": "NDA-protected work",
+      "subtitle": "I respect every project's confidentiality. Message me and I'll share real samples privately.",
+      "src": "/images/dayah/portfolio-nda.svg",
+      "alt": "Redacted sample of Dayah LitWorks portfolio",
+      "background": "surface",
+      "maxWidth": 1000
+    }
   },
   "blog": {
     "seo": {

--- a/sites/dayah-litworks/content/es.json
+++ b/sites/dayah-litworks/content/es.json
@@ -479,7 +479,7 @@
           "pricePYG": "₲250.000",
           "description": "Portada premade — Fantasía/Romance",
           "category": "Fantasía",
-          "imageUrl": "",
+          "imageUrl": "/images/dayah/covers/susurros-del-bosque.svg",
           "available": true,
           "format": "eBook",
           "includes": [
@@ -496,7 +496,7 @@
           "pricePYG": "₲250.000",
           "description": "Portada premade — Romance Oscuro",
           "category": "Romance",
-          "imageUrl": "",
+          "imageUrl": "/images/dayah/covers/corazon-de-cenizas.svg",
           "available": true,
           "format": "eBook",
           "includes": [
@@ -513,7 +513,7 @@
           "pricePYG": "₲250.000",
           "description": "Portada premade — Thriller/Suspenso",
           "category": "Thriller",
-          "imageUrl": "",
+          "imageUrl": "/images/dayah/covers/el-ultimo-codigo.svg",
           "available": true,
           "format": "eBook",
           "includes": [
@@ -530,7 +530,7 @@
           "pricePYG": "₲250.000",
           "description": "Portada premade — Ciencia Ficción",
           "category": "Ciencia Ficción",
-          "imageUrl": "",
+          "imageUrl": "/images/dayah/covers/galaxia-interior.svg",
           "available": true,
           "format": "eBook",
           "includes": [
@@ -547,7 +547,7 @@
           "pricePYG": "₲250.000",
           "description": "Portada premade — Terror/Horror",
           "category": "Terror",
-          "imageUrl": "",
+          "imageUrl": "/images/dayah/covers/sombras-en-el-espejo.svg",
           "available": true,
           "format": "eBook",
           "includes": [
@@ -564,7 +564,7 @@
           "pricePYG": "₲250.000",
           "description": "Portada premade — Fantasía Juvenil",
           "category": "Fantasía",
-          "imageUrl": "",
+          "imageUrl": "/images/dayah/covers/alas-de-cristal.svg",
           "available": true,
           "format": "eBook",
           "includes": [

--- a/sites/dayah-litworks/pages/portafolio.json
+++ b/sites/dayah-litworks/pages/portafolio.json
@@ -14,6 +14,11 @@
       "content": "portfolio.placeholder"
     },
     {
+      "id": "illustration",
+      "variant": "standard",
+      "content": "portfolio.nda"
+    },
+    {
       "id": "features",
       "variant": "three-col",
       "content": "portfolio.placeholder"

--- a/sites/superspuma/content/es.json
+++ b/sites/superspuma/content/es.json
@@ -968,7 +968,15 @@
         }
       ]
     },
-    "trustBadgesEnabled": false
+    "trustBadgesEnabled": false,
+    "map": {
+      "title": "7 tiendas + 6 centros logísticos en todo el país",
+      "subtitle": "Asunción y Central concentran los puntos propios. El resto del país llega vía centros logísticos.",
+      "src": "/images/ss/py-map.svg",
+      "alt": "Mapa de Paraguay con ubicación de tiendas Superspuma",
+      "background": "surface",
+      "maxWidth": 820
+    }
   },
   "guias": {
     "seo": {
@@ -1565,7 +1573,15 @@
         }
       ]
     },
-    "trustBadgesEnabled": false
+    "trustBadgesEnabled": false,
+    "map": {
+      "title": "Tres zonas de cobertura",
+      "subtitle": "Zona 1 gratis desde compras de Gs. 1.000.000. Zona 2 y 3 tienen costo fijo.",
+      "src": "/images/ss/py-map-zones.svg",
+      "alt": "Mapa de Paraguay con zonas de envío",
+      "background": "surface",
+      "maxWidth": 820
+    }
   },
   "financiacion": {
     "seo": {

--- a/sites/superspuma/pages/envios.json
+++ b/sites/superspuma/pages/envios.json
@@ -7,6 +7,7 @@
     { "id": "hero", "variant": "image", "content": "envios.hero" },
     { "id": "trust-badges", "variant": "strip", "content": "envios.trustBadges" },
     { "id": "programs-comparison", "variant": "tiered", "content": "envios.zones" },
+    { "id": "illustration", "variant": "standard", "content": "envios.map" },
     { "id": "process-timeline", "variant": "horizontal", "content": "envios.process" },
     { "id": "enhanced-faq", "variant": "searchable", "content": "envios.faq" },
     { "id": "contact", "variant": "split", "content": "home.contact" },

--- a/sites/superspuma/pages/tiendas.json
+++ b/sites/superspuma/pages/tiendas.json
@@ -5,6 +5,7 @@
   "sections": [
     { "id": "header", "variant": "standard", "content": "navigation" },
     { "id": "hero", "variant": "image", "content": "tiendas.hero" },
+    { "id": "illustration", "variant": "standard", "content": "tiendas.map" },
     { "id": "programs-comparison", "variant": "tiered", "content": "tiendas.stores" },
     { "id": "programs-comparison", "variant": "tiered", "content": "tiendas.logistics" },
     { "id": "trust-badges", "variant": "strip", "content": "home.trustBadges" },

--- a/src/verticals/portfolio-professional/vertical.json
+++ b/src/verticals/portfolio-professional/vertical.json
@@ -36,6 +36,7 @@
     "whatsapp-float",
     "product-catalog",
     "gallery",
+    "illustration",
     "photo-gallery",
     "instagram-feed",
     "pricing",

--- a/src/verticals/retail-local/vertical.json
+++ b/src/verticals/retail-local/vertical.json
@@ -19,6 +19,7 @@
     "product-grid",
     "services",
     "gallery",
+    "illustration",
     "testimonials",
     "faq",
     "business-hours",

--- a/web/components/sections/illustration-section.tsx
+++ b/web/components/sections/illustration-section.tsx
@@ -1,0 +1,68 @@
+import Image from 'next/image'
+import { Container } from '@/components/ui/container'
+import { Heading } from '@/components/ui/heading'
+
+export interface IllustrationSectionProps {
+  title?: string
+  subtitle?: string
+  src: string
+  alt: string
+  /** Max width in px. Defaults to 960 which fits most hero-adjacent diagrams. */
+  maxWidth?: number
+  /** 'background' (default) or 'surface' — lets the section blend with adjacent blocks. */
+  background?: 'background' | 'surface'
+  caption?: string
+}
+
+/**
+ * Single centred illustration / diagram / map. Built for cases where a
+ * gallery (grid of photos) is overkill but we still want one hero-sized
+ * visual in the page flow — Paraguay coverage map, process flow chart,
+ * factory floor plan, etc.
+ */
+export function IllustrationSection({
+  title,
+  subtitle,
+  src,
+  alt,
+  maxWidth = 960,
+  background = 'background',
+  caption,
+}: IllustrationSectionProps) {
+  if (!src) return null
+  const bg = background === 'surface' ? 'var(--surface)' : 'var(--background)'
+  return (
+    <section className="py-16 sm:py-20" style={{ backgroundColor: bg }}>
+      <Container>
+        {(title || subtitle) && (
+          <div className="mb-10 text-center">
+            {title && <Heading level={2}>{title}</Heading>}
+            {subtitle && (
+              <p className="mx-auto mt-3 max-w-2xl text-[var(--text-muted)]">{subtitle}</p>
+            )}
+          </div>
+        )}
+        <div className="mx-auto" style={{ maxWidth: `${maxWidth}px` }}>
+          <div className="relative w-full overflow-hidden rounded-2xl">
+            <Image
+              src={src}
+              alt={alt}
+              width={maxWidth}
+              height={Math.round(maxWidth * 1.125)}
+              className="h-auto w-full"
+              // SVGs don't benefit from next/image optimizer and triggering it
+              // on local /public SVGs causes unnecessary work.
+              unoptimized={src.endsWith('.svg') || src.startsWith('data:')}
+              priority={false}
+            />
+          </div>
+          {caption && (
+            <p className="mt-3 text-center text-sm italic text-[var(--text-muted)]">{caption}</p>
+          )}
+        </div>
+      </Container>
+    </section>
+  )
+}
+
+export default IllustrationSection

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -6110,6 +6110,11 @@ export const PAGES: Record<string, JsonRecord> = {
         "variant": "minimal"
       },
       {
+        "content": "portfolio.nda",
+        "id": "illustration",
+        "variant": "standard"
+      },
+      {
         "content": "portfolio.placeholder",
         "id": "features",
         "variant": "three-col"
@@ -13159,6 +13164,11 @@ export const PAGES: Record<string, JsonRecord> = {
         "variant": "tiered"
       },
       {
+        "content": "envios.map",
+        "id": "illustration",
+        "variant": "standard"
+      },
+      {
         "content": "envios.process",
         "id": "process-timeline",
         "variant": "horizontal"
@@ -15029,6 +15039,11 @@ export const PAGES: Record<string, JsonRecord> = {
         "variant": "image"
       },
       {
+        "content": "tiendas.map",
+        "id": "illustration",
+        "variant": "standard"
+      },
+      {
         "content": "tiendas.stores",
         "id": "programs-comparison",
         "variant": "tiered"
@@ -15872,6 +15887,14 @@ export const CONTENT: Record<string, JsonRecord> = {
         "Horror"
       ],
       "items": [],
+      "nda": {
+        "alt": "Redacted sample of Dayah LitWorks portfolio",
+        "background": "surface",
+        "maxWidth": 1000,
+        "src": "/images/dayah/portfolio-nda.svg",
+        "subtitle": "I respect every project's confidentiality. Message me and I'll share real samples privately.",
+        "title": "NDA-protected work"
+      },
       "placeholder": {
         "features": [
           {
@@ -16600,7 +16623,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Susurros%20del%20Bosque'",
             "description": "Portada premade — Fantasía/Romance",
             "format": "eBook",
-            "imageUrl": "",
+            "imageUrl": "/images/dayah/covers/susurros-del-bosque.svg",
             "includes": [
               "Portada eBook (JPG/PDF)",
               "Título PNG + Portadilla PNG",
@@ -16617,7 +16640,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Coraz%C3%B3n%20de%20Cenizas'",
             "description": "Portada premade — Romance Oscuro",
             "format": "eBook",
-            "imageUrl": "",
+            "imageUrl": "/images/dayah/covers/corazon-de-cenizas.svg",
             "includes": [
               "Portada eBook (JPG/PDF)",
               "Título PNG + Portadilla PNG",
@@ -16634,7 +16657,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'El%20%C3%9Altimo%20C%C3%B3digo'",
             "description": "Portada premade — Thriller/Suspenso",
             "format": "eBook",
-            "imageUrl": "",
+            "imageUrl": "/images/dayah/covers/el-ultimo-codigo.svg",
             "includes": [
               "Portada eBook (JPG/PDF)",
               "Título PNG + Portadilla PNG",
@@ -16651,7 +16674,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Galaxia%20Interior'",
             "description": "Portada premade — Ciencia Ficción",
             "format": "eBook",
-            "imageUrl": "",
+            "imageUrl": "/images/dayah/covers/galaxia-interior.svg",
             "includes": [
               "Portada eBook (JPG/PDF)",
               "Título PNG + Portadilla PNG",
@@ -16668,7 +16691,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Sombras%20en%20el%20Espejo'",
             "description": "Portada premade — Terror/Horror",
             "format": "eBook",
-            "imageUrl": "",
+            "imageUrl": "/images/dayah/covers/sombras-en-el-espejo.svg",
             "includes": [
               "Portada eBook (JPG/PDF)",
               "Título PNG + Portadilla PNG",
@@ -16685,7 +16708,7 @@ export const CONTENT: Record<string, JsonRecord> = {
             "ctaHref": "https://wa.me/595986868241?text=Hola!%20Me%20interesa%20la%20portada%20premade%20'Alas%20de%20Cristal'",
             "description": "Portada premade — Fantasía Juvenil",
             "format": "eBook",
-            "imageUrl": "",
+            "imageUrl": "/images/dayah/covers/alas-de-cristal.svg",
             "includes": [
               "Portada eBook (JPG/PDF)",
               "Título PNG + Portadilla PNG",
@@ -37218,6 +37241,14 @@ export const CONTENT: Record<string, JsonRecord> = {
         "subheadline": "Desde Villeta despachamos a Asunción, Central, Interior y Chaco. Coordinamos día, hora e instalación — vos solo elegí el colchón.",
         "trustBadgesEnabled": false
       },
+      "map": {
+        "alt": "Mapa de Paraguay con zonas de envío",
+        "background": "surface",
+        "maxWidth": 820,
+        "src": "/images/ss/py-map-zones.svg",
+        "subtitle": "Zona 1 gratis desde compras de Gs. 1.000.000. Zona 2 y 3 tienen costo fijo.",
+        "title": "Tres zonas de cobertura"
+      },
       "process": {
         "eyebrow": "Cómo funciona",
         "steps": [
@@ -42172,6 +42203,14 @@ export const CONTENT: Record<string, JsonRecord> = {
         ],
         "title": "Centros logísticos en el interior"
       },
+      "map": {
+        "alt": "Mapa de Paraguay con ubicación de tiendas Superspuma",
+        "background": "surface",
+        "maxWidth": 820,
+        "src": "/images/ss/py-map.svg",
+        "subtitle": "Asunción y Central concentran los puntos propios. El resto del país llega vía centros logísticos.",
+        "title": "7 tiendas + 6 centros logísticos en todo el país"
+      },
       "seo": {
         "description": "Red propia en Paraguay: 7 tiendas en Asunción y Central (Villamorra Shopping, Paseo La Galería, Fuente Shopping, Lillo, Fernando de la Mora, Luisito en Ñemby y el outlet Saldos Mariano) más 6 centros logísticos en el interior.",
         "title": "Tiendas Superspuma — 5 sucursales en Asunción y Central"
@@ -44170,6 +44209,7 @@ export const VERTICALS: Record<string, JsonRecord> = {
       "whatsapp-float",
       "product-catalog",
       "gallery",
+      "illustration",
       "photo-gallery",
       "instagram-feed",
       "pricing",
@@ -44263,6 +44303,7 @@ export const VERTICALS: Record<string, JsonRecord> = {
       "product-grid",
       "services",
       "gallery",
+      "illustration",
       "testimonials",
       "faq",
       "business-hours",

--- a/web/lib/engine/renderer.tsx
+++ b/web/lib/engine/renderer.tsx
@@ -23,6 +23,7 @@ import { QuoteFormSection } from '@/components/sections/quote-form-section'
 import { EmergencyIndicatorSection } from '@/components/sections/emergency-indicator-section'
 import { ProductCatalogSection } from '@/components/sections/product-catalog-section'
 import { GallerySection } from '@/components/sections/gallery-section'
+import { IllustrationSection } from '@/components/sections/illustration-section'
 import { TeamSection } from '@/components/sections/team-section'
 import { TestimonialsSection } from '@/components/sections/testimonials-section'
 import { ContactSection } from '@/components/sections/contact-section'
@@ -90,6 +91,7 @@ const SECTION_COMPONENTS: Record<string, React.ComponentType<any>> = {
   'emergency-indicator': EmergencyIndicatorSection,
   'product-catalog': ProductCatalogSection,
   gallery: GallerySection,
+  illustration: IllustrationSection,
   team: TeamSection,
   testimonials: TestimonialsSection,
   contact: ContactSection,

--- a/web/lib/engine/section-registry.ts
+++ b/web/lib/engine/section-registry.ts
@@ -125,6 +125,12 @@ export const SECTION_CATALOG: Record<string, SectionManifest> = {
     defaultVariant: 'grid',
     variants: ['grid', 'masonry'],
   },
+  illustration: {
+    id: 'illustration',
+    defaultVariant: 'standard',
+    variants: ['standard'],
+    requiredContentFields: ['src'],
+  },
   team: {
     id: 'team',
     defaultVariant: 'cards',

--- a/web/lib/engine/site-renderer.tsx
+++ b/web/lib/engine/site-renderer.tsx
@@ -17,6 +17,7 @@ import { CommerceCatalogSection } from '@/components/sections/commerce-catalog-s
 import { AgeGateSection } from '@/components/sections/age-gate-section'
 import { TrustBadgesSection } from '@/components/sections/trust-badges-section'
 import { GallerySection } from '@/components/sections/gallery-section'
+import { IllustrationSection } from '@/components/sections/illustration-section'
 import { TeamSection } from '@/components/sections/team-section'
 import { TestimonialsSection } from '@/components/sections/testimonials-section'
 import { ContactSection } from '@/components/sections/contact-section'
@@ -89,6 +90,7 @@ export const COMPONENTS: Record<string, React.ComponentType<any>> = {
   'age-gate': AgeGateSection,
   'trust-badges': TrustBadgesSection,
   gallery: GallerySection,
+  illustration: IllustrationSection,
   team: TeamSection,
   testimonials: TestimonialsSection,
   contact: ContactSection,

--- a/web/public/images/dayah/covers/alas-de-cristal.svg
+++ b/web/public/images/dayah/covers/alas-de-cristal.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 900" role="img" aria-label="Alas de Cristal — Portada">
+  <defs>
+    <linearGradient id="ac-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0a1e3a"/>
+      <stop offset="0.55" stop-color="#3a5b8a"/>
+      <stop offset="1" stop-color="#e8d5a3"/>
+    </linearGradient>
+    <linearGradient id="ac-wing" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.9"/>
+      <stop offset="0.5" stop-color="#ffcce8" stop-opacity="0.7"/>
+      <stop offset="1" stop-color="#9bd1ff" stop-opacity="0.8"/>
+    </linearGradient>
+    <linearGradient id="ac-gold" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#b08532"/>
+      <stop offset="0.5" stop-color="#efd07f"/>
+      <stop offset="1" stop-color="#8c6722"/>
+    </linearGradient>
+    <filter id="ac-glow"><feGaussianBlur stdDeviation="6"/></filter>
+  </defs>
+  <rect width="600" height="900" fill="url(#ac-bg)"/>
+
+  <!-- mist over lake -->
+  <ellipse cx="300" cy="780" rx="400" ry="60" fill="#ffffff" opacity="0.35"/>
+  <!-- sun -->
+  <circle cx="300" cy="660" r="80" fill="#fff2c8" opacity="0.9" filter="url(#ac-glow)"/>
+  <circle cx="300" cy="660" r="45" fill="#fff8e0"/>
+
+  <!-- crystalline wings -->
+  <g transform="translate(300,500)" fill="url(#ac-wing)" filter="url(#ac-glow)">
+    <path d="M 0 0 L -120 -30 L -180 -120 L -220 -60 L -160 40 L -60 30 Z" opacity="0.9"/>
+    <path d="M 0 0 L 120 -30 L 180 -120 L 220 -60 L 160 40 L 60 30 Z" opacity="0.9"/>
+  </g>
+  <g transform="translate(300,500)" fill="none" stroke="#ffffff" stroke-width="0.8" opacity="0.7">
+    <!-- left facets -->
+    <line x1="0" y1="0" x2="-120" y2="-30"/>
+    <line x1="-120" y1="-30" x2="-180" y2="-120"/>
+    <line x1="-180" y1="-120" x2="-220" y2="-60"/>
+    <line x1="-220" y1="-60" x2="-160" y2="40"/>
+    <line x1="-160" y1="40" x2="-60" y2="30"/>
+    <line x1="-120" y1="-30" x2="-160" y2="40"/>
+    <!-- right -->
+    <line x1="0" y1="0" x2="120" y2="-30"/>
+    <line x1="120" y1="-30" x2="180" y2="-120"/>
+    <line x1="180" y1="-120" x2="220" y2="-60"/>
+    <line x1="220" y1="-60" x2="160" y2="40"/>
+    <line x1="160" y1="40" x2="60" y2="30"/>
+    <line x1="120" y1="-30" x2="160" y2="40"/>
+  </g>
+
+  <!-- prism rays -->
+  <g stroke-width="2" opacity="0.45" fill="none">
+    <line x1="300" y1="500" x2="80" y2="300" stroke="#ff6b9e"/>
+    <line x1="300" y1="500" x2="140" y2="220" stroke="#ffcc66"/>
+    <line x1="300" y1="500" x2="240" y2="160" stroke="#9bd1ff"/>
+    <line x1="300" y1="500" x2="360" y2="160" stroke="#ff9b6b"/>
+    <line x1="300" y1="500" x2="460" y2="220" stroke="#a8ff9b"/>
+    <line x1="300" y1="500" x2="520" y2="300" stroke="#d9b3ff"/>
+  </g>
+
+  <!-- title -->
+  <g font-family="Playfair Display, Georgia, serif" text-anchor="middle">
+    <text x="300" y="160" font-size="42" font-weight="700" fill="url(#ac-gold)" letter-spacing="3">ALAS DE</text>
+    <text x="300" y="205" font-size="28" fill="#fff" letter-spacing="8" opacity="0.92">CRISTAL</text>
+  </g>
+  <line x1="210" y1="830" x2="390" y2="830" stroke="#d4b676" stroke-width="0.8" opacity="0.6"/>
+  <text x="300" y="860" font-family="Inter, sans-serif" font-size="10" fill="#7a6544" text-anchor="middle" letter-spacing="4">DAYAH · FANTASÍA JUVENIL</text>
+</svg>

--- a/web/public/images/dayah/covers/corazon-de-cenizas.svg
+++ b/web/public/images/dayah/covers/corazon-de-cenizas.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 900" role="img" aria-label="Corazón de Cenizas — Portada">
+  <defs>
+    <linearGradient id="cc-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1a0608"/>
+      <stop offset="0.6" stop-color="#4a0f14"/>
+      <stop offset="1" stop-color="#0a0203"/>
+    </linearGradient>
+    <radialGradient id="cc-glow" cx="0.5" cy="0.55" r="0.5">
+      <stop offset="0" stop-color="#ff4a5c" stop-opacity="0.45"/>
+      <stop offset="1" stop-color="#ff4a5c" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="cc-gold" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#c2974a"/>
+      <stop offset="0.5" stop-color="#f7dc8a"/>
+      <stop offset="1" stop-color="#8a6522"/>
+    </linearGradient>
+    <filter id="cc-grain"><feTurbulence baseFrequency="0.85" numOctaves="2" seed="7"/><feColorMatrix values="0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.06 0"/><feComposite in2="SourceGraphic" operator="in"/></filter>
+  </defs>
+  <rect width="600" height="900" fill="url(#cc-bg)"/>
+  <!-- ash drift -->
+  <g fill="#6a6a6a" opacity="0.25">
+    <circle cx="80" cy="100" r="1.5"/><circle cx="150" cy="180" r="1"/><circle cx="220" cy="70" r="1.2"/>
+    <circle cx="380" cy="140" r="1.4"/><circle cx="500" cy="200" r="1.1"/><circle cx="120" cy="320" r="1"/>
+    <circle cx="530" cy="380" r="1.3"/><circle cx="90" cy="500" r="1"/><circle cx="480" cy="560" r="1.2"/>
+    <circle cx="200" cy="620" r="1.1"/><circle cx="340" cy="720" r="1"/><circle cx="510" cy="780" r="1.3"/>
+  </g>
+  <!-- glow -->
+  <circle cx="300" cy="500" r="220" fill="url(#cc-glow)"/>
+  <!-- burning page -->
+  <g fill="#f0e6d2" opacity="0.78">
+    <path d="M230 400 L380 400 L390 620 L220 620 Z"/>
+  </g>
+  <g fill="none" stroke="#7a5a3a" stroke-width="0.6" opacity="0.6">
+    <line x1="245" y1="430" x2="365" y2="430"/><line x1="245" y1="450" x2="370" y2="450"/>
+    <line x1="245" y1="470" x2="360" y2="470"/><line x1="245" y1="490" x2="368" y2="490"/>
+    <line x1="245" y1="510" x2="355" y2="510"/><line x1="245" y1="530" x2="365" y2="530"/>
+  </g>
+  <!-- burn edge -->
+  <path d="M220 620 Q 240 600 270 615 Q 310 585 350 610 Q 380 590 390 620 Z" fill="#1a0608"/>
+  <path d="M220 620 Q 240 600 270 615 Q 310 585 350 610 Q 380 590 390 620 Q 370 640 330 625 Q 290 650 240 635 Z" fill="#c0392b" opacity="0.7"/>
+  <!-- wilting rose -->
+  <g transform="translate(290,460)" fill="#7a1820">
+    <circle cx="0" cy="0" r="22"/>
+    <path d="M-18,-6 Q-6,-22 6,-10 Q 18,-22 22,-4 Q 28,8 14,16 Q 0,28 -14,16 Q -24,8 -18,-6 Z" fill="#4a0810"/>
+    <path d="M-4,20 L0,60 L4,20" stroke="#2a0a0a" stroke-width="1.5" fill="none"/>
+  </g>
+  <!-- blood drop -->
+  <path d="M 300 590 Q 294 600 294 606 A 6 6 0 0 0 306 606 Q 306 600 300 590 Z" fill="#9b1b1b"/>
+  <!-- grain -->
+  <rect width="600" height="900" filter="url(#cc-grain)" opacity="0.4"/>
+  <!-- title -->
+  <g font-family="Playfair Display, Georgia, serif" text-anchor="middle">
+    <text x="300" y="180" font-size="42" font-weight="700" fill="url(#cc-gold)" letter-spacing="3">CORAZÓN</text>
+    <text x="300" y="225" font-size="20" fill="#d4b676" letter-spacing="6">DE CENIZAS</text>
+  </g>
+  <line x1="210" y1="830" x2="390" y2="830" stroke="#d4b676" stroke-width="0.8" opacity="0.6"/>
+  <text x="300" y="860" font-family="Inter, sans-serif" font-size="10" fill="#a39472" text-anchor="middle" letter-spacing="4">DAYAH · ROMANCE OSCURO</text>
+</svg>

--- a/web/public/images/dayah/covers/el-ultimo-codigo.svg
+++ b/web/public/images/dayah/covers/el-ultimo-codigo.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 900" role="img" aria-label="El Último Código — Portada">
+  <defs>
+    <linearGradient id="ec-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#05060c"/>
+      <stop offset="0.5" stop-color="#0b1126"/>
+      <stop offset="1" stop-color="#020308"/>
+    </linearGradient>
+    <linearGradient id="ec-gold" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#b08532"/>
+      <stop offset="0.5" stop-color="#efd07f"/>
+      <stop offset="1" stop-color="#8c6722"/>
+    </linearGradient>
+    <filter id="ec-glow"><feGaussianBlur stdDeviation="3"/></filter>
+  </defs>
+  <rect width="600" height="900" fill="url(#ec-bg)"/>
+  <!-- neon-rain glyphs -->
+  <g font-family="Courier New, monospace" font-size="14" fill="#b91c1c" opacity="0.35">
+    <text x="50" y="400">01</text><text x="80" y="420">11</text><text x="110" y="460">0</text>
+    <text x="60" y="480">10</text><text x="100" y="510">101</text><text x="140" y="540">1</text>
+    <text x="170" y="580">0</text><text x="80" y="610">11</text><text x="140" y="650">1</text>
+    <text x="180" y="680">010</text><text x="220" y="710">0</text><text x="100" y="720">11</text>
+    <text x="440" y="420">01</text><text x="470" y="450">1</text><text x="420" y="480">110</text>
+    <text x="480" y="510">0</text><text x="450" y="540">1</text><text x="500" y="570">11</text>
+    <text x="440" y="600">01</text><text x="480" y="630">1</text><text x="430" y="660">01</text>
+    <text x="490" y="700">0</text><text x="450" y="730">11</text><text x="510" y="760">0</text>
+  </g>
+  <!-- alley silhouette -->
+  <g fill="#0b1126">
+    <polygon points="0,900 0,620 180,520 180,900"/>
+    <polygon points="600,900 600,580 420,500 420,900"/>
+  </g>
+  <!-- wet reflection -->
+  <rect x="180" y="860" width="240" height="40" fill="#1a1f3a" opacity="0.6"/>
+  <!-- neon red glyph -->
+  <g font-family="Courier New, monospace" font-size="90" font-weight="700" fill="#e11d48" filter="url(#ec-glow)">
+    <text x="300" y="620" text-anchor="middle" opacity="0.85">⟨/⟩</text>
+  </g>
+  <g font-family="Courier New, monospace" font-size="90" font-weight="700" fill="#fda4af">
+    <text x="300" y="620" text-anchor="middle">⟨/⟩</text>
+  </g>
+  <!-- title -->
+  <g font-family="Playfair Display, Georgia, serif" text-anchor="middle">
+    <text x="300" y="180" font-size="42" font-weight="700" fill="url(#ec-gold)" letter-spacing="3">EL ÚLTIMO</text>
+    <text x="300" y="225" font-size="30" fill="#efd07f" letter-spacing="6">CÓDIGO</text>
+  </g>
+  <line x1="210" y1="830" x2="390" y2="830" stroke="#d4b676" stroke-width="0.8" opacity="0.6"/>
+  <text x="300" y="860" font-family="Inter, sans-serif" font-size="10" fill="#a39472" text-anchor="middle" letter-spacing="4">DAYAH · THRILLER</text>
+</svg>

--- a/web/public/images/dayah/covers/galaxia-interior.svg
+++ b/web/public/images/dayah/covers/galaxia-interior.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 900" role="img" aria-label="Galaxia Interior — Portada">
+  <defs>
+    <radialGradient id="gi-bg" cx="0.5" cy="0.55" r="0.7">
+      <stop offset="0" stop-color="#3a1e6b"/>
+      <stop offset="0.5" stop-color="#120a2e"/>
+      <stop offset="1" stop-color="#050214"/>
+    </radialGradient>
+    <radialGradient id="gi-nebula" cx="0.5" cy="0.55" r="0.45">
+      <stop offset="0" stop-color="#ffcc66" stop-opacity="0.5"/>
+      <stop offset="0.5" stop-color="#d946ef" stop-opacity="0.3"/>
+      <stop offset="1" stop-color="#d946ef" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="gi-gold" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#b08532"/>
+      <stop offset="0.5" stop-color="#efd07f"/>
+      <stop offset="1" stop-color="#8c6722"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="900" fill="url(#gi-bg)"/>
+  <!-- stars -->
+  <g fill="#f5e6c8" opacity="0.7">
+    <circle cx="40" cy="80" r="0.8"/><circle cx="120" cy="150" r="1.1"/><circle cx="250" cy="60" r="0.6"/>
+    <circle cx="380" cy="110" r="0.9"/><circle cx="520" cy="70" r="1.2"/><circle cx="90" cy="280" r="0.7"/>
+    <circle cx="180" cy="340" r="1"/><circle cx="440" cy="260" r="0.8"/><circle cx="550" cy="330" r="1"/>
+    <circle cx="70" cy="480" r="0.6"/><circle cx="520" cy="510" r="0.9"/><circle cx="110" cy="640" r="0.7"/>
+    <circle cx="440" cy="680" r="1"/><circle cx="60" cy="770" r="0.8"/><circle cx="540" cy="810" r="1.1"/>
+    <circle cx="300" cy="400" r="0.6"/><circle cx="410" cy="440" r="0.8"/><circle cx="200" cy="460" r="0.7"/>
+  </g>
+  <!-- nebula -->
+  <ellipse cx="300" cy="520" rx="260" ry="180" fill="url(#gi-nebula)"/>
+  <!-- astronaut silhouette dissolving -->
+  <g fill="#0a0618" opacity="0.9">
+    <ellipse cx="300" cy="440" rx="34" ry="40"/><!-- helmet -->
+    <rect x="266" y="480" width="68" height="120" rx="18"/><!-- torso -->
+    <rect x="238" y="510" width="30" height="70" rx="10"/><!-- arm -->
+    <rect x="332" y="510" width="30" height="70" rx="10"/><!-- arm -->
+  </g>
+  <!-- helmet visor gold reflection -->
+  <path d="M286 425 Q300 410 314 425 Q320 440 305 452 Q290 455 282 444 Z" fill="url(#gi-gold)" opacity="0.9"/>
+  <!-- dissolving particles -->
+  <g fill="#ffcc66" opacity="0.7">
+    <circle cx="260" cy="600" r="1.5"/><circle cx="280" cy="640" r="2"/><circle cx="300" cy="680" r="1.4"/>
+    <circle cx="320" cy="630" r="1.8"/><circle cx="340" cy="670" r="1.2"/><circle cx="250" cy="650" r="1"/>
+    <circle cx="360" cy="700" r="1.6"/>
+  </g>
+  <g fill="#d946ef" opacity="0.6">
+    <circle cx="230" cy="580" r="1.2"/><circle cx="270" cy="720" r="1.4"/><circle cx="350" cy="740" r="1.1"/>
+    <circle cx="380" cy="680" r="1.3"/>
+  </g>
+  <!-- title -->
+  <g font-family="Playfair Display, Georgia, serif" text-anchor="middle">
+    <text x="300" y="160" font-size="42" font-weight="700" fill="url(#gi-gold)" letter-spacing="3">GALAXIA</text>
+    <text x="300" y="205" font-size="24" fill="#efd07f" letter-spacing="8">INTERIOR</text>
+  </g>
+  <line x1="210" y1="830" x2="390" y2="830" stroke="#d4b676" stroke-width="0.8" opacity="0.6"/>
+  <text x="300" y="860" font-family="Inter, sans-serif" font-size="10" fill="#a39472" text-anchor="middle" letter-spacing="4">DAYAH · CIENCIA FICCIÓN</text>
+</svg>

--- a/web/public/images/dayah/covers/sombras-en-el-espejo.svg
+++ b/web/public/images/dayah/covers/sombras-en-el-espejo.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 900" role="img" aria-label="Sombras en el Espejo — Portada">
+  <defs>
+    <linearGradient id="se-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0a0a14"/>
+      <stop offset="1" stop-color="#151520"/>
+    </linearGradient>
+    <linearGradient id="se-gold" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#b08532"/>
+      <stop offset="0.5" stop-color="#efd07f"/>
+      <stop offset="1" stop-color="#8c6722"/>
+    </linearGradient>
+    <radialGradient id="se-mirror" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#5a5a6a"/>
+      <stop offset="0.7" stop-color="#1a1a25"/>
+      <stop offset="1" stop-color="#0a0a14"/>
+    </radialGradient>
+  </defs>
+  <rect width="600" height="900" fill="url(#se-bg)"/>
+
+  <!-- mirror frame -->
+  <ellipse cx="300" cy="540" rx="170" ry="230" fill="none" stroke="url(#se-gold)" stroke-width="10"/>
+  <ellipse cx="300" cy="540" rx="158" ry="218" fill="url(#se-mirror)"/>
+  <!-- crack -->
+  <g stroke="#0a0a14" stroke-width="2.5" fill="none">
+    <path d="M250 420 L270 480 L255 540 L285 610 L265 690"/>
+    <path d="M270 480 L310 500 M270 480 L240 510 M285 610 L325 620 M285 610 L245 625"/>
+  </g>
+
+  <!-- face 1 left -->
+  <g fill="#d8cdb4" opacity="0.85">
+    <ellipse cx="250" cy="500" rx="32" ry="42"/>
+    <circle cx="240" cy="495" r="3" fill="#1a1020"/>
+    <circle cx="260" cy="495" r="3" fill="#1a1020"/>
+    <path d="M240 515 Q250 520 260 515" stroke="#3a2028" stroke-width="1.3" fill="none"/>
+  </g>
+  <!-- face 2 right, distorted -->
+  <g fill="#8a6a55" opacity="0.9">
+    <ellipse cx="340" cy="580" rx="32" ry="42"/>
+    <circle cx="330" cy="575" r="3" fill="#f0d080"/><!-- eerie eye -->
+    <circle cx="350" cy="575" r="3" fill="#f0d080"/>
+    <path d="M330 600 Q340 593 350 600" stroke="#3a2028" stroke-width="1.3" fill="none"/>
+  </g>
+
+  <!-- title -->
+  <g font-family="Playfair Display, Georgia, serif" text-anchor="middle">
+    <text x="300" y="160" font-size="36" font-weight="700" fill="url(#se-gold)" letter-spacing="3">SOMBRAS EN</text>
+    <text x="300" y="205" font-size="26" fill="#efd07f" letter-spacing="8">EL ESPEJO</text>
+  </g>
+  <line x1="210" y1="830" x2="390" y2="830" stroke="#d4b676" stroke-width="0.8" opacity="0.6"/>
+  <text x="300" y="860" font-family="Inter, sans-serif" font-size="10" fill="#a39472" text-anchor="middle" letter-spacing="4">DAYAH · TERROR PSICOLÓGICO</text>
+</svg>

--- a/web/public/images/dayah/covers/susurros-del-bosque.svg
+++ b/web/public/images/dayah/covers/susurros-del-bosque.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 900" role="img" aria-label="Susurros del Bosque — Portada de libro">
+  <defs>
+    <linearGradient id="sb-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0c1724"/>
+      <stop offset="0.6" stop-color="#162942"/>
+      <stop offset="1" stop-color="#0a1120"/>
+    </linearGradient>
+    <radialGradient id="sb-moon" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#f5e6c8" stop-opacity="1"/>
+      <stop offset="0.7" stop-color="#d4b676" stop-opacity="0.6"/>
+      <stop offset="1" stop-color="#d4b676" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="sb-gold" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#b08532"/>
+      <stop offset="0.5" stop-color="#efd07f"/>
+      <stop offset="1" stop-color="#8c6722"/>
+    </linearGradient>
+    <filter id="sb-grain"><feTurbulence baseFrequency="0.9" numOctaves="2" seed="3"/><feColorMatrix values="0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.05 0"/><feComposite in2="SourceGraphic" operator="in"/></filter>
+  </defs>
+  <rect width="600" height="900" fill="url(#sb-bg)"/>
+  <!-- mist layers -->
+  <ellipse cx="300" cy="700" rx="320" ry="80" fill="#5b6b84" opacity="0.25"/>
+  <ellipse cx="300" cy="760" rx="360" ry="60" fill="#8aa0bf" opacity="0.2"/>
+  <!-- moon -->
+  <circle cx="300" cy="260" r="120" fill="url(#sb-moon)"/>
+  <!-- trees silhouettes (simplified pines) -->
+  <g fill="#050910">
+    <polygon points="30,900 80,500 130,900"/>
+    <polygon points="100,900 150,550 200,900"/>
+    <polygon points="180,900 230,480 280,900"/>
+    <polygon points="260,900 320,430 380,900"/>
+    <polygon points="360,900 420,470 480,900"/>
+    <polygon points="450,900 500,520 550,900"/>
+    <polygon points="520,900 570,550 620,900"/>
+  </g>
+  <!-- cloaked figure -->
+  <g fill="#030608">
+    <path d="M300 610 Q280 570 290 540 Q295 510 310 510 Q325 510 330 540 Q340 570 320 610 L340 760 L280 760 Z"/>
+    <path d="M280 760 L260 900 L360 900 L340 760 Z"/>
+  </g>
+  <!-- grain -->
+  <rect width="600" height="900" filter="url(#sb-grain)" opacity="0.4"/>
+  <!-- title -->
+  <g font-family="Playfair Display, Georgia, serif" text-anchor="middle">
+    <text x="300" y="180" font-size="44" font-weight="700" fill="url(#sb-gold)" letter-spacing="4">SUSURROS</text>
+    <text x="300" y="220" font-size="20" fill="#d4b676" letter-spacing="6">DEL BOSQUE</text>
+  </g>
+  <!-- divider -->
+  <line x1="210" y1="830" x2="390" y2="830" stroke="#d4b676" stroke-width="0.8" opacity="0.6"/>
+  <text x="300" y="860" font-family="Inter, sans-serif" font-size="10" fill="#a39472" text-anchor="middle" letter-spacing="4">DAYAH · FANTASÍA</text>
+</svg>

--- a/web/public/images/dayah/portfolio-nda.svg
+++ b/web/public/images/dayah/portfolio-nda.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" role="img" aria-label="Portafolio bajo NDA — vista previa de portadas con títulos redactados">
+  <defs>
+    <linearGradient id="nda-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0a0f1c"/>
+      <stop offset="1" stop-color="#14192b"/>
+    </linearGradient>
+    <!-- 9 mini-cover gradients -->
+    <linearGradient id="g1" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1f2a48"/><stop offset="1" stop-color="#0a1020"/></linearGradient>
+    <linearGradient id="g2" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#4a1218"/><stop offset="1" stop-color="#1a0408"/></linearGradient>
+    <linearGradient id="g3" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#2d1840"/><stop offset="1" stop-color="#0f0620"/></linearGradient>
+    <linearGradient id="g4" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#0f2a35"/><stop offset="1" stop-color="#041018"/></linearGradient>
+    <linearGradient id="g5" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3d2415"/><stop offset="1" stop-color="#1a0e08"/></linearGradient>
+    <linearGradient id="g6" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1a2e2a"/><stop offset="1" stop-color="#051412"/></linearGradient>
+    <linearGradient id="g7" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#502a18"/><stop offset="1" stop-color="#1c0c05"/></linearGradient>
+    <linearGradient id="g8" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1b2a4a"/><stop offset="1" stop-color="#081022"/></linearGradient>
+    <linearGradient id="g9" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3a1a3a"/><stop offset="1" stop-color="#15081a"/></linearGradient>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#9a7228"/><stop offset="0.5" stop-color="#e3c468"/><stop offset="1" stop-color="#7e5e20"/></linearGradient>
+  </defs>
+  <rect width="1200" height="900" fill="url(#nda-bg)"/>
+
+  <!-- decorative grid bg -->
+  <g stroke="#1d2540" stroke-width="0.5" opacity="0.4">
+    <line x1="0" y1="225" x2="1200" y2="225"/>
+    <line x1="0" y1="450" x2="1200" y2="450"/>
+    <line x1="0" y1="675" x2="1200" y2="675"/>
+    <line x1="300" y1="0" x2="300" y2="900"/>
+    <line x1="600" y1="0" x2="600" y2="900"/>
+    <line x1="900" y1="0" x2="900" y2="900"/>
+  </g>
+
+  <!-- 9 cover tiles with redaction bars -->
+  <g font-family="Playfair Display, Georgia, serif">
+    <!-- row 1 -->
+    <g transform="translate(40,40)">
+      <rect width="240" height="340" rx="6" fill="url(#g1)" stroke="#2a3452" stroke-width="1"/>
+      <circle cx="120" cy="130" r="50" fill="#2d3f6a" opacity="0.6"/>
+      <rect x="40" y="240" width="160" height="12" fill="#6b5e38" opacity="0.9"/>
+      <rect x="60" y="264" width="120" height="8" fill="#4a4028" opacity="0.7"/>
+    </g>
+    <g transform="translate(320,40)">
+      <rect width="240" height="340" rx="6" fill="url(#g2)" stroke="#542028" stroke-width="1"/>
+      <path d="M80 120 Q 120 80 160 120 Q 200 180 120 240 Q 40 180 80 120 Z" fill="#3a0a12" opacity="0.8"/>
+      <rect x="40" y="250" width="160" height="12" fill="#6b5e38" opacity="0.9"/>
+      <rect x="60" y="274" width="120" height="8" fill="#4a4028" opacity="0.7"/>
+    </g>
+    <g transform="translate(600,40)">
+      <rect width="240" height="340" rx="6" fill="url(#g3)" stroke="#3a204a" stroke-width="1"/>
+      <rect x="90" y="90" width="60" height="160" fill="#281638" opacity="0.8"/>
+      <circle cx="120" cy="160" r="18" fill="#c9a2d8" opacity="0.7"/>
+      <rect x="40" y="260" width="160" height="12" fill="#6b5e38" opacity="0.9"/>
+      <rect x="60" y="284" width="120" height="8" fill="#4a4028" opacity="0.7"/>
+    </g>
+    <g transform="translate(880,40)">
+      <rect width="240" height="340" rx="6" fill="url(#g4)" stroke="#153540" stroke-width="1"/>
+      <polygon points="40,240 80,140 120,180 170,100 210,240" fill="#0a1820" opacity="0.8"/>
+      <rect x="40" y="250" width="160" height="12" fill="#6b5e38" opacity="0.9"/>
+      <rect x="60" y="274" width="120" height="8" fill="#4a4028" opacity="0.7"/>
+    </g>
+    <!-- row 2 -->
+    <g transform="translate(40,420)">
+      <rect width="240" height="340" rx="6" fill="url(#g5)" stroke="#503220" stroke-width="1"/>
+      <circle cx="120" cy="140" r="60" fill="#6a3820" opacity="0.7"/>
+      <rect x="40" y="250" width="160" height="12" fill="#6b5e38" opacity="0.9"/>
+      <rect x="60" y="274" width="120" height="8" fill="#4a4028" opacity="0.7"/>
+    </g>
+    <g transform="translate(320,420)">
+      <rect width="240" height="340" rx="6" fill="url(#g6)" stroke="#1f3a35" stroke-width="1"/>
+      <ellipse cx="120" cy="150" rx="80" ry="40" fill="#0a1e1a" opacity="0.8"/>
+      <rect x="40" y="260" width="160" height="12" fill="#6b5e38" opacity="0.9"/>
+      <rect x="60" y="284" width="120" height="8" fill="#4a4028" opacity="0.7"/>
+    </g>
+    <g transform="translate(600,420)">
+      <rect width="240" height="340" rx="6" fill="url(#g7)" stroke="#6a3a1c" stroke-width="1"/>
+      <polygon points="120,80 180,200 60,200" fill="#8a4a20" opacity="0.7"/>
+      <rect x="40" y="250" width="160" height="12" fill="#6b5e38" opacity="0.9"/>
+      <rect x="60" y="274" width="120" height="8" fill="#4a4028" opacity="0.7"/>
+    </g>
+    <g transform="translate(880,420)">
+      <rect width="240" height="340" rx="6" fill="url(#g8)" stroke="#283860" stroke-width="1"/>
+      <rect x="50" y="100" width="140" height="120" fill="#0d1a34" opacity="0.8"/>
+      <circle cx="120" cy="160" r="22" fill="#c5dfff" opacity="0.6"/>
+      <rect x="40" y="250" width="160" height="12" fill="#6b5e38" opacity="0.9"/>
+      <rect x="60" y="274" width="120" height="8" fill="#4a4028" opacity="0.7"/>
+    </g>
+  </g>
+
+  <!-- heading -->
+  <g font-family="Inter, system-ui, sans-serif" fill="#e3c468">
+    <text x="600" y="860" font-size="20" font-weight="700" text-anchor="middle" letter-spacing="3">PORTAFOLIO BAJO NDA</text>
+    <text x="600" y="882" font-size="12" fill="#9a8a5a" text-anchor="middle" letter-spacing="2">TÍTULOS REDACTADOS — MUESTRA COMPLETA POR WHATSAPP</text>
+  </g>
+</svg>

--- a/web/public/images/ss/py-map-zones.svg
+++ b/web/public/images/ss/py-map-zones.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 900" role="img" aria-label="Mapa de Paraguay con zonas de envío">
+  <title>Zonas de envío</title>
+  <desc>Tres zonas de cobertura: Asunción metro, interior cercano, Chaco y norte.</desc>
+
+  <defs>
+    <linearGradient id="zland" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f7f3ed"/>
+      <stop offset="1" stop-color="#ece5d8"/>
+    </linearGradient>
+    <linearGradient id="zwater" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#cfe3ea"/>
+      <stop offset="1" stop-color="#b5d0d9"/>
+    </linearGradient>
+    <filter id="zshadow" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="3" stdDeviation="3" flood-color="#000" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+
+  <rect width="800" height="900" fill="#ffffff"/>
+
+  <!-- Country shape (same path as py-map) -->
+  <path id="pyShape" d="
+    M 280 110 L 390 95 L 500 125 L 560 180 L 610 260 L 595 340 L 630 420 L 640 500
+    L 610 560 L 640 640 L 660 720 L 620 790 L 540 810 L 460 790 L 380 760
+    L 320 720 L 270 660 L 230 600 L 200 520 L 170 440 L 155 360 L 170 280 L 210 200 L 250 140 Z"
+    fill="url(#zland)" stroke="#8b8373" stroke-width="1.2" stroke-linejoin="round" filter="url(#zshadow)"/>
+
+  <!-- Zone 3: Chaco + Norte (top-left half) -->
+  <path d="M 280 110 L 390 95 L 500 125 L 560 180 L 610 260 L 595 340 L 500 380 L 350 360 L 170 280 L 210 200 L 250 140 Z"
+    fill="#eab308" opacity="0.18"/>
+
+  <!-- Zone 2: Interior Central (middle) -->
+  <path d="M 170 280 L 350 360 L 500 380 L 595 340 L 630 420 L 640 500 L 500 520 L 300 500 L 155 360 Z"
+    fill="#f59e0b" opacity="0.22"/>
+
+  <!-- Zone 1: Asunción metro (southern pocket) -->
+  <path d="M 300 500 L 500 520 L 640 500 L 610 560 L 640 640 L 660 720 L 620 790 L 540 810 L 460 790 L 380 760
+    L 320 720 L 270 660 L 230 600 L 200 520 Z"
+    fill="#ef4444" opacity="0.22"/>
+
+  <!-- Rivers on top -->
+  <path d="M 300 130 Q 290 260 310 380 Q 350 520 370 660 Q 400 750 450 790"
+    fill="none" stroke="url(#zwater)" stroke-width="6" stroke-linecap="round" opacity="0.8"/>
+  <path d="M 595 340 Q 615 480 625 620 Q 635 720 620 790"
+    fill="none" stroke="url(#zwater)" stroke-width="5" stroke-linecap="round" opacity="0.7"/>
+
+  <!-- Country outline retrace on top for clarity -->
+  <use href="#pyShape" fill="none" stroke="#8b8373" stroke-width="1.2"/>
+
+  <!-- Zone labels -->
+  <g font-family="Inter, system-ui, sans-serif" font-weight="700">
+    <text x="310" y="200" font-size="14" fill="#854d0e">Zona 3 · Chaco y Norte</text>
+    <text x="280" y="450" font-size="14" fill="#b45309">Zona 2 · Interior</text>
+    <text x="380" y="690" font-size="14" fill="#991b1b">Zona 1 · Asunción metro</text>
+  </g>
+
+  <!-- Title -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="400" y="60" text-anchor="middle" font-size="26" font-weight="700" fill="#1a2740" letter-spacing="1">COBERTURA POR ZONA</text>
+  </g>
+
+  <!-- Legend -->
+  <g transform="translate(60,820)" font-family="Inter, system-ui, sans-serif" font-size="12" fill="#2d3748">
+    <rect x="0" y="-10" width="16" height="14" fill="#ef4444" opacity="0.55"/>
+    <text x="22" y="0" font-weight="600">Z1 Gratis &gt;1.000.000</text>
+    <rect x="180" y="-10" width="16" height="14" fill="#f59e0b" opacity="0.55"/>
+    <text x="202" y="0" font-weight="600">Z2 Desde Gs. 150.000</text>
+    <rect x="370" y="-10" width="16" height="14" fill="#eab308" opacity="0.55"/>
+    <text x="392" y="0" font-weight="600">Z3 Desde Gs. 250.000</text>
+  </g>
+</svg>

--- a/web/public/images/ss/py-map.svg
+++ b/web/public/images/ss/py-map.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 900" role="img" aria-label="Mapa de Paraguay con tiendas Superspuma">
+  <title>Mapa de Paraguay</title>
+  <desc>Ubicación de 7 tiendas Superspuma en Asunción y Central, más 6 centros logísticos en el interior.</desc>
+
+  <defs>
+    <linearGradient id="land" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f7f3ed"/>
+      <stop offset="1" stop-color="#ece5d8"/>
+    </linearGradient>
+    <linearGradient id="water" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#cfe3ea"/>
+      <stop offset="1" stop-color="#b5d0d9"/>
+    </linearGradient>
+    <radialGradient id="pinPrimary" cx="0.5" cy="0.3" r="0.7">
+      <stop offset="0" stop-color="#ff8a4c"/>
+      <stop offset="1" stop-color="#d94e17"/>
+    </radialGradient>
+    <filter id="shadow" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="3" stdDeviation="3" flood-color="#000" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+
+  <!-- Background wash -->
+  <rect width="800" height="900" fill="#ffffff"/>
+
+  <!-- Simplified Paraguay outline. Hand-traced approximation — not cartographic. -->
+  <path d="
+    M 280 110
+    L 390 95
+    L 500 125
+    L 560 180
+    L 610 260
+    L 595 340
+    L 630 420
+    L 640 500
+    L 610 560
+    L 640 640
+    L 660 720
+    L 620 790
+    L 540 810
+    L 460 790
+    L 380 760
+    L 320 720
+    L 270 660
+    L 230 600
+    L 200 520
+    L 170 440
+    L 155 360
+    L 170 280
+    L 210 200
+    L 250 140 Z"
+    fill="url(#land)"
+    stroke="#8b8373"
+    stroke-width="1.2"
+    stroke-linejoin="round"
+    filter="url(#shadow)"
+  />
+
+  <!-- River Paraguay (left-center vertical) -->
+  <path d="M 300 130 Q 290 260 310 380 Q 350 520 370 660 Q 400 750 450 790"
+    fill="none" stroke="url(#water)" stroke-width="6" stroke-linecap="round" opacity="0.8"/>
+  <!-- River Paraná (right edge) -->
+  <path d="M 595 340 Q 615 480 625 620 Q 635 720 620 790"
+    fill="none" stroke="url(#water)" stroke-width="5" stroke-linecap="round" opacity="0.7"/>
+
+  <!-- Department dashed lines, decorative -->
+  <g stroke="#b6ab96" stroke-width="0.8" stroke-dasharray="3 3" fill="none" opacity="0.55">
+    <path d="M 200 280 Q 350 300 560 280"/>
+    <path d="M 180 420 Q 350 440 620 430"/>
+    <path d="M 220 560 Q 380 580 630 580"/>
+    <path d="M 280 690 Q 420 700 630 700"/>
+  </g>
+
+  <!-- Logistics dots (secondary) -->
+  <g fill="#c9c1ae" stroke="#9a907a" stroke-width="0.8">
+    <circle cx="370" cy="170" r="5"/><!-- Pedro Juan Caballero -->
+    <circle cx="490" cy="220" r="5"/><!-- Concepción -->
+    <circle cx="540" cy="380" r="5"/><!-- Ciudad del Este -->
+    <circle cx="560" cy="520" r="5"/><!-- Encarnación -->
+    <circle cx="410" cy="490" r="5"/><!-- Coronel Oviedo -->
+    <circle cx="270" cy="580" r="5"/><!-- Pilar -->
+  </g>
+  <g font-family="Inter, system-ui, sans-serif" font-size="11" fill="#6a624f">
+    <text x="380" y="165">Pedro Juan Caballero</text>
+    <text x="500" y="215">Concepción</text>
+    <text x="548" y="378">Ciudad del Este</text>
+    <text x="568" y="518">Encarnación</text>
+    <text x="418" y="488">Coronel Oviedo</text>
+    <text x="278" y="578">Pilar</text>
+  </g>
+
+  <!-- Primary store pins (Asunción + Central area is around 370,600) -->
+  <g filter="url(#shadow)">
+    <!-- Cluster around Asunción -->
+    <g transform="translate(350,610)">
+      <circle r="11" fill="url(#pinPrimary)" stroke="#ffffff" stroke-width="2"/>
+    </g>
+    <g transform="translate(370,625)">
+      <circle r="11" fill="url(#pinPrimary)" stroke="#ffffff" stroke-width="2"/>
+    </g>
+    <g transform="translate(330,625)">
+      <circle r="11" fill="url(#pinPrimary)" stroke="#ffffff" stroke-width="2"/>
+    </g>
+    <g transform="translate(365,645)">
+      <circle r="11" fill="url(#pinPrimary)" stroke="#ffffff" stroke-width="2"/>
+    </g>
+    <g transform="translate(335,655)">
+      <circle r="11" fill="url(#pinPrimary)" stroke="#ffffff" stroke-width="2"/>
+    </g>
+    <g transform="translate(390,600)">
+      <circle r="11" fill="url(#pinPrimary)" stroke="#ffffff" stroke-width="2"/>
+    </g>
+    <g transform="translate(320,600)">
+      <circle r="11" fill="url(#pinPrimary)" stroke="#ffffff" stroke-width="2"/>
+    </g>
+  </g>
+
+  <!-- Asunción label -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="400" y="700" font-size="18" font-weight="700" fill="#1a2740">Asunción + Central</text>
+    <text x="400" y="720" font-size="12" fill="#4a5568">7 tiendas en shopping y puntos propios</text>
+  </g>
+
+  <!-- Legend -->
+  <g transform="translate(60,800)" font-family="Inter, system-ui, sans-serif" font-size="13" fill="#2d3748">
+    <circle cx="10" cy="-4" r="8" fill="url(#pinPrimary)" stroke="#ffffff" stroke-width="2"/>
+    <text x="28" y="0" font-weight="600">Tienda Superspuma</text>
+    <circle cx="200" cy="-4" r="5" fill="#c9c1ae" stroke="#9a907a" stroke-width="0.8"/>
+    <text x="215" y="0" fill="#4a5568">Centro logístico</text>
+  </g>
+
+  <!-- Country label -->
+  <g font-family="Inter, system-ui, sans-serif">
+    <text x="400" y="60" text-anchor="middle" font-size="26" font-weight="700" fill="#1a2740" letter-spacing="1">PARAGUAY</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
Implements visual assets from docs/audit/visual-critique-2026-04-24.md without waiting on external image generation. All new assets are hand-authored SVG (~18 KB total).

### New SVG assets
- **Dayah catalogo covers** (6 files) — one per premade title, consistent series style (oxblood + midnight + gold-foil, Playfair serif, subtle grain). Fixes the "placeholder tile card" look on `/catalogo`.
- **Dayah portafolio NDA grid** — 2×4 redacted covers, reinforces "trabajos bajo NDA" positioning. Inserted between hero and CTA cards on `/portafolio`.
- **Superspuma PY map** — 7 store pins clustered around Asunción + 6 logistics dots inland. Inserted on `/tiendas` after hero.
- **Superspuma PY zones map** — same base, 3 tinted coverage zones. Inserted on `/envios` between tier cards and process.

### New section type
- \`components/sections/illustration-section.tsx\` — single centred image with optional title/subtitle/caption. Registered in both renderers; added to `retail-local` and `portfolio-professional` `allowedSections`.

## Why
- Dayah catalogo was rendering premade-cover cards with title text only, no artwork. Zero evidence of design craft on the page that's supposed to showcase design craft.
- Superspuma tiendas claimed "7 tiendas + 6 centros logísticos" but had no geographic visual — the map makes the claim concrete.
- Superspuma envios described 3 zones with pricing but no illustration of where the zones actually were.

## Test plan
- [x] `npm run build` passes (no type or asset errors)
- [ ] Verify SVGs render in production after deploy
- [ ] Verify `/catalogo`, `/portafolio`, `/tiendas`, `/envios` show the new assets
- [ ] Check SVGs don't get mangled by next/image optimizer (added `unoptimized={src.endsWith('.svg')}` guard)

## Still deferred (follow-up PRs)
- Photo imagery (bed hero, combo still-lifes, craftsman, Cartagena hero, Dayah writer desk, Daihana portrait, atmospheric contact flat-lay) — need curated Unsplash URLs or AI generation
- Bank logos on ss-financiacion — need official press-kit SVGs
- Copy improvements on portafolio / blog / hero rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)