### PR TITLE
fix(chrome): skip contact-strip on pages with explicit full contact

### DIFF
--- a/sites/dayah-litworks/pages/contacto.json
+++ b/sites/dayah-litworks/pages/contacto.json
@@ -23,5 +23,8 @@
     }
   ],
   "titleKey": "contactHero.title",
-  "descriptionKey": "contactHero.subtitle"
+  "descriptionKey": "contactHero.subtitle",
+  "skipDefaults": [
+    "contact-strip"
+  ]
 }

--- a/sites/superspuma/pages/tiendas.json
+++ b/sites/superspuma/pages/tiendas.json
@@ -33,5 +33,8 @@
       "variant": "split",
       "content": "home.contact"
     }
+  ],
+  "skipDefaults": [
+    "contact-strip"
   ]
 }

--- a/web/lib/engine/generated/tenant-data.ts
+++ b/web/lib/engine/generated/tenant-data.ts
@@ -5975,6 +5975,9 @@ export const PAGES: Record<string, JsonRecord> = {
         "variant": "split"
       }
     ],
+    "skipDefaults": [
+      "contact-strip"
+    ],
     "slug": "contacto",
     "titleKey": "contactHero.title"
   },
@@ -14682,6 +14685,9 @@ export const PAGES: Record<string, JsonRecord> = {
         "id": "contact",
         "variant": "split"
       }
+    ],
+    "skipDefaults": [
+      "contact-strip"
     ],
     "slug": "tiendas",
     "titleKey": "tiendas.seo.title"


### PR DESCRIPTION
Small follow-up to #360 — /tiendas (SS) and /contacto (Dayah) were rendering both the full `ContactSection` (map iframe) AND the lightweight `contact-strip` below it. Adds `skipDefaults: ["contact-strip"]` on both pages.