### PR TITLE
feat(viajero-comercio): Wave 1 — declare integrations block (Pagopar env vars, GA4, hubspot/mailchimp/sendgrid stubs)

### DIFF
--- a/sites/viajero-comercio/site.json
+++ b/sites/viajero-comercio/site.json
@@ -97,6 +97,41 @@
       ]
     }
   },
+  "integrations": {
+    "hubspot": {
+      "portalId": "HS-PORTAL-PARAGUAI",
+      "formId": "contact-form-paragu-ai"
+    },
+    "mailchimp": {
+      "audienceId": "audience-paragu-ai-newsletter"
+    },
+    "analytics": {
+      "ga4": {
+        "measurementId": "R-XXXXXXXXXX",
+        "streamName": "paragu-ai-builder-viajero-comercio"
+      }
+    },
+    "payments": {
+      "provider": "pagopar",
+      "merchantIdEnvVar": "PAGOPAR_MERCHANT_KEY_VIAJERO",
+      "secretKeyEnvVar": "PAGOPAR_SECRET_KEY_VIAJERO",
+      "statementDescriptor": "VIAJERO COMERCIO"
+    },
+    "messaging": {
+      "whatsappClickToChat": true
+    },
+    "invoicing": {
+      "provider": "facture",
+      "enabled": false,
+      "plannedPhase": 2
+    },
+    "email": {
+      "provider": "sendgrid",
+      "transactional": true,
+      "newsletter": true,
+      "optInRequired": true
+    }
+  },
   "commerce": {
     "enabled": true,
     "currency": "PYG",


### PR DESCRIPTION
## Summary
- Adds the `integrations` block to `sites/viajero-comercio/site.json` so it matches the object-form schema audited by `web/scripts/production-status.ts` (parity with `de-abasto-a-casa`, `superspuma`, `dayah`, `nexa-paraguay`).
- Declares the **Pagopar env-var contract** (`PAGOPAR_MERCHANT_KEY_VIAJERO` / `PAGOPAR_SECRET_KEY_VIAJERO`) so the runtime checkout adapter can resolve credentials per memory rule (provider lives in site.json; secrets live in `payment_credentials` DB table + env).
- Stubs hubspot (portal + form), mailchimp (audience), GA4 measurement-id, sendgrid (transactional + newsletter, opt-in required), facture (invoicing — planned phase 2), and WhatsApp click-to-chat.

## Why
Wave 1 of the STORE_PLAYBOOK execution. `viajero-comercio` had `commerce.enabled: true` in its registry and runtime rules in `web/lib/commerce/tenant-config.ts` (Gs. 300.000 free-shipping, 3 cuotas from Gs. 100.000), but no `integrations` declaration in `site.json` — production-status audit was failing the integration counts even though README listed it as READY.

## Test plan
- [ ] `bun web/scripts/production-status.ts` reports viajero-comercio with integrations: hubspot ✓, mailchimp ✓, ga4 ✓, payments ✓
- [ ] No runtime regression — site.json still parses; commerce flow unchanged (this is config-only)
- [ ] GA4 measurement-id and Pagopar credentials are placeholders — operator to fill before live billing

## Notes for follow-up
- GA4 `R-XXXXXXXXXX` is intentional placeholder (matches other tenants pre-launch).
- Pagopar env vars need to be set in Hostinger VPS env before the first real checkout.
- Hubspot/mailchimp IDs are platform-shared placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)