### PR TITLE
feat(commerce): extract reusable FreeShippingProgress, surface on cart page

### DIFF
--- a/web/components/commerce/cart-drawer.tsx
+++ b/web/components/commerce/cart-drawer.tsx
@@ -4,8 +4,8 @@ import { useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { useCartStore, cartSubtotalCents } from '@/lib/stores/cart-store'
 import { formatCents } from '@/lib/commerce/compute-totals'
-import { getFreeShippingThresholdCents } from '@/lib/commerce/shipping-threshold'
 import { buildWhatsAppCartUrl } from '@/lib/commerce/whatsapp-cart-link'
+import { FreeShippingProgress } from './free-shipping-progress'
 
 interface Props {
   siteSlug: string
@@ -153,41 +153,7 @@ export function CartDrawer({ siteSlug, locale, open, onClose, whatsappNumber, bu
 
         {items.length > 0 ? (
           <footer className="border-t border-[color:var(--border,#e5e7eb)] px-6 py-4">
-            {(() => {
-              // Progress bar toward free-shipping threshold. Hidden when
-              // the tenant has no threshold configured, or when the cart
-              // currency doesn't match the tenant's threshold currency
-              // (both PYG for PY tenants today). Converts the "Gs 200.000"
-              // marketing promise into a concrete "faltan Gs X" nudge the
-              // moment the shopper opens the drawer.
-              const threshold = getFreeShippingThresholdCents(siteSlug)
-              if (threshold <= 0 || currency !== 'PYG') return null
-              const pct = Math.min(100, Math.round((subtotal / threshold) * 100))
-              const reached = subtotal >= threshold
-              return (
-                <div className="mb-3" aria-live="polite">
-                  <div className="mb-1 flex items-center justify-between text-xs">
-                    <span className={reached ? 'font-medium text-emerald-700' : 'text-[color:var(--text-muted,#6b7280)]'}>
-                      {reached
-                        ? '🎉 ¡Ya tenés envío gratis!'
-                        : `Te faltan ${formatCents(threshold - subtotal, 'PYG')} para envío gratis`}
-                    </span>
-                  </div>
-                  <div
-                    role="progressbar"
-                    aria-valuenow={pct}
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                    className="h-1.5 overflow-hidden rounded-full bg-surface-light"
-                  >
-                    <div
-                      className={`h-full transition-all duration-300 ${reached ? 'bg-emerald-600' : 'bg-primary'}`}
-                      style={{ width: `${pct}%` }}
-                    />
-                  </div>
-                </div>
-              )
-            })()}
+            <FreeShippingProgress siteSlug={siteSlug} subtotalCents={subtotal} currency={currency} compact />
             <div className="mb-3 flex items-center justify-between text-sm">
               <span className="text-[color:var(--text-muted,#6b7280)]">Subtotal</span>
               <span className="text-lg font-semibold">{formatCents(subtotal, currency)}</span>

--- a/web/components/commerce/cart-page-client.tsx
+++ b/web/components/commerce/cart-page-client.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useCartStore, cartSubtotalCents } from '@/lib/stores/cart-store'
 import { formatCents } from '@/lib/commerce/compute-totals'
 import { buildWhatsAppCartUrl } from '@/lib/commerce/whatsapp-cart-link'
+import { FreeShippingProgress } from './free-shipping-progress'
 
 interface Props {
   siteSlug: string
@@ -93,6 +94,7 @@ export function CartPageClient({ siteSlug, locale = 'es', whatsappNumber, busine
       </ul>
 
       <aside className="h-fit rounded-lg border border-[color:var(--border,#e5e7eb)] bg-surface p-6">
+        <FreeShippingProgress siteSlug={siteSlug} subtotalCents={subtotal} currency={cart.currency} />
         <div className="flex justify-between text-lg font-semibold">
           <span>Subtotal</span>
           <span>{formatCents(subtotal, cart.currency)}</span>

--- a/web/components/commerce/free-shipping-progress.tsx
+++ b/web/components/commerce/free-shipping-progress.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { getFreeShippingThresholdCents } from '@/lib/commerce/tenant-config'
+import { formatCents } from '@/lib/commerce/compute-totals'
+
+interface Props {
+  siteSlug: string
+  subtotalCents: number
+  currency: string
+  /** Tightens the surrounding spacing for compact surfaces (drawer footer). */
+  compact?: boolean
+}
+
+/**
+ * Progress bar toward the tenant's free-shipping threshold.
+ *
+ * Renders nothing when the tenant has no threshold or the cart currency
+ * doesn't match the tenant's threshold currency (PYG today). Converts the
+ * "Gs 200.000" marketing promise into a concrete "te faltan Gs X" nudge
+ * the moment a shopper sees their cart.
+ */
+export function FreeShippingProgress({ siteSlug, subtotalCents, currency, compact = false }: Props) {
+  const threshold = getFreeShippingThresholdCents(siteSlug)
+  if (threshold <= 0 || currency !== 'PYG') return null
+
+  const pct = Math.min(100, Math.round((subtotalCents / threshold) * 100))
+  const reached = subtotalCents >= threshold
+
+  return (
+    <div className={compact ? 'mb-3' : 'mb-4'} aria-live="polite">
+      <div className="mb-1 flex items-center justify-between text-xs">
+        <span className={reached ? 'font-medium text-emerald-700' : 'text-[color:var(--text-muted,#6b7280)]'}>
+          {reached
+            ? '🎉 ¡Ya tenés envío gratis!'
+            : `Te faltan ${formatCents(threshold - subtotalCents, 'PYG')} para envío gratis`}
+        </span>
+      </div>
+      <div
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className="h-1.5 overflow-hidden rounded-full bg-surface-light"
+      >
+        <div
+          className={`h-full transition-all duration-300 ${reached ? 'bg-emerald-600' : 'bg-primary'}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/web/tests/unit/components/free-shipping-progress.test.tsx
+++ b/web/tests/unit/components/free-shipping-progress.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FreeShippingProgress } from '@/components/commerce/free-shipping-progress'
+
+// viajero-comercio: Gs. 300.000 → 30_000_000 cents
+// fun4me:          Gs. 200.000 → 20_000_000 cents
+// (see web/lib/commerce/tenant-config.ts)
+
+describe('free-shipping-progress.tsx', () => {
+  it('renders nothing when the tenant has no threshold configured', () => {
+    const { container } = render(
+      <FreeShippingProgress siteSlug="unknown-tenant" subtotalCents={5_000_000} currency="PYG" />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when the cart currency is not PYG', () => {
+    const { container } = render(
+      <FreeShippingProgress siteSlug="viajero-comercio" subtotalCents={5_000_000} currency="USD" />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows remaining gap and a partial progress bar below the threshold', () => {
+    render(<FreeShippingProgress siteSlug="viajero-comercio" subtotalCents={15_000_000} currency="PYG" />)
+    expect(screen.getByText(/Te faltan .* para envío gratis/)).toBeInTheDocument()
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '50')
+  })
+
+  it('shows the reached message and a full bar at or above the threshold', () => {
+    render(<FreeShippingProgress siteSlug="fun4me" subtotalCents={25_000_000} currency="PYG" />)
+    expect(screen.getByText(/¡Ya tenés envío gratis!/)).toBeInTheDocument()
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '100')
+  })
+
+  it('caps the progress percentage at 100 when subtotal exceeds the threshold', () => {
+    render(<FreeShippingProgress siteSlug="fun4me" subtotalCents={1_000_000_000} currency="PYG" />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '100')
+  })
+})


### PR DESCRIPTION
## Summary

The free-shipping progress bar was hand-rolled inline inside `cart-drawer.tsx` (35-line IIFE). This wave:

- Extracts it into `web/components/commerce/free-shipping-progress.tsx` — a reusable client component reading `getFreeShippingThresholdCents(siteSlug)` from `tenant-config.ts`.
- Drops the bar into `cart-page-client.tsx` (it was missing from the full cart page summary aside).
- Keeps the `compact` flag for the drawer footer's tighter spacing.
- Adds a unit test covering: no-threshold tenant → null, non-PYG currency → null, partial fill, reached state, and >100% clamp.

Renders nothing when the tenant has no threshold or when the cart currency ≠ PYG, so it's safe to drop into any future surface (PDP / checkout summary / mini-cart) without per-tenant guards.

Part of the **STORE_PLAYBOOK** wave series — Wave 2 of the prioritized work list. PR #375 was Wave 1 (viajero `integrations` block).

## Test plan
- [x] `bunx vitest run tests/unit/components/free-shipping-progress.test.tsx` — 5/5 pass
- [ ] Manual: add an item to the cart on `/s/es/viajero-comercio/tienda`, open drawer → "Te faltan Gs. X para envío gratis" with partial bar; navigate to `/s/es/viajero-comercio/cart` → same bar above subtotal
- [ ] Manual: same on `/fun4me` (Gs. 200.000 threshold)
- [ ] Manual: any tenant without a configured threshold → bar is hidden on both surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)