### PR TITLE
feat(seo): Wave 3 — universal JSON-LD generator

### DIFF
--- a/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
+++ b/web/app/s/[locale]/[site]/producto/[slug]/page.tsx
@@ -39,6 +39,7 @@ import {
 } from '@/lib/commerce/reviews'
 import { loadPygRates } from '@/lib/commerce/currency-server'
 import { env } from '@/lib/env'
+import { buildProduct } from '@/lib/seo/json-ld'
 
 export const runtime = 'nodejs'
 export const revalidate = 300
@@ -156,46 +157,37 @@ export default async function ProductPage({ params }: { params: Promise<{ site: 
   const imageList = product.images
     .map((i) => i.url)
     .filter((u): u is string => typeof u === 'string' && u.length > 0)
-  const structuredData = {
-    '@context': 'https://schema.org',
-    '@type': 'Product',
-    name: product.name,
-    description: product.description ?? undefined,
-    image: imageList.length > 0 ? imageList : cover?.url,
-    sku: product.sku ?? undefined,
-    mpn: product.sku ?? undefined,
-    url: productUrl,
-    brand: product.brand ? { '@type': 'Brand', name: product.brand } : undefined,
-    offers: {
-      '@type': 'Offer',
+  const structuredData = buildProduct(
+    {
+      name: product.name,
+      description: product.description ?? undefined,
+      image: imageList.length > 0 ? imageList : cover?.url ? [cover.url] : undefined,
+      sku: product.sku ?? undefined,
+      mpn: product.sku ?? undefined,
       url: productUrl,
-      price: (product.priceCents / 100).toFixed(2),
+      brand: product.brand ?? undefined,
+      category: product.category ?? undefined,
+      priceCents: product.priceCents,
       priceCurrency: product.currency,
-      itemCondition: 'https://schema.org/NewCondition',
+      seller: business.name,
       availability:
         product.inventoryPolicy === 'deny' && product.inventoryQty === 0
           ? 'https://schema.org/OutOfStock'
           : 'https://schema.org/InStock',
-      seller: { '@type': 'Organization', name: business.name },
+      aggregateRating:
+        aggregate && aggregate.count > 0
+          ? { ratingValue: Number(aggregate.avg.toFixed(1)), reviewCount: aggregate.count }
+          : undefined,
+      reviews: reviews.slice(0, 10).map((r) => ({
+        authorName: r.authorName,
+        rating: r.rating,
+        createdAt: r.createdAt,
+        title: r.title,
+        content: r.content,
+      })),
     },
-    aggregateRating: aggregate && aggregate.count > 0
-      ? {
-          '@type': 'AggregateRating',
-          ratingValue: aggregate.avg.toFixed(1),
-          reviewCount: aggregate.count,
-          bestRating: 5,
-          worstRating: 1,
-        }
-      : undefined,
-    review: reviews.slice(0, 10).map((r) => ({
-      '@type': 'Review',
-      author: { '@type': 'Person', name: r.authorName },
-      datePublished: r.createdAt,
-      reviewRating: { '@type': 'Rating', ratingValue: r.rating, bestRating: 5, worstRating: 1 },
-      name: r.title ?? undefined,
-      reviewBody: r.content,
-    })),
-  }
+    env.APP_URL,
+  )
 
   const sessionToken = await getSessionToken()
   const initialCart = sessionToken && business

--- a/web/lib/seo/json-ld.ts
+++ b/web/lib/seo/json-ld.ts
@@ -374,15 +374,71 @@ function absoluteUrl(baseUrl: string, src: string): string {
 export interface ProductShape {
   name: string
   sku?: string
+  /** Manufacturer Part Number — Google requires gtin/mpn/brand for rich results. Defaults to sku when omitted. */
+  mpn?: string
   description?: string
   brand?: string
   category?: string
   image?: string | string[]
+  /** Single-variant price in cents (with `priceCurrency`). Used when there are no size variants and no `priceFromGs`. */
+  priceCents?: number
+  priceCurrency?: string
   priceFromGs?: number
   sizes?: Array<{ label: string; dimensions?: string; priceGs: number }>
   warranty?: string
   url: string
   aggregateRating?: { ratingValue: number; reviewCount: number }
+  /** Inline reviews — schema.org allows up to ~10 in a single Product node. Each is normalised through `buildReview` minus its @context. */
+  reviews?: ReviewShape[]
+  /** Schema.org URL: NewCondition / UsedCondition / RefurbishedCondition / DamagedCondition. Defaults to NewCondition. */
+  itemCondition?: string
+  /** Override availability when the caller knows stock (defaults to InStock). */
+  availability?: string
+  /** Seller organisation name — populated for marketplace contexts where the seller differs from the brand. */
+  seller?: string
+}
+
+export interface ReviewShape {
+  authorName: string
+  /** 1-5 star rating. */
+  rating: number
+  /** ISO 8601 date string. */
+  createdAt: string
+  title?: string | null
+  content: string
+  /** Defaults to 5; only override for non-5-point scales. */
+  bestRating?: number
+  /** Defaults to 1. */
+  worstRating?: number
+}
+
+/**
+ * Standalone Review JSON-LD with a Rating subobject. Wraps the embedded
+ * shape used inside `buildProduct`'s `review[]` array — call this when
+ * emitting a Review node on its own (e.g. dedicated review page).
+ */
+export function buildReview(r: ReviewShape): object {
+  return {
+    '@context': 'https://schema.org',
+    ...stripContext(buildReviewInner(r)),
+  }
+}
+
+function buildReviewInner(r: ReviewShape): object {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Review',
+    author: { '@type': 'Person', name: r.authorName },
+    datePublished: r.createdAt,
+    reviewRating: {
+      '@type': 'Rating',
+      ratingValue: r.rating,
+      bestRating: r.bestRating ?? 5,
+      worstRating: r.worstRating ?? 1,
+    },
+    ...(r.title ? { name: r.title } : {}),
+    reviewBody: r.content,
+  }
 }
 
 export function buildProduct(p: ProductShape, baseUrl: string): object {
@@ -399,6 +455,9 @@ export function buildProduct(p: ProductShape, baseUrl: string): object {
     url: p.url,
   }
   if (p.sku) schema.sku = p.sku
+  // Default mpn to sku — Google's rich-results validator wants both when only one is known.
+  const mpn = p.mpn ?? p.sku
+  if (mpn) schema.mpn = mpn
   if (p.description) schema.description = p.description
   if (images) schema.image = images
   if (p.brand) schema.brand = { '@type': 'Brand', name: p.brand }
@@ -409,31 +468,49 @@ export function buildProduct(p: ProductShape, baseUrl: string): object {
     ]
   }
 
+  const itemCondition = p.itemCondition ?? 'https://schema.org/NewCondition'
+  const availability = p.availability ?? 'https://schema.org/InStock'
+  const seller = p.seller ? { '@type': 'Organization', name: p.seller } : undefined
+
   if (p.sizes && p.sizes.length > 0) {
     const prices = p.sizes.map((s) => s.priceGs).filter((n) => typeof n === 'number')
     if (prices.length > 0) {
       schema.offers = {
         '@type': 'AggregateOffer',
-        priceCurrency: 'PYG',
+        priceCurrency: p.priceCurrency ?? 'PYG',
         lowPrice: Math.min(...prices),
         highPrice: Math.max(...prices),
         offerCount: p.sizes.length,
-        availability: 'https://schema.org/InStock',
+        availability,
         offers: p.sizes.map((s) => ({
           '@type': 'Offer',
           name: s.label,
           price: s.priceGs,
-          priceCurrency: 'PYG',
-          availability: 'https://schema.org/InStock',
+          priceCurrency: p.priceCurrency ?? 'PYG',
+          itemCondition,
+          availability,
+          ...(seller ? { seller } : {}),
         })),
       }
+    }
+  } else if (typeof p.priceCents === 'number') {
+    schema.offers = {
+      '@type': 'Offer',
+      url: p.url,
+      price: (p.priceCents / 100).toFixed(2),
+      priceCurrency: p.priceCurrency ?? 'USD',
+      itemCondition,
+      availability,
+      ...(seller ? { seller } : {}),
     }
   } else if (typeof p.priceFromGs === 'number') {
     schema.offers = {
       '@type': 'Offer',
       price: p.priceFromGs,
-      priceCurrency: 'PYG',
-      availability: 'https://schema.org/InStock',
+      priceCurrency: p.priceCurrency ?? 'PYG',
+      itemCondition,
+      availability,
+      ...(seller ? { seller } : {}),
     }
   }
 
@@ -442,8 +519,67 @@ export function buildProduct(p: ProductShape, baseUrl: string): object {
       '@type': 'AggregateRating',
       ratingValue: p.aggregateRating.ratingValue,
       reviewCount: p.aggregateRating.reviewCount,
+      bestRating: 5,
+      worstRating: 1,
     }
   }
 
+  if (p.reviews && p.reviews.length > 0) {
+    schema.review = p.reviews.slice(0, 10).map((r) => stripContext(buildReviewInner(r)))
+  }
+
   return schema
+}
+
+/**
+ * WebSite node with a SearchAction so Google's site-links search box can
+ * point at the tenant's `/buscar?q=` route. One per site, emitted once
+ * (typically on the homepage).
+ */
+export function buildWebsiteSearch(
+  site: SiteShape,
+  content: ContentShape,
+  baseUrl: string,
+  locale: string,
+): object {
+  const homeUrl = `${baseUrl}/s/${locale}/${site.slug}`
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: content.siteName || site.slug,
+    url: homeUrl,
+    inLanguage: locale,
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: {
+        '@type': 'EntryPoint',
+        urlTemplate: `${homeUrl}/buscar?q={search_term_string}`,
+      },
+      'query-input': 'required name=search_term_string',
+    },
+  }
+}
+
+/**
+ * Generic ItemList wrapper — like `buildServiceItemList` but accepts any
+ * pre-built schema.org node array (Products, BlogPostings, etc.). Use
+ * this for category PLPs, blog index pages, lookbook grids.
+ */
+export function buildItemList(
+  items: object[],
+  title: string,
+  pageUrl: string,
+): object {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: title,
+    url: pageUrl,
+    numberOfItems: items.length,
+    itemListElement: items.map((item, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      item: stripContext(item),
+    })),
+  }
 }

--- a/web/tests/unit/seo/json-ld.test.ts
+++ b/web/tests/unit/seo/json-ld.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest'
-import { localBusiness, faqPage, breadcrumbList, productOffers, aggregateRating } from '@/lib/seo/json-ld'
+import {
+  localBusiness,
+  faqPage,
+  breadcrumbList,
+  productOffers,
+  aggregateRating,
+  buildReview,
+  buildProduct,
+  buildWebsiteSearch,
+  buildItemList,
+} from '@/lib/seo/json-ld'
 
 describe('JSON-LD builders', () => {
   it('localBusiness with Schema.org subtype', () => {
@@ -37,5 +47,152 @@ describe('JSON-LD builders', () => {
     const r = aggregateRating(4.67, 42) as { ratingValue: string; reviewCount: number }
     expect(r.ratingValue).toBe('4.7')
     expect(r.reviewCount).toBe(42)
+  })
+})
+
+describe('buildReview', () => {
+  it('emits standalone Review with Rating subobject and bestRating/worstRating defaults', () => {
+    const r = buildReview({
+      authorName: 'Ana',
+      rating: 5,
+      createdAt: '2026-04-01T10:00:00Z',
+      title: 'Excelente',
+      content: 'Muy buen producto',
+    }) as Record<string, unknown>
+    expect(r['@context']).toBe('https://schema.org')
+    expect(r['@type']).toBe('Review')
+    const author = r.author as Record<string, unknown>
+    expect(author['@type']).toBe('Person')
+    expect(author.name).toBe('Ana')
+    const rating = r.reviewRating as Record<string, unknown>
+    expect(rating['@type']).toBe('Rating')
+    expect(rating.ratingValue).toBe(5)
+    expect(rating.bestRating).toBe(5)
+    expect(rating.worstRating).toBe(1)
+    expect(r.name).toBe('Excelente')
+    expect(r.reviewBody).toBe('Muy buen producto')
+  })
+
+  it('omits name when title is null', () => {
+    const r = buildReview({
+      authorName: 'Bea',
+      rating: 4,
+      createdAt: '2026-04-02T10:00:00Z',
+      title: null,
+      content: 'Está bien',
+    }) as Record<string, unknown>
+    expect(r.name).toBeUndefined()
+  })
+})
+
+describe('buildProduct (extended)', () => {
+  it('uses priceCents + priceCurrency for single-variant Offer', () => {
+    const r = buildProduct(
+      {
+        name: 'Widget',
+        url: 'https://example.com/p/widget',
+        priceCents: 12345,
+        priceCurrency: 'USD',
+        seller: 'Acme',
+        sku: 'WID-1',
+      },
+      'https://example.com',
+    ) as Record<string, unknown>
+    const offer = r.offers as Record<string, unknown>
+    expect(offer['@type']).toBe('Offer')
+    expect(offer.price).toBe('123.45')
+    expect(offer.priceCurrency).toBe('USD')
+    expect(offer.itemCondition).toBe('https://schema.org/NewCondition')
+    expect(offer.availability).toBe('https://schema.org/InStock')
+    const seller = offer.seller as Record<string, unknown>
+    expect(seller.name).toBe('Acme')
+    // mpn defaults to sku
+    expect(r.mpn).toBe('WID-1')
+  })
+
+  it('honours caller-supplied availability (OutOfStock)', () => {
+    const r = buildProduct(
+      {
+        name: 'Sold Out',
+        url: 'https://example.com/p/x',
+        priceCents: 100,
+        priceCurrency: 'USD',
+        availability: 'https://schema.org/OutOfStock',
+      },
+      'https://example.com',
+    ) as Record<string, unknown>
+    const offer = r.offers as Record<string, unknown>
+    expect(offer.availability).toBe('https://schema.org/OutOfStock')
+  })
+
+  it('embeds review[] (capped at 10) without nested @context', () => {
+    const reviews = Array.from({ length: 12 }, (_, i) => ({
+      authorName: `R${i}`,
+      rating: 4,
+      createdAt: '2026-04-01',
+      content: `body ${i}`,
+    }))
+    const r = buildProduct(
+      { name: 'P', url: 'https://x/p', priceCents: 100, priceCurrency: 'USD', reviews },
+      'https://x',
+    ) as Record<string, unknown>
+    const review = r.review as Array<Record<string, unknown>>
+    expect(review.length).toBe(10)
+    expect(review[0]['@context']).toBeUndefined()
+    expect(review[0]['@type']).toBe('Review')
+  })
+
+  it('aggregateRating includes bestRating/worstRating', () => {
+    const r = buildProduct(
+      {
+        name: 'P',
+        url: 'https://x/p',
+        priceCents: 100,
+        priceCurrency: 'USD',
+        aggregateRating: { ratingValue: 4.7, reviewCount: 9 },
+      },
+      'https://x',
+    ) as Record<string, unknown>
+    const ar = r.aggregateRating as Record<string, unknown>
+    expect(ar.ratingValue).toBe(4.7)
+    expect(ar.reviewCount).toBe(9)
+    expect(ar.bestRating).toBe(5)
+    expect(ar.worstRating).toBe(1)
+  })
+})
+
+describe('buildWebsiteSearch', () => {
+  it('emits WebSite with SearchAction targeting tenant /buscar route', () => {
+    const r = buildWebsiteSearch(
+      { slug: 'fun4me', defaultLocale: 'es' },
+      { siteName: 'Fun4Me' },
+      'https://paragu-ai.com',
+      'es',
+    ) as Record<string, unknown>
+    expect(r['@type']).toBe('WebSite')
+    expect(r.name).toBe('Fun4Me')
+    expect(r.url).toBe('https://paragu-ai.com/s/es/fun4me')
+    expect(r.inLanguage).toBe('es')
+    const action = r.potentialAction as Record<string, unknown>
+    expect(action['@type']).toBe('SearchAction')
+    const target = action.target as Record<string, unknown>
+    expect(target.urlTemplate).toBe('https://paragu-ai.com/s/es/fun4me/buscar?q={search_term_string}')
+    expect(action['query-input']).toBe('required name=search_term_string')
+  })
+})
+
+describe('buildItemList (generic)', () => {
+  it('wraps pre-built nodes and strips nested @context', () => {
+    const a = { '@context': 'https://schema.org', '@type': 'Product', name: 'A' }
+    const b = { '@context': 'https://schema.org', '@type': 'Product', name: 'B' }
+    const r = buildItemList([a, b], 'Tienda', 'https://x/tienda') as Record<string, unknown>
+    expect(r['@type']).toBe('ItemList')
+    expect(r.numberOfItems).toBe(2)
+    const els = r.itemListElement as Array<Record<string, unknown>>
+    expect(els[0].position).toBe(1)
+    expect(els[1].position).toBe(2)
+    const item0 = els[0].item as Record<string, unknown>
+    expect(item0['@context']).toBeUndefined()
+    expect(item0.name).toBe('A')
   })
 })


### PR DESCRIPTION
## Summary

Wave 3 of `docs/reference/STORE_PLAYBOOK.md`. Centralises schema.org JSON-LD so every storefront page emits consistent rich-result data without per-page hand-rolling.

- **buildReview** — standalone Review with Rating subobject (bestRating/worstRating default 5/1)
- **buildProduct (extended)** — adds mpn (defaults to sku), seller Organization, itemCondition (default NewCondition), caller-computed availability, priceCents/priceCurrency Offer, embedded review[] capped at 10 with @context stripped, aggregateRating with bestRating/worstRating
- **buildWebsiteSearch** — WebSite + SearchAction targeting tenant `/buscar?q={search_term_string}` route
- **buildItemList** — generic wrapper (separate from service-specific `buildServiceItemList`) for product-list pages
- **PDP refactor** — `app/s/[locale]/[site]/producto/[slug]/page.tsx` now calls `buildProduct({...}, env.APP_URL)` instead of inlining ~40 lines of JSON-LD

## Test plan

- [x] `bunx vitest run tests/unit/seo/json-ld.test.ts` — 13/13 passing
- [x] `bunx tsc --noEmit -p tsconfig.json` — clean
- [ ] Visual: load a fun4me PDP and confirm `<script type="application/ld+json">` payload contains expected Product/Offer/AggregateRating/Review fields
- [ ] Validate emitted JSON-LD via Google Rich Results Test on a sample product URL after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)