### PR TITLE
feat(seo): wave 4 — filter URL convention + index policy

### DIFF
--- a/web/app/s/[locale]/[site]/robots.txt/route.ts
+++ b/web/app/s/[locale]/[site]/robots.txt/route.ts
@@ -11,8 +11,20 @@ export async function GET(
   const { locale, site: slug } = await params
   try { loadSite(slug) } catch { return new NextResponse('Not found', { status: 404 }) }
   const base = getAppUrl()
+  // Disallow rules per playbook §5.4 / §6:
+  // - View-only params (sort/view/per_page) generate duplicate content.
+  // - Cart/checkout/account are session pages, never index.
   const body = `User-agent: *
 Allow: /
+Disallow: /s/${locale}/${slug}/cart
+Disallow: /s/${locale}/${slug}/checkout
+Disallow: /s/${locale}/${slug}/account
+Disallow: /*?sort=
+Disallow: /*&sort=
+Disallow: /*?view=
+Disallow: /*&view=
+Disallow: /*?per_page=
+Disallow: /*&per_page=
 Sitemap: ${base}/s/${locale}/${slug}/sitemap.xml
 `
   return new NextResponse(body, {

--- a/web/app/s/[locale]/[site]/tienda/categoria/[category]/[tag]/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/categoria/[category]/[tag]/page.tsx
@@ -21,6 +21,7 @@ import { getCartBySessionToken } from '@/lib/commerce/cart'
 import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { TiendaPagination } from '@/components/commerce/tienda-pagination'
 import { loadPygRates } from '@/lib/commerce/currency-server'
+import { parseFilterParams, buildCanonicalUrl, computeIndexPolicy } from '@/lib/seo/filter-url'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -51,7 +52,7 @@ export async function generateMetadata({
   if (!business) return {}
   const prettyCat = pretty(category)
   const prettyTag = pretty(tag)
-  const canonical = `${env.APP_URL}/s/${locale}/${site}/tienda/categoria/${category}/${tag}`
+  const baseUrl = `${env.APP_URL}/s/${locale}/${site}/tienda/categoria/${category}/${tag}`
   const decodedCat = decodeURIComponent(category)
   const decodedTag = decodeURIComponent(tag)
   const count = await countActiveProducts(business.id, {
@@ -65,21 +66,20 @@ export async function generateMetadata({
   const description = count > 0
     ? `${prettyTag} · ${prettyCat} en ${business.name}: ${count} producto${count === 1 ? '' : 's'} con envío discreto a todo Paraguay. Pagá por transferencia, tarjeta o WhatsApp.`
     : `${prettyTag} · ${prettyCat} en ${business.name}. Envío a domicilio en Asunción y área metropolitana.`
-  // noindex if any filter param set — the clean nested URL is the one
-  // that should rank, permutations of it are duplicates.
-  const hasFilterParam = ['q', 'min', 'max', 'sort', 'page', 'in_stock', 'on_sale']
-    .some((k) => {
-      const v = sp[k]
-      return typeof v === 'string' ? v.length > 0 : Array.isArray(v) ? v.length > 0 : false
-    })
+  // (category, tag) come from the URL path — drop them from the query parsing
+  // so canonical doesn't echo them as facets.
+  const { category: _omitCat, tag: _omitTag, ...spForFacets } = sp
+  const parsed = parseFilterParams(spForFacets)
+  const canonical = buildCanonicalUrl(baseUrl, parsed)
+  const facetPolicy = computeIndexPolicy(parsed)
+  // Thin-content guard: empty (cat,tag) pages are noindex regardless of facets.
+  const policy = count > 0 ? facetPolicy : { index: false, follow: true }
   return {
     title,
     description,
     alternates: { canonical },
     openGraph: { url: canonical, title, description },
-    robots: count > 0 && !hasFilterParam
-      ? { index: true, follow: true }
-      : { index: false, follow: true },
+    robots: policy,
   }
 }
 

--- a/web/app/s/[locale]/[site]/tienda/categoria/[category]/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/categoria/[category]/page.tsx
@@ -20,6 +20,7 @@ import { CartStoreHydrator } from '@/components/commerce/cart-store-hydrator'
 import { TiendaToolbar } from '@/components/commerce/tienda-toolbar'
 import { TiendaPagination } from '@/components/commerce/tienda-pagination'
 import { loadPygRates } from '@/lib/commerce/currency-server'
+import { parseFilterParams, buildCanonicalUrl, computeIndexPolicy } from '@/lib/seo/filter-url'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -37,18 +38,19 @@ export async function generateMetadata({
   if (!business) return {}
   const decoded = decodeURIComponent(category)
   const pretty = decoded.charAt(0).toUpperCase() + decoded.slice(1)
-  const canonical = `${env.APP_URL}/s/${locale}/${site}/tienda/categoria/${category}`
+  const baseUrl = `${env.APP_URL}/s/${locale}/${site}/tienda/categoria/${category}`
   // Get a rough product count for richer meta. Errors swallowed on purpose
   // — metadata should never crash the page render.
   const count = await countActiveProducts(business.id, { category: decoded }).catch(() => 0)
   const description = count > 0
     ? `${pretty} en ${business.name}: ${count} producto${count === 1 ? '' : 's'} con envío discreto a todo Paraguay. Pago con tarjeta, transferencia o WhatsApp.`
     : `Productos de ${pretty} en ${business.name}. Envío a domicilio en Asunción y área metropolitana.`
-  const hasFilterParam = ['q', 'brand', 'tag', 'min', 'max', 'sort', 'page', 'in_stock', 'on_sale']
-    .some((k) => {
-      const v = sp[k]
-      return typeof v === 'string' ? v.length > 0 : Array.isArray(v) ? v.length > 0 : false
-    })
+  // The route's category is fixed by the URL — strip it from the parsed facets
+  // so canonical doesn't double-encode it as a query param.
+  const { category: _omit, ...spForFacets } = sp
+  const parsed = parseFilterParams(spForFacets)
+  const canonical = buildCanonicalUrl(baseUrl, parsed)
+  const policy = computeIndexPolicy(parsed)
   // Transactional-intent title: "Comprar [Category] en Paraguay | Store".
   // Peer analysis (luden.store) ranks consistently on this pattern for
   // Paraguay-specific long-tail.
@@ -58,9 +60,7 @@ export async function generateMetadata({
     description,
     alternates: { canonical },
     openGraph: { url: canonical, title, description },
-    robots: hasFilterParam
-      ? { index: false, follow: true }
-      : { index: true, follow: true },
+    robots: policy,
   }
 }
 

--- a/web/app/s/[locale]/[site]/tienda/page.tsx
+++ b/web/app/s/[locale]/[site]/tienda/page.tsx
@@ -39,6 +39,7 @@ import { Breadcrumbs } from '@/components/commerce/breadcrumbs'
 import { TiendaSearchTracker } from '@/components/commerce/tienda-search-tracker'
 import { env } from '@/lib/env'
 import { loadPygRates } from '@/lib/commerce/currency-server'
+import { parseFilterParams, buildCanonicalUrl, computeIndexPolicy } from '@/lib/seo/filter-url'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic' // search/sort/filter params kill static caching
@@ -54,24 +55,19 @@ export async function generateMetadata({
   const sp = await searchParams
   const business = await resolveBusinessBySlug(site)
   if (!business) return {}
-  const canonical = `${env.APP_URL}/s/${locale}/${site}/tienda`
-  // Filtered / searched / paged views are duplicate content from Google's
-  // view — canonical points at the bare /tienda and we noindex anything
-  // with a search, filter, sort, or pagination query. Prevents Google from
-  // spidering 10k permutations of the same catalog.
-  const hasSearchyParam = ['q', 'category', 'brand', 'tag', 'min', 'max', 'sort', 'page', 'in_stock', 'on_sale']
-    .some((k) => {
-      const v = sp[k]
-      return typeof v === 'string' ? v.length > 0 : Array.isArray(v) ? v.length > 0 : false
-    })
+  const baseUrl = `${env.APP_URL}/s/${locale}/${site}/tienda`
+  // Per playbook §5.4: canonical strips view-only params and emits remaining
+  // facets alphabetically; index policy allows ≤2 allowlisted facets and
+  // noindexes everything with sort/view/per_page/page>1/q or any non-allowlisted facet.
+  const parsed = parseFilterParams(sp)
+  const canonical = buildCanonicalUrl(baseUrl, parsed)
+  const policy = computeIndexPolicy(parsed)
   return {
     title: `Tienda — ${business.name}`,
     description: `Catálogo completo de ${business.name}. Envío a domicilio, pago seguro por Pagopar, Mercado Pago o transferencia.`,
     alternates: { canonical },
     openGraph: { url: canonical, title: `Tienda — ${business.name}` },
-    robots: hasSearchyParam
-      ? { index: false, follow: true }
-      : { index: true, follow: true },
+    robots: policy,
   }
 }
 

--- a/web/lib/seo/filter-url.ts
+++ b/web/lib/seo/filter-url.ts
@@ -1,0 +1,133 @@
+/**
+ * Filter URL convention + indexability policy for storefront PLPs.
+ *
+ * Spec: docs/reference/STORE_PLAYBOOK.md §5.4.
+ *
+ * - Multi-value facets are comma-joined: `?color=azul,rojo`
+ * - Canonical URL strips view-only params (`sort`, `view`, `per_page`, `page`)
+ *   and emits remaining facet values alphabetically — so `?brand=acme&color=azul`
+ *   and `?color=azul&brand=acme` collapse to the same canonical.
+ * - Index policy: a page is indexable when ≤ 2 facets from the indexable
+ *   allowlist (category, brand, tag) are active and no view-only param is set.
+ *   Three or more facets, or any sort/view/per_page, → noindex,follow.
+ */
+
+export const INDEXABLE_FACETS = ['category', 'brand', 'tag'] as const
+export type IndexableFacet = typeof INDEXABLE_FACETS[number]
+
+export const VIEW_ONLY_PARAMS = ['sort', 'view', 'per_page', 'page'] as const
+
+export type RawSearchParams = Record<string, string | string[] | undefined>
+
+export interface ParsedFilterParams {
+  /** Facet name → list of selected values, comma-split if needed. */
+  facets: Record<string, string[]>
+  /** Free-text search query (`q`). */
+  search?: string
+  sort?: string
+  view?: string
+  perPage?: string
+  page?: number
+  /** True iff any of the view-only params (sort/view/per_page) is set. */
+  hasViewOnlyParam: boolean
+}
+
+const FACET_KEYS_ALL = ['category', 'brand', 'tag', 'min', 'max', 'in_stock', 'on_sale'] as const
+
+function asScalar(v: string | string[] | undefined): string | undefined {
+  if (Array.isArray(v)) return v[0]
+  return v
+}
+
+function splitMulti(v: string | undefined): string[] {
+  if (!v) return []
+  return v
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+export function parseFilterParams(sp: RawSearchParams): ParsedFilterParams {
+  const facets: Record<string, string[]> = {}
+  for (const key of FACET_KEYS_ALL) {
+    const raw = asScalar(sp[key])
+    const values = splitMulti(raw)
+    if (values.length > 0) facets[key] = values
+  }
+
+  const sort = asScalar(sp.sort)
+  const view = asScalar(sp.view)
+  const perPage = asScalar(sp.per_page)
+  const pageRaw = asScalar(sp.page)
+  const pageNum = pageRaw ? parseInt(pageRaw, 10) : NaN
+  const page = Number.isFinite(pageNum) && pageNum > 1 ? pageNum : undefined
+
+  const search = asScalar(sp.q)?.trim() || undefined
+
+  return {
+    facets,
+    search,
+    sort: sort && sort.length > 0 ? sort : undefined,
+    view: view && view.length > 0 ? view : undefined,
+    perPage: perPage && perPage.length > 0 ? perPage : undefined,
+    page,
+    hasViewOnlyParam: Boolean(sort || view || perPage),
+  }
+}
+
+/**
+ * Build the canonical URL for a PLP given its base path and parsed filters.
+ *
+ * - View-only params (sort/view/per_page/page) are dropped — Google should
+ *   treat permutations of them as duplicates of the unsorted page.
+ * - Free-text search (`q`) is dropped — the canonical for `/tienda?q=foo`
+ *   is `/tienda` (search results are not indexable).
+ * - Facets are emitted in alphabetical order with values sorted, so the
+ *   canonical is stable regardless of input ordering.
+ */
+export function buildCanonicalUrl(
+  baseUrl: string,
+  parsed: Pick<ParsedFilterParams, 'facets'>,
+): string {
+  const keys = Object.keys(parsed.facets).sort()
+  if (keys.length === 0) return baseUrl
+  const parts = keys.map((k) => {
+    const values = [...parsed.facets[k]].sort()
+    return `${encodeURIComponent(k)}=${values.map(encodeURIComponent).join(',')}`
+  })
+  return `${baseUrl}?${parts.join('&')}`
+}
+
+export interface IndexPolicy {
+  index: boolean
+  follow: boolean
+}
+
+/**
+ * Indexability decision for a faceted PLP.
+ *
+ * Rules (playbook §5.4):
+ * - Free-text search (`q`) → noindex,follow (search results never index).
+ * - Any view-only param (`sort`/`view`/`per_page`) → noindex,follow.
+ * - Page > 1 → noindex,follow (paginated rel=next/prev replacement).
+ * - 0–2 facets from allowlist (category, brand, tag) → index,follow.
+ * - 3+ facets or facets outside the allowlist (price min/max, in_stock,
+ *   on_sale) → noindex,follow.
+ */
+export function computeIndexPolicy(parsed: ParsedFilterParams): IndexPolicy {
+  if (parsed.search) return { index: false, follow: true }
+  if (parsed.hasViewOnlyParam) return { index: false, follow: true }
+  if (parsed.page && parsed.page > 1) return { index: false, follow: true }
+
+  const facetKeys = Object.keys(parsed.facets)
+  const indexableKeys = facetKeys.filter((k): k is IndexableFacet =>
+    (INDEXABLE_FACETS as readonly string[]).includes(k),
+  )
+  const nonIndexableKeys = facetKeys.filter(
+    (k) => !(INDEXABLE_FACETS as readonly string[]).includes(k),
+  )
+
+  if (nonIndexableKeys.length > 0) return { index: false, follow: true }
+  if (indexableKeys.length > 2) return { index: false, follow: true }
+  return { index: true, follow: true }
+}

--- a/web/tests/unit/seo/filter-url.test.ts
+++ b/web/tests/unit/seo/filter-url.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseFilterParams,
+  buildCanonicalUrl,
+  computeIndexPolicy,
+} from '@/lib/seo/filter-url'
+
+describe('parseFilterParams', () => {
+  it('returns empty facets when no params', () => {
+    const r = parseFilterParams({})
+    expect(r.facets).toEqual({})
+    expect(r.hasViewOnlyParam).toBe(false)
+    expect(r.search).toBeUndefined()
+  })
+
+  it('splits comma-separated multi-value facets', () => {
+    const r = parseFilterParams({ brand: 'acme,zeta', category: 'gym' })
+    expect(r.facets.brand).toEqual(['acme', 'zeta'])
+    expect(r.facets.category).toEqual(['gym'])
+  })
+
+  it('flags view-only params', () => {
+    const r = parseFilterParams({ sort: 'price-asc', per_page: '48' })
+    expect(r.hasViewOnlyParam).toBe(true)
+    expect(r.sort).toBe('price-asc')
+    expect(r.perPage).toBe('48')
+  })
+
+  it('parses page only when > 1', () => {
+    expect(parseFilterParams({ page: '1' }).page).toBeUndefined()
+    expect(parseFilterParams({ page: '3' }).page).toBe(3)
+    expect(parseFilterParams({ page: 'abc' }).page).toBeUndefined()
+  })
+
+  it('captures search query trimmed', () => {
+    expect(parseFilterParams({ q: '  hello  ' }).search).toBe('hello')
+    expect(parseFilterParams({ q: '' }).search).toBeUndefined()
+  })
+
+  it('treats string[] params by taking first value', () => {
+    const r = parseFilterParams({ brand: ['acme', 'zeta'] })
+    expect(r.facets.brand).toEqual(['acme'])
+  })
+})
+
+describe('buildCanonicalUrl', () => {
+  const base = 'https://example.com/s/es/foo/tienda'
+
+  it('returns base when no facets', () => {
+    expect(buildCanonicalUrl(base, { facets: {} })).toBe(base)
+  })
+
+  it('emits facets sorted alphabetically by key', () => {
+    const url = buildCanonicalUrl(base, {
+      facets: { color: ['azul'], brand: ['acme'] },
+    })
+    expect(url).toBe(`${base}?brand=acme&color=azul`)
+  })
+
+  it('sorts multi-values within a facet', () => {
+    const url = buildCanonicalUrl(base, {
+      facets: { color: ['rojo', 'azul'] },
+    })
+    expect(url).toBe(`${base}?color=azul,rojo`)
+  })
+
+  it('encodes special characters in facet values', () => {
+    const url = buildCanonicalUrl(base, {
+      facets: { brand: ['acme & co'] },
+    })
+    expect(url).toContain('brand=acme%20%26%20co')
+  })
+})
+
+describe('computeIndexPolicy', () => {
+  it('indexes the bare PLP', () => {
+    expect(computeIndexPolicy(parseFilterParams({}))).toEqual({
+      index: true,
+      follow: true,
+    })
+  })
+
+  it('indexes single allowlisted facet', () => {
+    expect(computeIndexPolicy(parseFilterParams({ category: 'gym' }))).toEqual({
+      index: true,
+      follow: true,
+    })
+  })
+
+  it('indexes brand+category (two allowlisted facets)', () => {
+    expect(
+      computeIndexPolicy(parseFilterParams({ category: 'gym', brand: 'acme' })),
+    ).toEqual({ index: true, follow: true })
+  })
+
+  it('noindexes 3+ allowlisted facets', () => {
+    expect(
+      computeIndexPolicy(
+        parseFilterParams({ category: 'gym', brand: 'acme', tag: 'sale' }),
+      ),
+    ).toEqual({ index: false, follow: true })
+  })
+
+  it('noindexes any non-allowlisted facet (price, in_stock, on_sale)', () => {
+    expect(computeIndexPolicy(parseFilterParams({ min: '1000' }))).toEqual({
+      index: false,
+      follow: true,
+    })
+    expect(computeIndexPolicy(parseFilterParams({ in_stock: '1' }))).toEqual({
+      index: false,
+      follow: true,
+    })
+  })
+
+  it('noindexes when sort/view/per_page set', () => {
+    expect(computeIndexPolicy(parseFilterParams({ sort: 'price-asc' }))).toEqual({
+      index: false,
+      follow: true,
+    })
+    expect(computeIndexPolicy(parseFilterParams({ view: 'grid' }))).toEqual({
+      index: false,
+      follow: true,
+    })
+  })
+
+  it('noindexes paginated pages (page > 1)', () => {
+    expect(computeIndexPolicy(parseFilterParams({ page: '2' }))).toEqual({
+      index: false,
+      follow: true,
+    })
+  })
+
+  it('noindexes search results', () => {
+    expect(computeIndexPolicy(parseFilterParams({ q: 'foo' }))).toEqual({
+      index: false,
+      follow: true,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Wave 4 of the [STORE_PLAYBOOK](docs/reference/STORE_PLAYBOOK.md) rollout. Replaces the coarse "any-filter → noindex" logic on the three storefront PLP routes with a shared helper that implements §5.4 of the playbook.

### What changed

- **New helper** `web/lib/seo/filter-url.ts`
  - `parseFilterParams` — splits comma-separated multi-value facets, extracts view-only params and search query
  - `buildCanonicalUrl` — emits canonical with facets sorted alphabetically (so permutations collapse), strips view-only params, multi-values comma-joined (`?color=azul,rojo`)
  - `computeIndexPolicy` — returns `{ index, follow }` per the playbook rules
- **Three PLP routes wired up**
  - `/s/[locale]/[site]/tienda` (root PLP)
  - `/s/[locale]/[site]/tienda/categoria/[category]` (path-param `category` excluded from facet parsing)
  - `/s/[locale]/[site]/tienda/categoria/[category]/[tag]` (both path params excluded; thin-content guard preserved — empty cat+tag pages stay noindex regardless of facets)
- **Per-tenant `robots.txt`** now disallows `?sort=` / `?view=` / `?per_page=` and the `cart` / `checkout` / `account` session pages

### Index policy (per §5.4)

| URL shape | Policy |
|---|---|
| Bare PLP / single allowlisted facet (category, brand, tag) | index, follow |
| 2 allowlisted facets (e.g. category + brand) | index, follow |
| 3+ allowlisted facets | noindex, follow |
| Any non-allowlisted facet (price, in_stock, on_sale) | noindex, follow |
| sort / view / per_page set | noindex, follow |
| page > 1 | noindex, follow |
| q (search) | noindex, follow |

## Test plan

- [x] 18 unit tests in web/tests/unit/seo/filter-url.test.ts — all green
- [x] Typecheck clean for the changed files
- [ ] After merge: re-crawl tienda routes via Search Console URL Inspection and verify canonical/robots header reflects the new policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)