### PR TITLE
Update Spanish site content and add services.categories normalization

### DIFF
--- a/sites/dayah-litworks/content/es.json
+++ b/sites/dayah-litworks/content/es.json
@@ -51,11 +51,11 @@
       },
       {
         "question": "¿Puedo contratar urgente (48–72h)?",
-        "answer": "Contáctanos por WhatsApp para verificar disponibilidad. Los proyectos urgentes pueden tener un recargo."
+        "answer": "Escribime por WhatsApp para confirmar disponibilidad. Los proyectos urgentes pueden incluir recargo."
       },
       {
-        "question": "¿Cómo se entregados los archivos finales?",
-        "answer": "Archivos en alta resolución (JPG, PDF, PNG) listos para subir a tu plataforma. Los mockups se entrega como imágenes renderizadas."
+        "question": "¿Cómo se entregan los archivos finales?",
+        "answer": "Archivos en alta resolución (JPG, PDF, PNG) listos para subir a tu plataforma. Los mockups se entregan como imágenes renderizadas."
       }
     ]
   },
@@ -104,7 +104,7 @@
         "href": "/s/es/dayah-litworks/contacto"
       }
     ],
-    "ctaText": "Contactanos",
+    "ctaText": "Escribime por WhatsApp",
     "ctaHref": "https://wa.me/595986868241"
   },
   "home": {
@@ -114,17 +114,17 @@
     },
     "hero": {
       "headline": "Portadas que venden.",
-      "subheadline": "Para autores indie en todo el mundo. USD o PYG.",
+      "subheadline": "Para autores indie de habla hispana y global. Cobro en USD o PYG.",
       "ctaPrimaryText": "Ver Catálogo",
       "ctaPrimaryHref": "/s/es/dayah-litworks/catalogo",
-      "ctaSecondaryText": "WhatsApp",
+      "ctaSecondaryText": "Hablar por WhatsApp",
       "ctaSecondaryHref": "https://wa.me/595986868241",
       "trustBadges": [
         "+6 años de experiencia",
         "USD o PYG",
         "Entrega 1–2 semanas"
       ],
-      "backgroundImage": "https://images.unsplash.com/photo-1519682337058-a94d519337bc?auto=format&fit=crop&w=2000&q=80"
+      "backgroundImage": "/sites/dayah-litworks/images/brand/og-default.png"
     },
     "trustBadges": {
       "title": "¿Por qué elegirnos?",
@@ -132,12 +132,12 @@
         {
           "icon": "palette",
           "label": "Diseño profesional",
-          "description": "Portadas que venden libros"
+          "description": "Portadas enfocadas en clic y conversión"
         },
         {
           "icon": "globe",
           "label": "Clientes globales",
-          "description": "Autores en USA, Europa y LATAM"
+          "description": "Autores indie en LATAM, España y EE. UU."
         },
         {
           "icon": "dollar-sign",
@@ -770,16 +770,16 @@
           "label": "Proyectos entregados",
           "icon": "Briefcase"
         },
-    {
-      "value": "+6",
-      "label": "Años en el rubro",
-      "icon": "Calendar"
-    },
-    {
-      "value": "15+",
-      "label": "Países alcanzados",
-      "icon": "Globe"
-    }
+        {
+          "value": "+6",
+          "label": "Años en el rubro",
+          "icon": "Calendar"
+        },
+        {
+          "value": "15+",
+          "label": "Países alcanzados",
+          "icon": "Globe"
+        }
       ]
     },
     "portfolio": {
@@ -843,7 +843,7 @@
       "description": "Galería de portadas de libros diseñadas por Dayah LitWorks"
     },
     "title": "Portafolio",
-    "subtitle": "Portadas que venden libros",
+    "subtitle": "Selección pública reciente + trabajos privados por NDA",
     "filters": [
       "Todos",
       "Fantasía",
@@ -852,9 +852,46 @@
       "Ciencia Ficción",
       "Terror"
     ],
-    "items": [],
+    "items": [
+      {
+        "title": "Cómo Volver Loco a Mi Guardaespaldas",
+        "category": "Romance",
+        "imageUrl": "/sites/dayah-litworks/images/covers/cover-como-volver-loco-guardaespaldas.jpg",
+        "description": "Portada romance — eBook"
+      },
+      {
+        "title": "El Secreto Que Nos Unió",
+        "category": "Romance",
+        "imageUrl": "/sites/dayah-litworks/images/covers/cover-el-secreto-que-nos-unio.jpg",
+        "description": "Portada romance — eBook"
+      },
+      {
+        "title": "Perdóname Padre o Hazme Tuya",
+        "category": "Romance Oscuro",
+        "imageUrl": "/sites/dayah-litworks/images/covers/cover-perdoname-padre-o-hazme-tuya.jpg",
+        "description": "Portada dark romance — eBook"
+      },
+      {
+        "title": "Macarena y sus Ex",
+        "category": "Romance",
+        "imageUrl": "/sites/dayah-litworks/images/covers/cover-macarena-y-sus-ex.jpg",
+        "description": "Portada romance — eBook"
+      },
+      {
+        "title": "PF Vol I — Tapa Blanda",
+        "category": "Paperback",
+        "imageUrl": "/sites/dayah-litworks/images/covers/cover-pf-vol1-paperback.jpg",
+        "description": "Portada completa tapa blanda"
+      },
+      {
+        "title": "PF Vol II — Tapa Blanda",
+        "category": "Paperback",
+        "imageUrl": "/sites/dayah-litworks/images/covers/cover-pf-vol2-paperback.jpg",
+        "description": "Portada completa tapa blanda"
+      }
+    ],
     "placeholder": {
-      "title": "Portafolio privado",
+      "title": "Portafolio mixto (público + privado)",
       "subtitle": "Mis clientes están publicando — estoy esperando permisos para compartir trabajos recientes acá. Si querés ver ejemplos de tu género específico (fantasía, romance, thriller…), pedímelos por WhatsApp y te mando una muestra privada en el día.",
       "features": [
         {
@@ -886,8 +923,8 @@
       "maxWidth": 1000
     },
     "hero": {
-      "title": "Portafolio privado",
-      "subtitle": "Mis clientes están publicando — estoy esperando permisos para compartir trabajos recientes acá. Si querés ver ejemplos de tu género específico (fantasía, romance, thriller…), pedímelos por WhatsApp y te mando una muestra privada en el día.",
+      "title": "Portafolio mixto (público + privado)",
+      "subtitle": "Acá vas a ver una selección pública. Si querés ejemplos de tu género, te comparto una muestra privada por WhatsApp.",
       "backgroundImage": "https://images.unsplash.com/photo-1507842217343-583bb7270b66?auto=format&fit=crop&w=2000&q=80"
     }
   },
@@ -900,7 +937,7 @@
       "title": "Blog",
       "subtitle": "Tips, tendencias y recursos para autores",
       "trustBadgesEnabled": false,
-      "backgroundImage": "https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=2000&q=80"
+      "backgroundImage": "/sites/dayah-litworks/images/covers/cover-como-volver-loco-guardaespaldas.jpg"
     },
     "posts": [
       {
@@ -1126,7 +1163,7 @@
       "title": "Sobre Dayah LitWorks",
       "subtitle": "Donde la fantasía se convierte en realidad",
       "trustBadgesEnabled": false,
-      "backgroundImage": "https://images.unsplash.com/photo-1455390582262-044cdead277a?auto=format&fit=crop&w=2000&q=80"
+      "backgroundImage": "/sites/dayah-litworks/images/covers/cover-el-secreto-que-nos-unio.jpg"
     },
     "bio": {
       "features": [
@@ -1312,7 +1349,7 @@
         "href": "/s/es/dayah-litworks/servicios"
       },
       {
-        "label": "Portafolio",
+        "label": "Portfolio",
         "href": "/s/es/dayah-litworks/portafolio"
       },
       {
@@ -1398,7 +1435,7 @@
     "hero": {
       "title": "Nuestros Servicios",
       "subtitle": "Diseño profesional para tu libro",
-      "backgroundImage": "https://images.unsplash.com/photo-1481627834876-b7833e8f5570?auto=format&fit=crop&w=2000&q=80"
+      "backgroundImage": "/sites/dayah-litworks/images/covers/cover-perdoname-padre-o-hazme-tuya.jpg"
     }
   },
   "seo": {

--- a/web/lib/engine/compose-site.ts
+++ b/web/lib/engine/compose-site.ts
@@ -385,6 +385,25 @@ function normalizeSectionProps(sectionId: string, props: Record<string, unknown>
       if (normalized.items && !normalized.services) {
         normalized.services = normalized.items
       }
+      // Some tenant content ships grouped data under
+      // `services.categories[].items[]` (pricing-page shape) while the
+      // section component expects a flat `services[]` list. Flattening here
+      // keeps legacy content renderable and prevents empty-state fallbacks.
+      if (!normalized.services && Array.isArray(normalized.categories)) {
+        const flattened = (normalized.categories as Array<Record<string, unknown>>).flatMap((category) => {
+          const categoryTitle = typeof category.title === 'string' ? category.title : undefined
+          const rawItems = Array.isArray(category.items) ? category.items : []
+          return rawItems
+            .filter((item): item is Record<string, unknown> => !!item && typeof item === 'object')
+            .map((item) => ({
+              ...item,
+              category: typeof item.category === 'string' ? item.category : categoryTitle,
+            }))
+        })
+        if (flattened.length > 0) {
+          normalized.services = flattened
+        }
+      }
       break
     case 'testimonials':
       if (normalized.items && !normalized.testimonials) {


### PR DESCRIPTION
### Motivation
- Refresh and correct Spanish copy, CTAs, portfolio visibility and local images for the Dayah LitWorks Spanish site to improve messaging and visual consistency.
- Make the site composition engine more resilient to legacy content shapes by supporting grouped `services.categories` data so pages don't render empty when content uses the pricing-page shape.

### Description
- Edited `sites/dayah-litworks/content/es.json` to update copy (WhatsApp CTA phrasing, hero subheadlines, trust badge descriptions, portfolio and blog text), replace several external Unsplash backgrounds with local images, and populate the portfolio `items` list for public display.
- Adjusted footer navigation label from "Portafolio" to "Portfolio" and updated multiple UI strings and placeholders across `home`, `portfolio`, `blog`, `sobre`, and `servicios` sections.
- Fixed small formatting/indentation and delivery wording in FAQs and file delivery text.
- Updated `web/lib/engine/compose-site.ts` to flatten `services.categories[].items[]` into a flat `services[]` when `services` is missing, preserving `category` via the category title so legacy/pricing-shaped tenant content renders correctly.

### Testing
- Ran the TypeScript build and type-check via the project build pipeline (`yarn build` / `npm run build`) and the TypeScript compiler errors were resolved successfully.
- Executed the unit test suite (`yarn test` / `npm test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2abf057cc8321bfb6f7467b4d4e5e)