### PR TITLE
ci: add governance workflow caller from central ci-cd

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,13 @@
+name: Governance
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  governance:
+    uses: Ai-Whisperers/ci-cd/.github/workflows/governance.yml@main
+    with:
+      working-directory: .
+      fail-on-todo: true


### PR DESCRIPTION
## Summary
- Add repo-level governance workflow caller
- Uses central reusable workflow from Ai-Whisperers/ci-cd

## Why
Standardize enforcement of org rules across core repos.

## Workflow
- .github/workflows/governance.yml
- calls: Ai-Whisperers/ci-cd/.github/workflows/governance.yml@main